### PR TITLE
Fix case in include filename

### DIFF
--- a/Archives/ArchiveFile.cpp
+++ b/Archives/ArchiveFile.cpp
@@ -1,5 +1,5 @@
 #include "ArchiveFile.h"
-#include "../Xfile.h"
+#include "../XFile.h"
 
 namespace Archives
 {


### PR DESCRIPTION
This prevents errors on case sensitive filesystems, such as on Linux.