### PR TITLE
Remove argument internalNames from ArchivePacker::CreateVolume

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -1,4 +1,7 @@
 #include "ArchivePacker.h"
+#include "../XFile.h"
+#include "../StringHelper.h"
+#include <stdexcept>
 
 namespace Archives
 {
@@ -47,5 +50,20 @@ namespace Archives
 		DeleteFileA("Delete.vol");
 
 		return true;
+	}
+
+	std::vector<std::string> ArchivePacker::GetInternalNamesFromPaths(std::vector<std::string> paths)
+	{
+		std::vector<std::string> fileNames;
+
+		for (std::string fileName : paths) {
+			if (StringHelper::ContainsStringCaseInsensitive(fileNames, fileName)) {
+				throw std::runtime_error("Unable to create an archive containing multiple files with the same filename.");
+			}
+
+			fileNames.push_back(XFile::GetFilename(fileName));
+		}
+
+		return fileNames;
 	}
 }

--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -17,12 +17,16 @@ namespace Archives
 		virtual bool Repack() = 0;
 		// Create volume is used to create a new volume file with the files specified in filesToPack.
 		// Returns true if successful and false otherwise
-		virtual bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames) = 0;
+		virtual bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack) = 0;
 
 	protected:
 		int OpenOutputFile(const char *fileName);
 		void CloseOutputFile();
 		bool ReplaceFileWithFile(const char *fileToReplace, const char *newFile);
+
+		// Returns the filenames from each path stripping the rest of the path. 
+		// Throws an error if 2 filenames are identical, case insensitve.
+		std::vector<std::string> ArchivePacker::GetInternalNamesFromPaths(std::vector<std::string> paths);
 
 		HANDLE m_OutFileHandle;
 	};

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -247,19 +247,18 @@ namespace Archives
 
 		for (int i = 0; i < m_NumberOfPackedFiles; i++)
 		{
-			internalNames[i] = GetInternalFileName(i);
-			filesToPack[i] = internalNames[i] + ".wav";
+			//Filename is equivalent to internalName since filename is a relative path from current directory.
+			filesToPack[i] = std::string(GetInternalFileName(i)) + ".wav";
 		}
 
-		// Create the volume
-		return CreateVolume("temp.clm", filesToPack, internalNames);
+		return CreateVolume("temp.clm", filesToPack);
 	}
 
 	// Creates a new volume file with the file name volumeFileName and packs the
 	// numFilesToPack files listed in the array filesToPack into the volume.
 	// The internal names of these files are given in the array internalNames.
 	// Returns nonzero if successful and zero otherwise
-	bool ClmFile::CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames)
+	bool ClmFile::CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack)
 	{
 		// Make sure files are specified properly.
 		if (filesToPack.size() < 1) {
@@ -311,7 +310,7 @@ namespace Archives
 		}
 
 		// Write the volume header and copy files into the volume
-		if (!WriteVolume(outFile, filesToPack.size(), fileHandle, indexEntry, internalNames, waveFormat))
+		if (!WriteVolume(outFile, filesToPack.size(), fileHandle, indexEntry, GetInternalNamesFromPaths(filesToPack), waveFormat))
 		{
 			// Error writing volume file
 			CleanUpVolumeCreate(outFile, filesToPack.size(), fileHandle, waveFormat, indexEntry);

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -24,7 +24,7 @@ namespace Archives
 		int GetInternalFileSize(int index);
 
 		bool Repack();
-		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames);
+		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
 

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -147,16 +147,14 @@ namespace Archives
 	bool VolFile::Repack()
 	{
 		std::vector<std::string> filesToPack(m_NumberOfPackedFiles);
-		std::vector<std::string> internalNames(m_NumberOfPackedFiles);
 
 		for (int i = 0; i < m_NumberOfPackedFiles; i++)
 		{
 			//Filename is equivalent to internalName since filename is a relative path from current directory.
-			internalNames.push_back(GetInternalFileName(i));
-			filesToPack.push_back(internalNames[i]); 
+			filesToPack.push_back(GetInternalFileName(i));
 		}
 
-		if (!CreateVolume("Temp.vol", filesToPack, internalNames)) {
+		if (!CreateVolume("Temp.vol", filesToPack)) {
 			return false;
 		}
 
@@ -167,12 +165,12 @@ namespace Archives
 		return ReplaceFileWithFile(m_VolumeFileName, "Temp.vol");
 	}
 
-	bool VolFile::CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames)
+	bool VolFile::CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack)
 	{
 		CreateVolumeInfo volInfo;
 
 		volInfo.filesToPack = filesToPack;
-		volInfo.internalNames = internalNames;
+		volInfo.internalNames = GetInternalNamesFromPaths(filesToPack);
 
 		if (OpenOutputFile(volumeFileName.c_str()) == 0) {
 			return false;

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -32,7 +32,7 @@ namespace Archives
 
 		// Volume Creation
 		bool Repack();
-		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack, std::vector<std::string> internalNames);
+		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
 		int GetInternalFileOffset(int index);


### PR DESCRIPTION
 - Generate internalNames from within ArchivePacker instead of forcing users of the library to generate internalNames manually, standardizing the process.
 - Add error checking to throw an exception when creating volumes containing 2 files with the same internalName (filename not including path).