### PR TITLE
Refactor StreamReader class series

### DIFF
--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -37,7 +37,7 @@ MapData MapReader::Read(std::unique_ptr<SeekableStreamReader> mapStream, bool sa
 
 void MapReader::SkipSaveGameHeader()
 {
-	streamReader->Ignore(0x1E025);
+	streamReader->Seek(0x1E025);
 }
 
 void MapReader::ReadHeader(MapData& mapData)
@@ -113,7 +113,7 @@ void MapReader::ReadTileGroups(MapData& mapData)
 {
 	int numTileGroups;
 	streamReader->Read((char*)&numTileGroups, sizeof(numTileGroups));
-	streamReader->Ignore(4);
+	streamReader->Seek(4);
 
 	for (int i = 0; i < numTileGroups; ++i)
 	{

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -4,16 +4,14 @@
 #include <cstring>
 #include <stdexcept>
 
-using namespace std;
-
 StreamReader::~StreamReader() { }
 
 // Defers calls to C++ standard library methods
 FileStreamReader::FileStreamReader(std::string filename) {
-	file = ifstream(filename, ios::in | ios::binary);
+	file = std::ifstream(filename, std::ios::in | std::ios::binary);
 
 	if (!file.is_open()) {
-		throw runtime_error("File could not be opened.");
+		throw std::runtime_error("File could not be opened.");
 	}
 }
 
@@ -25,8 +23,8 @@ void FileStreamReader::Read(char* buffer, size_t size) {
 	file.read(buffer, size);
 }
 
-void FileStreamReader::Ignore(size_t size) {
-	file.ignore(size);
+void FileStreamReader::Seek(int offset) {
+	file.seekg(offset, std::ios_base::cur);
 }
 
 
@@ -39,18 +37,18 @@ MemoryStreamReader::MemoryStreamReader(char* buffer, size_t size) {
 void MemoryStreamReader::Read(char* buffer, size_t size) 
 {
 	if (offset + size > streamSize) {
-		throw runtime_error("Size of bytes to read exceeds remaining size of buffer.");
+		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");
 	}
 
 	memcpy(buffer, streamBuffer + offset, size);
 	offset += size;
 }
 
-void MemoryStreamReader::Ignore(size_t size)
+void MemoryStreamReader::Seek(int offset)
 {
-	if (offset + size > streamSize) {
-		throw runtime_error("Size of bytes to ignore exceeds remaining size of buffer.");
+	if (this->offset + offset > streamSize || this->offset + offset < 0) {
+		throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 	}
 
-	offset += size;
+	this->offset += offset;
 }

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -11,8 +11,8 @@ public:
 
 class SeekableStreamReader : public StreamReader {
 public:
-	//virtual ~SeekableStreamReader() = 0;
-	virtual void Ignore(size_t size) = 0;
+	// Change position forward or backword in buffer.
+	virtual void Seek(int offset) = 0;
 };
 
 class FileStreamReader : public SeekableStreamReader {
@@ -20,7 +20,8 @@ public:
 	FileStreamReader(std::string fileName);
 	~FileStreamReader();
 	void Read(char* buffer, size_t size);
-	void Ignore(size_t size);
+	// Change position forward or backword in buffer.
+	void Seek(int offset);
 
 private:
 	std::ifstream file;
@@ -31,7 +32,7 @@ class MemoryStreamReader : public SeekableStreamReader {
 public:
 	MemoryStreamReader(char* buffer, size_t size);
 	void Read(char* buffer, size_t size);
-	void Ignore(size_t size);
+	void Seek(int offset);
 
 private:
 	char* streamBuffer;


### PR DESCRIPTION
 - Change SeekableStreamReader::Ignore(size_t size) to be Seek(int offset). This allows for seeking both forward and backwards in a memoryStream or fileStream.
 - Add bounds check to ensure MemoryStreamReader does not allow offsetting to a negative value (before the start of the actual stream).

- This puts StreamReader in a closer position for integration as a Serializer if desired in the future.