### PR TITLE
Add CellType scoped enum to Maps

### DIFF
--- a/Maps/CellType.h
+++ b/Maps/CellType.h
@@ -1,0 +1,38 @@
+#pragma once
+
+// CellTypes returned and set by the GameMap class
+enum class CellType
+{
+	FastPassible1 = 0,	// Rock vegetation
+	Impassible2,		// Meteor craters, cracks/crevases
+	SlowPassible1,		// Lava rock (dark)
+	SlowPassible2,		// Rippled dirt/Lava rock bumps
+	MediumPassible1,	// Dirt
+	MediumPassible2,	// Lava rock
+	Impassible1,		// Dirt/Rock/Lava rock mound/ice/volcano
+	FastPassible2,		// Rock
+	NorthCliffs,
+	CliffsHighSide,
+	CliffsLowSide,      // Cliffs, low and middle sections
+	VentsAndFumaroles,	// Fumaroles (passable by GeoCons)
+	zPad12,
+	zPad13,
+	zPad14,
+	zPad15,
+	zPad16,
+	zPad17,
+	zPad18,
+	zPad19,
+	zPad20,
+	DozedArea,			// Bulldozed, non tubed area (buildings are tubed underneath). Does not include buildings.
+	Rubble,
+	NormalWall,
+	MicrobeWall,
+	LavaWall,
+	Tube0,				// Used for tubes and areas under buildings
+	Tube1,				// Note: Tube values 1-5 don't appear to be used
+	Tube2,
+	Tube3,
+	Tube4,
+	Tube5,
+};

--- a/Maps/MapData.cpp
+++ b/Maps/MapData.cpp
@@ -1,4 +1,5 @@
 #include "MapData.h"
+#include "CellType.h"
 
 unsigned int MapData::GetTileInfoIndex(unsigned int x, unsigned int y) const
 {
@@ -6,7 +7,7 @@ unsigned int MapData::GetTileInfoIndex(unsigned int x, unsigned int y) const
 	return tiles[cellIndex].tileIndex;
 }
 
-int MapData::GetCellType(unsigned int x, unsigned int y) const
+CellType MapData::GetCellType(unsigned int x, unsigned int y) const
 {
 	return tiles[GetCellIndex(x, y)].cellType;
 }

--- a/Maps/MapData.h
+++ b/Maps/MapData.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+enum class CellType;
 
 // FILE FORMAT DOCUMENTATION: 
 //     Outpost2SVN\OllyDbg\InternalData\FileFormat SavedGame and Map.txt.
@@ -40,7 +41,7 @@ struct MapData
 
 public:
 	unsigned int GetTileInfoIndex(unsigned int x, unsigned int y) const;
-	int GetCellType(unsigned int x, unsigned int y) const;
+	CellType GetCellType(unsigned int x, unsigned int y) const;
 	int GetLavaPossible(unsigned int x, unsigned int y) const;
 	short GetTilesetIndex(unsigned int x, unsigned int y) const;
 	short GetImageIndex(unsigned int x, unsigned int y) const;

--- a/Maps/TileData.h
+++ b/Maps/TileData.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include "CellType.h"
+
 #pragma pack(push, 1) // Make sure structures are byte aligned
 
 // Outpost 2 Tile metadata. Implemented as a Bitfield structure (32 bits total)
 struct TileData
 {
 	// Determines movement speed of tile, or if tile is bulldozed, walled, tubed, or has rubble.
-	int cellType : 5;
+	//int cellType : 5;
+	CellType cellType : 5;
 
 	// The tile's associated index in the TileInfo array. 
 	// TileInfo lists general properties associated with a tile.

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -119,6 +119,7 @@
     <ClInclude Include="Archives\ArchiveUnpacker.h" />
     <ClInclude Include="Archives\CompressionType.h" />
     <ClInclude Include="Archives\MemoryMappedFile.h" />
+    <ClInclude Include="Maps\CellType.h" />
     <ClInclude Include="Maps\ClipRect.h" />
     <ClInclude Include="Maps\MapData.h" />
     <ClInclude Include="Maps\MapHeader.h" />
@@ -141,7 +142,6 @@
     <ClCompile Include="Maps\MapData.cpp" />
     <ClCompile Include="Maps\MapReader.cpp" />
     <ClCompile Include="Maps\MapWriter.cpp" />
-
     <ClCompile Include="ResourceManager.cpp" />
     <ClCompile Include="Archives\AdaptHuffTree.cpp" />
     <ClCompile Include="Archives\MemoryMappedFile.cpp" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="Maps\MapReader.h">
       <Filter>Maps</Filter>
     </ClInclude>
+    <ClInclude Include="Maps\CellType.h">
+      <Filter>Maps</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="XFile.cpp">


### PR DESCRIPTION
 - Decided to use a scoped enum to limit the number of individual items added to the working namespace when included.
 - Mirrors the enum CellTypes in Outpost2DLL.

** This is a good candidate for Squash and Merge **