### PR TITLE
Refactor Function ClmFile::WriteVolume

### DIFF
--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -7,6 +7,7 @@
 
 namespace Archives
 {
+	const unsigned int CLM_WRITE_SIZE = 0x00020000;
 	const int32_t RIFF = 0x46464952;	// "RIFF"
 	const int32_t WAVE = 0x45564157;	// "WAVE"
 	const int FMT  = 0x20746D66;	// "fmt "
@@ -490,10 +491,9 @@ namespace Archives
 
 		// Copy the files into the volume
 		unsigned long numBytesRead;
-		std::array<char, CLM_WRITE_SIZE> buffer;
 		for (int i = 0; i < header.packedFilesCount; i++)
 		{
-			if (!PackFile(outFile, buffer, numBytesRead, entry[i], fileHandle[i])) {
+			if (!PackFile(outFile, numBytesRead, entry[i], fileHandle[i])) {
 				// Error reading input file
 				delete[] entry;	// Release the memory for the index table
 				return false;
@@ -516,8 +516,9 @@ namespace Archives
 		}
 	}
 
-	bool ClmFile::PackFile(HANDLE outFile, std::array<char, CLM_WRITE_SIZE>& buffer, unsigned long& numBytesRead, const IndexEntry& entry, HANDLE fileHandle)
+	bool ClmFile::PackFile(HANDLE outFile, unsigned long& numBytesRead, const IndexEntry& entry, HANDLE fileHandle)
 	{
+		std::array<char, CLM_WRITE_SIZE> buffer;
 		int offset = 0;
 		do
 		{

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -28,8 +28,6 @@ namespace Archives
 		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
-		static const unsigned int CLM_WRITE_SIZE = 0x00020000;
-
 #pragma pack(push, 1)
 		/*
 		*  extended waveform format structure used for all non-PCM formats. this
@@ -94,7 +92,7 @@ namespace Archives
 		bool WriteVolume(HANDLE outFile, HANDLE *fileHandle,
 			IndexEntry *entry, const std::vector<std::string>& internalNames, WaveFormatEx *waveFormat);
 		void ClmFile::PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, IndexEntry* entry);
-		bool PackFile(HANDLE outFile, std::array<char, CLM_WRITE_SIZE>& buffer, unsigned long& numBytesRead, const IndexEntry& entry, HANDLE fileHandle);
+		bool PackFile(HANDLE outFile, unsigned long& numBytesRead, const IndexEntry& entry, HANDLE fileHandle);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -4,6 +4,7 @@
 #include <windows.h>
 #include <cstdint>
 #include <string>
+#include <array>
 #include <vector>
 #include <memory>
 
@@ -27,6 +28,8 @@ namespace Archives
 		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
+		static const unsigned int CLM_WRITE_SIZE = 0x00020000;
+
 #pragma pack(push, 1)
 		/*
 		*  extended waveform format structure used for all non-PCM formats. this
@@ -88,8 +91,10 @@ namespace Archives
 		int FindChunk(int chunkTag, HANDLE file);
 		void CleanUpVolumeCreate(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle, WaveFormatEx *waveFormat, IndexEntry *indexEntry);
 		bool CompareWaveFormats(int numFilesToPack, WaveFormatEx *waveFormat);
-		bool WriteVolume(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle,
-			IndexEntry *entry, std::vector<std::string> internalNames, WaveFormatEx *waveFormat);
+		bool WriteVolume(HANDLE outFile, HANDLE *fileHandle,
+			IndexEntry *entry, const std::vector<std::string>& internalNames, WaveFormatEx *waveFormat);
+		void ClmFile::PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, IndexEntry* entry);
+		bool PackFile(HANDLE outFile, std::array<char, CLM_WRITE_SIZE>& buffer, unsigned long& numBytesRead, const IndexEntry& entry, HANDLE fileHandle);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -92,7 +92,7 @@ namespace Archives
 		bool WriteVolume(HANDLE outFile, HANDLE *fileHandle,
 			IndexEntry *entry, const std::vector<std::string>& internalNames, WaveFormatEx *waveFormat);
 		void ClmFile::PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, IndexEntry* entry);
-		bool PackFile(HANDLE outFile, unsigned long& numBytesRead, const IndexEntry& entry, HANDLE fileHandle);
+		bool PackFile(HANDLE outFile, const IndexEntry& entry, HANDLE fileHandle);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 


### PR DESCRIPTION
 - Replace char[] with std::array<char, X>
 - Remove S (struct) prefix from ClmHeader name
 - Create 2 subroutines to reduce size of function (PackFile & PrepareIndex)
 - Add brackets to one line if statements
 - Move variable initialization to first use instead of at top of function