### PR TITLE
Correct include for WAVEFORMATEX

### DIFF
--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -2,7 +2,7 @@
 
 #include "ArchiveFile.h"
 #include <windows.h>
-#include <mmeapi.h>
+#include <mmreg.h>	// WAVEFORMATEX (omitted from windows.h if #define WIN32_LEAN_AND_MEAN)
 #include <memory>
 
 namespace Archives


### PR DESCRIPTION
Offical include header listed at:
https://msdn.microsoft.com/en-us/library/windows/desktop/dd390970(v=vs.85).aspx

This corrects errors when compiling with MinGW compiler.