### PR TITLE
Refactor ClmFile::CreateVolume and subordinate functions

### DIFF
--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -17,7 +17,7 @@ namespace Archives
 		virtual bool Repack() = 0;
 		// Create volume is used to create a new volume file with the files specified in filesToPack.
 		// Returns true if successful and false otherwise
-		virtual bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack) = 0;
+		virtual bool CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack) = 0;
 
 	protected:
 		int OpenOutputFile(const char *fileName);

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -187,8 +187,8 @@ namespace Archives
 		headerOut.formatChunk.waveFormat = m_WaveFormat;
 		headerOut.formatChunk.waveFormat.cbSize = 0;
 
-		headerOut.dataChunk.dataTag = DATA;
-		headerOut.dataChunk.dataSize = m_IndexEntry[fileIndex].dataLength;
+		headerOut.dataChunk.formatTag = DATA;
+		headerOut.dataChunk.length = m_IndexEntry[fileIndex].dataLength;
 	}
 
 	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(const char* internalFileName)
@@ -334,17 +334,9 @@ namespace Archives
 	// Returns the chunk length if found or -1 otherwise
 	int ClmFile::FindChunk(uint32_t chunkTag, SeekableStreamReader& seekableStreamReader)
 	{
-#pragma pack(push, 1)
-		struct ChunkHeader
-		{
-			uint32_t formatTag;
-			uint32_t length;
-		};
-#pragma pack(pop)
-
 		uint64_t fileSize = seekableStreamReader.Length();
 
-		if (fileSize < 20) {
+		if (fileSize < sizeof(RiffHeader) + sizeof(ChunkHeader)) {
 			return -1;
 		}
 
@@ -365,7 +357,7 @@ namespace Archives
 			}
 			
 			// If not the right header, skip to next header
-			currentPosition += header.length + 8;
+			currentPosition += header.length + sizeof(ChunkHeader);
 			seekableStreamReader.Seek(currentPosition);
 		} while (currentPosition < fileSize);
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -60,17 +60,18 @@ namespace Archives
 			WaveFormatEx waveFormat;
 		};
 
-		struct DataChunk
+		struct ChunkHeader
 		{
-			int dataTag;
-			int dataSize;
+			uint32_t formatTag;
+			uint32_t length;
 		};
 
+	    // http://soundfile.sapp.org/doc/WaveFormat/
 		struct WaveHeader
 		{
 			RiffHeader riffHeader;
 			FormatChunk formatChunk;
-			DataChunk dataChunk;
+			ChunkHeader dataChunk;
 		};
 
 		struct IndexEntry

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "ArchiveFile.h"
+#include "../StreamReader.h"
+#include "../StreamWriter.h"
 #include <windows.h>
 #include <cstdint>
 #include <string>
-#include <array>
 #include <vector>
 #include <memory>
 
@@ -25,7 +26,7 @@ namespace Archives
 		int GetInternalFileSize(int index);
 
 		bool Repack();
-		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
+		bool CreateArchive(std::string archiveFileName, std::vector<std::string> filesToPack);
 
 	private:
 #pragma pack(push, 1)
@@ -77,6 +78,8 @@ namespace Archives
 			char fileName[8];
 			unsigned int dataOffset;
 			unsigned int dataLength;
+
+			std::string GetFileName() const { return std::string(fileName); }
 		};
 #pragma pack(pop)
 
@@ -84,15 +87,13 @@ namespace Archives
 		bool ReadHeader();
 
 		// Private functions for packing files
-		bool OpenAllInputFiles(std::vector<std::string> filesToPack, HANDLE *fileHandle);
-		bool ReadAllWaveHeaders(int numFilesToPack, HANDLE *file, WaveFormatEx *format, IndexEntry *indexEntry);
-		int FindChunk(int chunkTag, HANDLE file);
-		void CleanUpVolumeCreate(HANDLE outFile, int numFilesToPack, HANDLE *fileHandle, WaveFormatEx *waveFormat, IndexEntry *indexEntry);
-		bool CompareWaveFormats(int numFilesToPack, WaveFormatEx *waveFormat);
-		bool WriteVolume(HANDLE outFile, HANDLE *fileHandle,
-			IndexEntry *entry, const std::vector<std::string>& internalNames, WaveFormatEx *waveFormat);
-		void ClmFile::PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, IndexEntry* entry);
-		bool PackFile(HANDLE outFile, const IndexEntry& entry, HANDLE fileHandle);
+		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
+		int FindChunk(uint32_t chunkTag, FileStreamReader& fileStreamReader);
+		bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
+		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
+			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
+		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
+		void PackFile(FileStreamWriter& clmFileWriter, const IndexEntry& entry, FileStreamReader& fileToPackReader);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -88,12 +88,12 @@ namespace Archives
 
 		// Private functions for packing files
 		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
