### PR TITLE
Use stream writer when unpacking archives

### DIFF
--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -18,16 +18,12 @@ namespace Archives
 		delete m_VolumeFileName;
 	}
 
-	int ArchiveUnpacker::ExtractAllFiles(const char* destDirectory)
+	void ArchiveUnpacker::ExtractAllFiles(const char* destDirectory)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{
-			if (ExtractFile(i, XFile::ReplaceFilename(destDirectory, GetInternalFileName(i)).c_str()) == false) {
-				return false;
-			}
+			ExtractFile(i, XFile::ReplaceFilename(destDirectory, GetInternalFileName(i)).c_str());
 		}
-
-		return true;
 	}
 
 	bool ArchiveUnpacker::ContainsFile(const char* fileName)

--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -36,4 +36,11 @@ namespace Archives
 
 		return false;
 	}
+
+	void ArchiveUnpacker::CheckPackedFileIndexBounds(int fileIndex)
+	{
+		if (fileIndex < 0 || fileIndex >= m_NumberOfPackedFiles) {
+			throw std::runtime_error("fileIndex is outside the bounds of packed files.");
+		}
+	}
 }

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -28,6 +28,8 @@ namespace Archives
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;
 
 	protected:
+		void CheckPackedFileIndexBounds(int fileIndex);
+
 		char *m_VolumeFileName;
 		int m_NumberOfPackedFiles;
 		int m_VolumeFileSize;

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -22,8 +22,7 @@ namespace Archives
 		// Returns -1 if internalFileName is not present in archive.
 		virtual int GetInternalFileIndex(const char *internalFileName) = 0;
 		virtual int GetInternalFileSize(int index) = 0;
-		virtual void ExtractFile(size_t index, const std::string& pathOut) = 0;
-		//virtual int ExtractFile(int index, const char *fileName) = 0;
+		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
 		virtual void ExtractAllFiles(const char* destDirectory);
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <memory>
 
 class SeekableStreamReader;
@@ -21,8 +22,9 @@ namespace Archives
 		// Returns -1 if internalFileName is not present in archive.
 		virtual int GetInternalFileIndex(const char *internalFileName) = 0;
 		virtual int GetInternalFileSize(int index) = 0;
-		virtual int ExtractFile(int index, const char *fileName) = 0;
-		virtual int ExtractAllFiles(const char* destDirectory);
+		virtual void ExtractFile(size_t index, const std::string& pathOut) = 0;
+		//virtual int ExtractFile(int index, const char *fileName) = 0;
+		virtual void ExtractAllFiles(const char* destDirectory);
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;
 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -100,6 +100,8 @@ namespace Archives
 	// Returns the internal file name of the internal file corresponding to index
 	const char* ClmFile::GetInternalFileName(int index)
 	{
+		CheckPackedFileIndexBounds(index);
+
 		return m_FileName[index];
 	}
 
@@ -118,6 +120,8 @@ namespace Archives
 	// Returns the size of the internal file corresponding to index
 	int ClmFile::GetInternalFileSize(int index)
 	{
+		CheckPackedFileIndexBounds(index);
+
 		return m_IndexEntry[index].dataLength;
 	}
 
