### PR TITLE
Add FileStreamWriter control flags

### DIFF
--- a/FileWriteFlags.h
+++ b/FileWriteFlags.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace FileWriteFlag
+{
+	// Default values are Do not overwrite files, append to existing files, and write in binary format.
+	enum FileWriteFlag : unsigned int
+	{
+		// SET:     Allow overwritting the file if it exists (mutually exclusive from Append).
+		// NOT SET: Do not allow overwritting an exisitng file.
+		Overwrite = 0b0000'0001,
+
+		// SET:     Do not allow a new file to be created (Mutually exclusive from Overwrite).
+		// NOT SET: Allow new file creation. Overwrite must also be set.
+		DoNotCreate = 0b0000'0010,
+
+		// SET:     If file exists, default to truncating file to zero bytes
+		// NOT SET: If file exists, default to writing at end of file (Append).
+		Truncate = 0b0000'0100,
+
+		// SET:     Specifies text file format.
+		// NOT SET: Specified binary file format.
+		Text = 0b0000'1000
+	};
+}

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -19,9 +19,10 @@ void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData)
 	WriteTileGroups(mapData.tileGroups);
 }
 
+// Creates a new map file by truncating an existing file if it exists.
 void MapWriter::Write(const std::string& filename, const MapData& mapData)
 {
-	Write(FileStreamWriter(filename), mapData);
+	Write(FileStreamWriter(filename, FileWriteFlag::Overwrite | FileWriteFlag::Truncate), mapData);
 }
 
 void MapWriter::WriteHeader(const MapHeader& header)

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -119,6 +119,7 @@
     <ClInclude Include="Archives\ArchiveUnpacker.h" />
     <ClInclude Include="Archives\CompressionType.h" />
     <ClInclude Include="Archives\MemoryMappedFile.h" />
+    <ClInclude Include="FileWriteFlags.h" />
     <ClInclude Include="Maps\CellType.h" />
     <ClInclude Include="Maps\ClipRect.h" />
     <ClInclude Include="Maps\MapData.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClInclude Include="StreamWriter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FileWriteFlags.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="XFile.cpp">

--- a/StreamWriter.h
+++ b/StreamWriter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "FileWriteFlags.h"
 #include <fstream>
 #include <string>
 
@@ -20,7 +21,7 @@ public:
 class FileStreamWriter : public SeekableStreamWriter
 {
 public:
-	FileStreamWriter(const std::string& filename);
+	FileStreamWriter(const std::string& filename, unsigned int writeSettings);
 	~FileStreamWriter();
 	void Write(const char* buffer, size_t size);
 	// Change position forward or backword in buffer.
@@ -28,6 +29,9 @@ public:
 
 private:
 	std::fstream fileStream;
+
+	unsigned int FormatFstreamMode(unsigned int writeSettings) const;
+	bool FlagSet(unsigned int bitfield, unsigned int flag) const;
 };
 
 class MemoryStreamWriter : public SeekableStreamWriter


### PR DESCRIPTION
Add an enum called FileWriteFlag that allows manipulating file write settings. Based on options provided in Windows by dwCreationDisposition (https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx) This enum is mapped to appropriate flags for manipulating std::fstream.

There is a helper function FileStreamWriter::FlagSet. It is very generic though and could possibly live somewhere else. Since it is only one function, I didn't want to create a separate header file for it right now though.

Usability could possibly be approved right now by adding more flags. For example, if you want to append data to the file, there is no option. You have to recognize that appending is the default value and just not set Truncate. The tradeoff here is we are adding unnecessary flags and then I'll have to increase the codebase to handle them.

Current default settings are create files if they do not exist, append data if they do exist, and write in binary as default. Writing in binary is not default for std::fstream, but it seemed to make more sense as a default for our uses.

Thanks.  
