### PR TITLE
Update ArchivePacker::CreateVolume() to use std::string and std::vector in input arguments

### DIFF
--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Windows.h>
+#include <string>
+#include <vector>
 
 namespace Archives
 {
@@ -13,11 +15,9 @@ namespace Archives
 		// Repack is used to replace the old volume with a new volume created from the
 		// files (in the current directory) that match the internal file names
 		virtual bool Repack() = 0;
-		// Create volume is used to create a new volume file with the files specified
-		// in filesToPack and gives them internal volume names specified in internalNames.
+		// Create volume is used to create a new volume file with the files specified in filesToPack.
 		// Returns true if successful and false otherwise
-		virtual bool CreateVolume(const char *volumeFileName, int numFilesToPack,
-			const char **filesToPack, const char **internalNames) = 0;
+		virtual bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames) = 0;
 
 	protected:
 		int OpenOutputFile(const char *fileName);

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -3,6 +3,8 @@
 #include "ArchiveFile.h"
 #include <windows.h>
 #include <mmreg.h>	// WAVEFORMATEX (omitted from windows.h if #define WIN32_LEAN_AND_MEAN)
+#include <string>
+#include <vector>
 #include <memory>
 
 namespace Archives
@@ -22,8 +24,7 @@ namespace Archives
 		int GetInternalFileSize(int index);
 
 		bool Repack();
-		bool CreateVolume(const char *volumeFileName, int numFilesToPack,
-			const char **filesToPack, const char **internalNames);
+		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames);
 
 	private:
 
@@ -40,13 +41,13 @@ namespace Archives
 		bool ReadHeader();
 
 		// Private functions for packing files
-		bool OpenAllInputFiles(int numFilesToPack, const char **filesToPack, HANDLE *fileHandle);
+		bool OpenAllInputFiles(std::vector<std::string> filesToPack, HANDLE *fileHandle);
 		bool ReadAllWaveHeaders(int numFilesToPack, HANDLE *file, WAVEFORMATEX *format, IndexEntry *indexEntry);
 		int FindChunk(int chunkTag, HANDLE file);
 		void CleanUpVolumeCreate(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle, WAVEFORMATEX *waveFormat, IndexEntry *indexEntry);
 		bool CompareWaveFormats(int numFilesToPack, WAVEFORMATEX *waveFormat);
 		bool WriteVolume(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle,
-			IndexEntry *entry, const char **internalName, WAVEFORMATEX *waveFormat);
+			IndexEntry *entry, std::vector<std::string> internalNames, WAVEFORMATEX *waveFormat);
 
 		HANDLE m_FileHandle;
 		WAVEFORMATEX m_WaveFormat;

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -5,6 +5,8 @@
 #include "ArchiveFile.h"
 #include "CompressionType.h"
 #include <windows.h>
+#include <string>
+#include <vector>
 #include <memory>
 
 namespace Archives
@@ -30,8 +32,7 @@ namespace Archives
 
 		// Volume Creation
 		bool Repack();
-		bool CreateVolume(const char *volumeFileName, int numFilesToPack,
-			const char **filesToPack, const char **internalNames);
+		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames);
 
 	private:
 		int GetInternalFileOffset(int index);
@@ -52,13 +53,17 @@ namespace Archives
 			IndexEntry *indexEntry;
 			int *fileNameLength;
 			HANDLE *fileHandle;
-			int numFilesToPack;
-			const char **filesToPack;
-			const char **internalNames;
+			std::vector<std::string> filesToPack;
+			std::vector<std::string> internalNames;
 			int stringTableLength;
 			int indexTableLength;
 			int paddedStringTableLength;
 			int paddedIndexTableLength;
+
+			size_t fileCount()
+			{
+				return filesToPack.size();
+			}
 		};
 
 		int ReadTag(int offset, const char *tagText);


### PR DESCRIPTION
 - Update VolFile.h/.cpp to use size_t to represent the number of files in archive instead of using int.
 - Store filesToPack and internalNames as std::vector<std::string> instead of char**.
 - Remove destruction subroutines where char** was replaced with std::vector<std::string>.