@@ -126,6 +130,8 @@ namespace Archives
 	// Extracts the internal file corresponding to index
 	void ClmFile::ExtractFile(int fileIndex, const std::string& pathOut)
 	{
+		CheckPackedFileIndexBounds(fileIndex);
+
 		WaveHeader header;
 		InitializeWaveHeader(header, fileIndex);
 
@@ -201,6 +207,8 @@ namespace Archives
 
 	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(int fileIndex)
 	{
+		CheckPackedFileIndexBounds(fileIndex);
+
 		throw std::logic_error("OpenSeekableStreamReader not yet implemented for Clm files.");
 	}
 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -66,7 +66,7 @@ namespace Archives
 		if (ReadFile(m_FileHandle, buff, 32, &numBytes, nullptr) == 0) return false;
 		if (memcmp(buff, "OP2 Clump File Version 1.0\x01A\0\0\0\0", 32)) return false;
 
-		// Read in the WAVEFORMATEX structure
+		// Read in the WaveFormatEx structure
 		if (ReadFile(m_FileHandle, &m_WaveFormat, sizeof(m_WaveFormat), &numBytes, nullptr) == 0) return false;
 
 		// Read remaining header info
@@ -124,7 +124,7 @@ namespace Archives
 	
 
 	// Extracts the internal file corresponding to index
-	void ClmFile::ExtractFile(size_t fileIndex, const std::string& pathOut)
+	void ClmFile::ExtractFile(int fileIndex, const std::string& pathOut)
 	{
 		WaveHeader header;
 		InitializeWaveHeader(header, fileIndex);
@@ -234,7 +234,7 @@ namespace Archives
 
 		HANDLE outFile = nullptr;
 		HANDLE *fileHandle;
-		WAVEFORMATEX *waveFormat;
+		WaveFormatEx *waveFormat;
 		IndexEntry *indexEntry;
 
 		// Allocate space for all the file handles
@@ -250,7 +250,7 @@ namespace Archives
 		// Allocate space for index entries
 		indexEntry = new IndexEntry[filesToPack.size()];
 		// Allocate space for the format of all wave files
-		waveFormat = new WAVEFORMATEX[filesToPack.size()];
+		waveFormat = new WaveFormatEx[filesToPack.size()];
 		// Read in all the wave headers
 		if (!ReadAllWaveHeaders(filesToPack.size(), fileHandle, waveFormat, indexEntry))
 		{
@@ -331,7 +331,7 @@ namespace Archives
 	// Returns nonzero if successful and zero otherwise.
 	// Note: This function assumes that all file pointers are initially set to the beginning
 	//  of the file. When reading the wave file header, it does not seek to the file start.
-	bool ClmFile::ReadAllWaveHeaders(int numFilesToPack, HANDLE *file, WAVEFORMATEX *format, IndexEntry *indexEntry)
+	bool ClmFile::ReadAllWaveHeaders(int numFilesToPack, HANDLE *file, WaveFormatEx *format, IndexEntry *indexEntry)
 	{
 #pragma pack(push, 1)
 		struct RiffHeader
@@ -361,7 +361,7 @@ namespace Archives
 			length = FindChunk(FMT, file[i]);
 			if (length == -1) return false;		// Format chunk not found
 			// Read in the wave format
-			if (ReadFile(file[i], &format[i], sizeof(WAVEFORMATEX), &numBytesRead, nullptr) == 0) {
+			if (ReadFile(file[i], &format[i], sizeof(WaveFormatEx), &numBytesRead, nullptr) == 0) {
 				return false;					// Error reading in wave format
 			}
 			format[i].cbSize = 0;
@@ -421,7 +421,7 @@ namespace Archives
 	void ClmFile::CleanUpVolumeCreate(HANDLE outFile,
 		int numFilesToPack,
 		HANDLE *fileHandle,
-		WAVEFORMATEX *waveFormat,
+		WaveFormatEx *waveFormat,
 		IndexEntry *indexEntry)
 	{
 		int i;
@@ -440,13 +440,13 @@ namespace Archives
 
 	// Compares wave format structures in the array waveFormat
 	// Returns true if they are all the same and false otherwise.
-	bool ClmFile::CompareWaveFormats(int numFilesToPack, WAVEFORMATEX *waveFormat)
+	bool ClmFile::CompareWaveFormats(int numFilesToPack, WaveFormatEx *waveFormat)
 	{
 		int i;
 
 		for (i = 1; i < numFilesToPack; i++)
 		{
-			if (memcmp(&waveFormat[i], &waveFormat[0], sizeof(WAVEFORMATEX))) {
+			if (memcmp(&waveFormat[i], &waveFormat[0], sizeof(WaveFormatEx))) {
 				return false;		// Mismatch found
 			}
 		}
@@ -459,13 +459,13 @@ namespace Archives
 		HANDLE *fileHandle,
 		IndexEntry *entry,
 		std::vector<std::string> internalNames,
-		WAVEFORMATEX *waveFormat)
+		WaveFormatEx *waveFormat)
 	{
 #pragma pack(push, 1)
 		struct SClmHeader
 		{
 			char textBuff[32];
-			WAVEFORMATEX waveFormat;
+			WaveFormatEx waveFormat;
 			char unknown[6];
 			int numIndexEntries;
 		};
@@ -491,7 +491,7 @@ namespace Archives
 		// Write the text header
 		if (WriteFile(outFile, textBuff, 32, &numBytes, NULL) == 0) return false;
 		// Write the wave format
-		if (WriteFile(outFile, waveFormat, sizeof(WAVEFORMATEX), &numBytes, NULL) == 0) return false;
+		if (WriteFile(outFile, waveFormat, sizeof(WaveFormatEx), &numBytes, NULL) == 0) return false;
 		// Write the unknown bytes
 		if (WriteFile(outFile, m_Unknown, 6, &numBytes, NULL) == 0) return false;
 		// Write the number of internal files

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -16,7 +16,7 @@ namespace Archives
 
 		const char* GetInternalFileName(int index);
 		int GetInternalFileIndex(const char *internalFileName);
-		void ExtractFile(size_t fileIndex, const std::string& pathOut);
+		void ExtractFile(int fileIndex, const std::string& pathOut);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
@@ -83,12 +83,12 @@ namespace Archives
 
 		// Private functions for packing files
 		bool OpenAllInputFiles(std::vector<std::string> filesToPack, HANDLE *fileHandle);
-		bool ReadAllWaveHeaders(int numFilesToPack, HANDLE *file, WAVEFORMATEX *format, IndexEntry *indexEntry);
+		bool ReadAllWaveHeaders(int numFilesToPack, HANDLE *file, WaveFormatEx *format, IndexEntry *indexEntry);
 		int FindChunk(int chunkTag, HANDLE file);
-		void CleanUpVolumeCreate(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle, WAVEFORMATEX *waveFormat, IndexEntry *indexEntry);
-		bool CompareWaveFormats(int numFilesToPack, WAVEFORMATEX *waveFormat);
+		void CleanUpVolumeCreate(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle, WaveFormatEx *waveFormat, IndexEntry *indexEntry);
+		bool CompareWaveFormats(int numFilesToPack, WaveFormatEx *waveFormat);
 		bool WriteVolume(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle,
-			IndexEntry *entry, std::vector<std::string> internalNames, WAVEFORMATEX *waveFormat);
+			IndexEntry *entry, std::vector<std::string> internalNames, WaveFormatEx *waveFormat);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -17,7 +17,7 @@ namespace Archives
 
 		const char* GetInternalFileName(int index);
 		int GetInternalFileIndex(const char *internalFileName);
-		int ExtractFile(int index, const char *fileName);
+		void ExtractFile(size_t fileIndex, const std::string& pathOut);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
@@ -27,6 +27,35 @@ namespace Archives
 		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
+#pragma pack(push, 1)
+		struct RiffHeader
+		{
+			int riffTag;
+			int chunkSize;
+			int waveTag;
+		};
+
+		struct FormatChunk
+		{
+			int fmtTag;
+			int formatSize;
+			WAVEFORMATEX waveFormat;
+		};
+
+		struct DataChunk
+		{
+			int dataTag;
+			int dataSize;
+		};
+
+		struct WaveHeader
+		{
+			RiffHeader riffHeader;
+			FormatChunk formatChunk;
+			DataChunk dataChunk;
+		};
+#pragma pack(pop)
+
 
 #pragma pack(push, 1)
 		struct IndexEntry
@@ -49,6 +78,7 @@ namespace Archives
 		bool WriteVolume(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle,
 			IndexEntry *entry, std::vector<std::string> internalNames, WAVEFORMATEX *waveFormat);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
+		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 
 		HANDLE m_FileHandle;
 		WAVEFORMATEX m_WaveFormat;

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -2,7 +2,6 @@
 
 #include "ArchiveFile.h"
 #include <windows.h>
-#include <mmreg.h>	// WAVEFORMATEX (omitted from windows.h if #define WIN32_LEAN_AND_MEAN)
 #include <string>
 #include <vector>
 #include <memory>
@@ -28,6 +27,22 @@ namespace Archives
 
 	private:
 #pragma pack(push, 1)
+		/*
+		*  extended waveform format structure used for all non-PCM formats. this
+		*  structure is common to all non-PCM formats.
+		*  Identical to Windows.h WAVEFORMATEX typedef contained in mmeapi.h
+		*/
+		struct WaveFormatEx
+		{
+			unsigned short wFormatTag;         /* format type */
+			unsigned short nChannels;          /* number of channels (i.e. mono, stereo...) */
+			unsigned long  nSamplesPerSec;     /* sample rate */
+			unsigned long  nAvgBytesPerSec;    /* for buffer estimation */
+			unsigned short nBlockAlign;        /* block size of data */
+			unsigned short wBitsPerSample;     /* number of bits per sample of mono data */
+			unsigned short cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
+		};
+
 		struct RiffHeader
 		{
 			int riffTag;
@@ -39,7 +54,7 @@ namespace Archives
 		{
 			int fmtTag;
 			int formatSize;
-			WAVEFORMATEX waveFormat;
+			WaveFormatEx waveFormat;
 		};
 
 		struct DataChunk
@@ -54,10 +69,7 @@ namespace Archives
 			FormatChunk formatChunk;
 			DataChunk dataChunk;
 		};
-#pragma pack(pop)
 
-
-#pragma pack(push, 1)
 		struct IndexEntry
 		{
 			char fileName[8];
@@ -81,7 +93,7 @@ namespace Archives
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 
 		HANDLE m_FileHandle;
-		WAVEFORMATEX m_WaveFormat;
+		WaveFormatEx m_WaveFormat;
 		char m_Unknown[6];
 		IndexEntry *m_IndexEntry;
 		char(*m_FileName)[9];

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -2,6 +2,7 @@
 
 #include "ArchiveFile.h"
 #include <windows.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <memory>
@@ -34,13 +35,13 @@ namespace Archives
 		*/
 		struct WaveFormatEx
 		{
-			unsigned short wFormatTag;         /* format type */
-			unsigned short nChannels;          /* number of channels (i.e. mono, stereo...) */
-			unsigned long  nSamplesPerSec;     /* sample rate */
-			unsigned long  nAvgBytesPerSec;    /* for buffer estimation */
-			unsigned short nBlockAlign;        /* block size of data */
-			unsigned short wBitsPerSample;     /* number of bits per sample of mono data */
-			unsigned short cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
+			uint16_t wFormatTag;         /* format type */
+			uint16_t nChannels;          /* number of channels (i.e. mono, stereo...) */
+			uint32_t nSamplesPerSec;     /* sample rate */
+			uint32_t nAvgBytesPerSec;    /* for buffer estimation */
+			uint16_t nBlockAlign;        /* block size of data */
+			uint16_t wBitsPerSample;     /* number of bits per sample of mono data */
+			uint16_t cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
 		};
 
 		struct RiffHeader

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -1,5 +1,6 @@
 #include "VolFile.h"
 #include "../StreamReader.h"
+#include "../StreamWriter.h"
 #include "../XFile.h"
 #include <stdexcept>
 #include <algorithm>
@@ -86,63 +87,63 @@ namespace Archives
 		return std::make_unique<MemoryStreamReader>(offset, length);
 	}
 
-	// Extracts the internal file at the given index to the file 
-	// fileName. Returns nonzero if successful.
-	int VolFile::ExtractFile(int index, const char *filename)
+	// Extracts the internal file at the given index to the fileName.
+	void VolFile::ExtractFile(size_t fileIndex, const std::string& pathOut)
 	{
-		if (index < 0) {
-			return false;
-		}
-
-		HANDLE outFile;
-		unsigned long bytesWritten;
-		int retVal;
-
-		outFile = CreateFileA(filename,					// fileName
-			GENERIC_WRITE,			// access mode
-			0,						// share mode
-			nullptr,				// security attributes
-			CREATE_ALWAYS,			// creation disposition
-			FILE_ATTRIBUTE_NORMAL,	// file attributes
-			0);						// template
-
-		// Check for errors opening file
-		if (m_FileHandle == INVALID_HANDLE_VALUE) {
-			return false; // Error opening file
-		}
-
-		char* offset = (char*)m_BaseOfFile + m_Index[index].dataBlockOffset;
-		int length = *(int*)(offset + 4) & 0x7FFFFFFF;
-		offset += 8;
-
-		if (m_Index[index].compressionType == CompressionType::Uncompressed)
+		if (m_Index[fileIndex].compressionType == CompressionType::Uncompressed)
 		{
-			retVal = WriteFile(outFile, offset, length, &bytesWritten, nullptr);
+			ExtractFileUncompressed(fileIndex, pathOut);
 		}
-		else
+		else if (m_Index[fileIndex].compressionType == CompressionType::LZH)
 		{
-			if (m_Index[index].compressionType == CompressionType::LZH)
+			ExtractFileLzh(fileIndex, pathOut);
+		}
+		else {
+			//TODO: Convert Compression Type from an enum to a string for output in error message
+			throw std::runtime_error("Compression type is not supported."); 
+		}
+	}
+
+	void VolFile::ExtractFileUncompressed(size_t fileIndex, const std::string& pathOut)
+	{
+		try
+		{
+			char* offset = (char*)m_BaseOfFile + m_Index[fileIndex].dataBlockOffset;
+			int length = *(int*)(offset + 4) & 0x7FFFFFFF;
+			offset += 8;
+			
+			FileStreamWriter fileStreamWriter(pathOut);
+			fileStreamWriter.Write(offset, length);
+		}
+		catch (std::exception e)
+		{
+			throw std::runtime_error("Error attempting to extracted uncompressed file " + pathOut + ". Internal Error Message: " + e.what());
+		}
+	}
+
+	void VolFile::ExtractFileLzh(size_t fileIndex, const std::string& pathOut)
+	{
+		try
+		{
+			char* offset = (char*)m_BaseOfFile + m_Index[fileIndex].dataBlockOffset;
+			int length = *(int*)(offset + 4) & 0x7FFFFFFF;
+			offset += 8;
+
+			HuffLZ decompressor(length, offset);
+			const char *buffer = 0;
+
+			FileStreamWriter fileStreamWriter(pathOut);
+
+			do
 			{
-				// Decompress the file
-				// Construct the decompressor
-				HuffLZ decomp(length, offset);
-				const char *buff = 0;
-
-				do
-				{
-					buff = decomp.GetInternalBuffer(&length);
-					retVal = WriteFile(outFile, buff, length, &bytesWritten, nullptr);
-				} while (length);
-			}
-			else {
-				retVal = 0;
-			}
+				buffer = decompressor.GetInternalBuffer(&length);
+				fileStreamWriter.Write(buffer, length);
+			} while (length);
 		}
-
-		// Close the file
-		CloseHandle(outFile);
-
-		return retVal;
+		catch (std::exception e)
+		{
+			throw std::runtime_error("Error attempting to extracted LZH compressed file " + pathOut + ". Internal Error Message: " + e.what());
+		}
 	}
 
 

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -29,6 +29,8 @@ namespace Archives
 
 	const char* VolFile::GetInternalFileName(int index)
 	{
+		CheckPackedFileIndexBounds(index);
+
 		return m_StringTable + m_Index[index].fileNameOffset;
 	}
 
@@ -47,11 +49,15 @@ namespace Archives
 
 	CompressionType VolFile::GetInternalCompressionCode(int index)
 	{
+		CheckPackedFileIndexBounds(index);
+
 		return m_Index[index].compressionType;
 	}
 
 	int VolFile::GetInternalFileSize(int index)
 	{
+		CheckPackedFileIndexBounds(index);
+
 		return m_Index[index].fileSize;
 	}
 
@@ -80,6 +86,8 @@ namespace Archives
 
 	std::unique_ptr<SeekableStreamReader> VolFile::OpenSeekableStreamReader(int fileIndex)
 	{
+		CheckPackedFileIndexBounds(fileIndex);
+
 		char* offset = (char*)m_BaseOfFile + m_Index[fileIndex].dataBlockOffset;
 		size_t length = *(int*)(offset + 4) & 0x7FFFFFFF;
 		offset += 8;
@@ -90,6 +98,8 @@ namespace Archives
 	// Extracts the internal file at the given index to the fileName.
 	void VolFile::ExtractFile(int fileIndex, const std::string& pathOut)
 	{
+		CheckPackedFileIndexBounds(fileIndex);
+
 		if (m_Index[fileIndex].compressionType == CompressionType::Uncompressed)
 		{
 			ExtractFileUncompressed(fileIndex, pathOut);

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -88,7 +88,7 @@ namespace Archives
 	}
 
 	// Extracts the internal file at the given index to the fileName.
-	void VolFile::ExtractFile(size_t fileIndex, const std::string& pathOut)
+	void VolFile::ExtractFile(int fileIndex, const std::string& pathOut)
 	{
 		if (m_Index[fileIndex].compressionType == CompressionType::Uncompressed)
 		{

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -99,7 +99,6 @@ namespace Archives
 			ExtractFileLzh(fileIndex, pathOut);
 		}
 		else {
-			//TODO: Convert Compression Type from an enum to a string for output in error message
 			throw std::runtime_error("Compression type is not supported."); 
 		}
 	}

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -26,7 +26,7 @@ namespace Archives
 		int GetInternalFileSize(int index);
 
 		// Extraction
-		int ExtractFile(int index, const char *filename);
+		void ExtractFile(size_t fileIndex, const std::string& pathOut);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
@@ -37,6 +37,9 @@ namespace Archives
 	private:
 		int GetInternalFileOffset(int index);
 		int GetInternalFileNameOffset(int index);
+
+		void VolFile::ExtractFileUncompressed(size_t index, const std::string& filename);
+		void VolFile::ExtractFileLzh(size_t index, const std::string& filename);
 
 #pragma pack(push, 1)
 		struct IndexEntry

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -26,7 +26,7 @@ namespace Archives
 		int GetInternalFileSize(int index);
 
 		// Extraction
-		void ExtractFile(size_t fileIndex, const std::string& pathOut);
+		void ExtractFile(int fileIndex, const std::string& pathOut);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 


### PR DESCRIPTION
Working towards removing dependencies on Windows.h and associated headers within Archives code.

Remove some calls to Windows specific code when extracting files from archives by using the OP2Utility's native StreamWriter. Also removed ClmFile's dependency on Windows specific WAVEFORMATEX typedef in the process.

Attempted to improve messaging when an error is occurred when extracting archive files.

Still a lot of Windows specific code, but I was encouraged that the StreamWrier worked.

Following tests performed successfully:

- Extracted a map from a VOL File. Extracted map ran in Outpost 2.
- Extracted a single CLM file. Music track played properly in VLC player.
- Extracted all files from a CLM file. Then repacked them. Newly packed CLM file had same size as original. Outpost 2 appeared able to read the file and was playing a track.

-Brett