-		int FindChunk(uint32_t chunkTag, FileStreamReader& fileStreamReader);
+		int FindChunk(uint32_t chunkTag, SeekableStreamReader& seekableStreamReader);
 		bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
 		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
 		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
-		void PackFile(FileStreamWriter& clmFileWriter, const IndexEntry& entry, FileStreamReader& fileToPackReader);
+		void PackFile(StreamWriter& clmWriter, const IndexEntry& entry, StreamReader& fileToPackReader);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -167,7 +167,7 @@ namespace Archives
 			filesToPack.push_back(GetInternalFileName(i));
 		}
 
-		if (!CreateVolume("Temp.vol", filesToPack)) {
+		if (!CreateArchive("Temp.vol", filesToPack)) {
 			return false;
 		}
 
@@ -178,7 +178,7 @@ namespace Archives
 		return ReplaceFileWithFile(m_VolumeFileName, "Temp.vol");
 	}
 
-	bool VolFile::CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack)
+	bool VolFile::CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack)
 	{
 		std::sort(filesToPack.begin(), filesToPack.end(), ComparePathFilenames);
 

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -32,7 +32,7 @@ namespace Archives
 
 		// Volume Creation
 		bool Repack();
-		bool CreateVolume(std::string volumeFileName, std::vector<std::string> filesToPack);
+		bool CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
 		int GetInternalFileOffset(int index);

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -11,7 +11,7 @@ FileStreamReader::FileStreamReader(std::string filename) {
 	file = std::ifstream(filename, std::ios::in | std::ios::binary);
 
 	if (!file.is_open()) {
-		throw std::runtime_error("File could not be opened.");
+		throw std::runtime_error("The following file could not be opened: " + filename + ".");
 	}
 }
 
@@ -21,6 +21,20 @@ FileStreamReader::~FileStreamReader() {
 
 void FileStreamReader::Read(char* buffer, size_t size) {
 	file.read(buffer, size);
+}
+
+uint64_t FileStreamReader::Length() {
+	uint64_t currentPosition = file.tellg();
+	file.seekg(0, std::ios_base::end);
+	uint64_t length = file.tellg();
+
+	file.seekg(currentPosition, std::ios_base::beg);
+
+	return length;
+}
+
+void FileStreamReader::Seek(uint64_t position) {
+	file.seekg(position, std::ios_base::beg);
 }
 
 void FileStreamReader::SeekRelative(int offset) {

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -11,7 +11,7 @@ FileStreamReader::FileStreamReader(std::string filename) {
 	file = std::ifstream(filename, std::ios::in | std::ios::binary);
 
 	if (!file.is_open()) {
-		throw std::runtime_error("The following file could not be opened: " + filename + ".");
+		throw std::runtime_error("Could not open file: " + filename);
 	}
 }
 
@@ -19,7 +19,7 @@ FileStreamReader::~FileStreamReader() {
 	file.close();
 }
 
-void FileStreamReader::Read(char* buffer, size_t size) {
+void FileStreamReader::Read(char* buffer, uint64_t size) {
 	file.read(buffer, size);
 }
 
@@ -37,34 +37,58 @@ void FileStreamReader::Seek(uint64_t position) {
 	file.seekg(position, std::ios_base::beg);
 }
 
-void FileStreamReader::SeekRelative(int offset) {
+void FileStreamReader::SeekRelative(int64_t offset) {
 	file.seekg(offset, std::ios_base::cur);
 }
 
 
-MemoryStreamReader::MemoryStreamReader(char* buffer, size_t size) {
+MemoryStreamReader::MemoryStreamReader(char* buffer, uint64_t size) {
 	streamBuffer = buffer;
 	streamSize = size;
-	offset = 0;
+	position = 0;
 }
 
-void MemoryStreamReader::Read(char* buffer, size_t size) 
+void MemoryStreamReader::Read(char* buffer, uint64_t size) 
 {
-	if (offset + size > streamSize) {
+	if (position + size > streamSize) {
 		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");
 	}
 
-	memcpy(buffer, streamBuffer + offset, size);
-	offset += size;
+	// std::memcpy takes a _Size to copy of size_t. 
+	// Depending on the system, size_t may not be able to store the max value of uint64_t. 
+	// SIZE_MAX is the largest value that may be stored in size_t for the given system.
+	do {
+		size_t nextReadLength = SIZE_MAX;
+		// Check if remaining value of size will fit in a size_t.
+		if (size < SIZE_MAX) {
+			nextReadLength = static_cast<size_t>(size);
+		}
+
+		std::memcpy(buffer, streamBuffer + position, nextReadLength);
+		position += nextReadLength;
+		size -= nextReadLength;
+	} while (size != 0); // Continue reading in chunks until all data has been copied.
 }
 
-void MemoryStreamReader::SeekRelative(int offset)
-{
-	// Checking if offset goes below 0 is unnecessary. Arithmetic on a signed and unsigned number results 
-	// in a signed number that will wraparound to a large positive and be caught.
-	if (this->offset + offset > streamSize) {
+uint64_t MemoryStreamReader::Length() {
+	return streamSize;
+}
+
+void MemoryStreamReader::Seek(uint64_t position) {
+	if (position > this->position) {
 		throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 	}
 
-	this->offset += offset;
+	this->position = position;
+}
+
+void MemoryStreamReader::SeekRelative(int64_t offset)
+{
+	// Checking if offset goes below 0 is unnecessary. Arithmetic on a signed and unsigned number results 
+	// in a signed number that will wraparound to a large positive and be caught.
+	if (this->position + offset > streamSize) {
+		throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
+	}
+
+	this->position += offset;
 }

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -19,8 +19,10 @@ class FileStreamReader : public SeekableStreamReader {
 public:
 	FileStreamReader(std::string fileName);
 	~FileStreamReader();
+
 	void Read(char* buffer, size_t size);
-	// Change position forward or backword in buffer.
+	uint64_t Length();
+	void Seek(uint64_t position);
 	void SeekRelative(int offset);
 
 private:

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -7,7 +7,7 @@
 class StreamReader {
 public:
 	virtual ~StreamReader() = 0;
-	virtual void Read(char* buffer, uint64_t size) = 0;
+	virtual void Read(char* buffer, size_t size) = 0;
 };
 
 class SeekableStreamReader : public StreamReader {
@@ -27,7 +27,7 @@ public:
 	FileStreamReader(std::string fileName);
 	~FileStreamReader();
 
-	void Read(char* buffer, uint64_t size);
+	void Read(char* buffer, size_t size);
 	uint64_t Length();
 	void Seek(uint64_t position);
 	void SeekRelative(int64_t offset);
@@ -39,14 +39,14 @@ private:
 
 class MemoryStreamReader : public SeekableStreamReader {
 public:
-	MemoryStreamReader(char* buffer, uint64_t size);
-	void Read(char* buffer, uint64_t size);
+	MemoryStreamReader(char* buffer, size_t size);
+	void Read(char* buffer, size_t size);
 	uint64_t Length();
 	void Seek(uint64_t position);
 	void SeekRelative(int64_t offset);
 
 private:
 	char* streamBuffer;
-	uint64_t streamSize;
-	uint64_t position;
+	size_t streamSize;
+	size_t position;
 };

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -2,17 +2,24 @@
 
 #include <fstream>
 #include <string>
+#include <cstdint>
 
 class StreamReader {
 public:
 	virtual ~StreamReader() = 0;
-	virtual void Read(char* buffer, size_t size) = 0;
+	virtual void Read(char* buffer, uint64_t size) = 0;
 };
 
 class SeekableStreamReader : public StreamReader {
 public:
-	// Change position forward or backword in buffer.
-	virtual void SeekRelative(int offset) = 0;
+	// Get the size of the stream
+	virtual uint64_t Length() = 0;
+	
+	// Seek to absolute position, given as offset from beginning of stream
+	virtual void Seek(uint64_t position) = 0;
+	
+	// Seek by a relative amount, given as offset from current position
+	virtual void SeekRelative(int64_t offset) = 0;
 };
 
 class FileStreamReader : public SeekableStreamReader {
@@ -20,10 +27,10 @@ public:
 	FileStreamReader(std::string fileName);
 	~FileStreamReader();
 
-	void Read(char* buffer, size_t size);
+	void Read(char* buffer, uint64_t size);
 	uint64_t Length();
 	void Seek(uint64_t position);
-	void SeekRelative(int offset);
+	void SeekRelative(int64_t offset);
 
 private:
 	std::ifstream file;
@@ -32,12 +39,14 @@ private:
 
 class MemoryStreamReader : public SeekableStreamReader {
 public:
-	MemoryStreamReader(char* buffer, size_t size);
-	void Read(char* buffer, size_t size);
-	void SeekRelative(int offset);
+	MemoryStreamReader(char* buffer, uint64_t size);
+	void Read(char* buffer, uint64_t size);
+	uint64_t Length();
+	void Seek(uint64_t position);
+	void SeekRelative(int64_t offset);
 
 private:
 	char* streamBuffer;
-	size_t streamSize;
-	size_t offset;
+	uint64_t streamSize;
+	uint64_t position;
 };


### PR DESCRIPTION
Remove all Windows specific code from packing a clmFile.

 - Rename ArchivePacker::CreateVolume as CreateArchive
 - Exchange C Style Arrays for std::vector, allowing for simplified memory management
 - Change outFile from a HANDLE to a FileStreamWriter
 - Rename outFile to clmFileWriter
 - Rename ClmFile::WriteVolume to WriteArchive
 - Move creation of clmFileWriter to ClmFile::WriteArchive
 - Replace filesToPack HANDLES with FileStreamWriters.
 - Standardize ClmFile.cpp constants as fixed width unsigned integers
 - Begin standardizing use of constant width integers when serializing and unserializing data.