### PR TITLE
Remove Windows header from ClmFile

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -75,6 +75,10 @@ namespace Archives
 
 	void ArchivePacker::CheckSortedContainerForDuplicateNames(const std::vector<std::string>& internalNames) 
 	{
+		if (internalNames.size() == 0) {
+			return;
+		}
+
 		for (size_t i = 0; i < internalNames.size() - 1; ++i)
 		{
 			if (StringHelper::CheckIfStringsAreEqual(internalNames[i], internalNames[i + 1])) {

--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -66,7 +66,7 @@ namespace Archives
 	{
 		std::vector<std::string> fileNames;
 
-		for (std::string& fileName : paths) {
+		for (const std::string& fileName : paths) {
 			fileNames.push_back(XFile::GetFilename(fileName));
 		}
 
@@ -75,13 +75,9 @@ namespace Archives
 
 	void ArchivePacker::CheckSortedContainerForDuplicateNames(const std::vector<std::string>& internalNames) 
 	{
-		if (internalNames.size() == 0) {
-			return;
-		}
-
-		for (size_t i = 0; i < internalNames.size() - 1; ++i)
+		for (size_t i = 1; i < internalNames.size(); ++i)
 		{
-			if (StringHelper::CheckIfStringsAreEqual(internalNames[i], internalNames[i + 1])) {
+			if (StringHelper::CheckIfStringsAreEqual(internalNames[i - 1], internalNames[i])) {
 				throw std::runtime_error("Unable to create an archive containing files with the same filename. Duplicate filename: " + internalNames[i]);
 			}
 		}

--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -50,13 +50,14 @@ namespace Archives
 	// Returns true if successful and false otherwise
 	bool ArchivePacker::ReplaceFileWithFile(const char *fileToReplace, const char *newFile)
 	{
-		MoveFileA(fileToReplace, "Delete.vol");
+		std::string tempFileName("Temporary.vol");
+		MoveFileA(fileToReplace, tempFileName.c_str());
 		
 		if (MoveFileA(newFile, fileToReplace) == 0) {
 			return false;
 		}
 
-		DeleteFileA("Delete.vol");
+		DeleteFileA(tempFileName.c_str());
 
 		return true;
 	}

--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -12,7 +12,9 @@ namespace Archives
 
 	ArchivePacker::~ArchivePacker()
 	{
-		if (m_OutFileHandle) CloseHandle(m_OutFileHandle);
+		if (m_OutFileHandle) {
+			CloseHandle(m_OutFileHandle);
+		}
 	}
 
 	// Opens the file for output and returns nonzero if successful
@@ -37,7 +39,10 @@ namespace Archives
 	// Closes the file whose handle is in m_OutFileHandle
 	void ArchivePacker::CloseOutputFile()
 	{
-		if (m_OutFileHandle) CloseHandle(m_OutFileHandle);
+		if (m_OutFileHandle) {
+			CloseHandle(m_OutFileHandle);
+		}
+
 		m_OutFileHandle = nullptr;
 	}
 
@@ -46,7 +51,11 @@ namespace Archives
 	bool ArchivePacker::ReplaceFileWithFile(const char *fileToReplace, const char *newFile)
 	{
 		MoveFileA(fileToReplace, "Delete.vol");
-		if (MoveFileA(newFile, fileToReplace) == 0) return false;
+		
+		if (MoveFileA(newFile, fileToReplace) == 0) {
+			return false;
+		}
+
 		DeleteFileA("Delete.vol");
 
 		return true;
@@ -56,7 +65,7 @@ namespace Archives
 	{
 		std::vector<std::string> fileNames;
 
-		for (std::string fileName : paths) {
+		for (std::string& fileName : paths) {
 			fileNames.push_back(XFile::GetFilename(fileName));
 		}
 

--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -3,20 +3,15 @@
 
 namespace Archives
 {
-	ArchiveUnpacker::ArchiveUnpacker(const char *fileName)
+	ArchiveUnpacker::ArchiveUnpacker(const std::string& fileName)
 	{
-		// Copy the filename to class storage
-		m_VolumeFileName = new char[strlen(fileName) + 1];// Allocate space for the filename
-		strcpy(m_VolumeFileName, fileName);				  // Copy the filename to class storage
+		this->m_VolumeFileName = fileName;
 
 		m_NumberOfPackedFiles = 0;
 		m_VolumeFileSize = 0;
 	}
 
-	ArchiveUnpacker::~ArchiveUnpacker()
-	{
-		delete m_VolumeFileName;
-	}
+	ArchiveUnpacker::~ArchiveUnpacker() { }
 
 	void ArchiveUnpacker::ExtractAllFiles(const char* destDirectory)
 	{

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -10,10 +10,10 @@ namespace Archives
 	class ArchiveUnpacker
 	{
 	public:
-		ArchiveUnpacker(const char *fileName);
+		ArchiveUnpacker(const std::string& fileName);
 		virtual ~ArchiveUnpacker();
 
-		const char* GetVolumeFileName() { return m_VolumeFileName; };
+		std::string GetVolumeFileName() { return m_VolumeFileName; };
 		int GetVolumeFileSize() { return m_VolumeFileSize; };
 		int GetNumberOfPackedFiles() { return m_NumberOfPackedFiles; };
 		bool ContainsFile(const char* fileName);
@@ -30,7 +30,7 @@ namespace Archives
 	protected:
 		void CheckPackedFileIndexBounds(int fileIndex);
 
-		char *m_VolumeFileName;
+		std::string m_VolumeFileName;
 		int m_NumberOfPackedFiles;
 		int m_VolumeFileSize;
 	};

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -18,7 +18,7 @@ namespace Archives
 		int GetNumberOfPackedFiles() { return m_NumberOfPackedFiles; };
 		bool ContainsFile(const char* fileName);
 
-		virtual const char* GetInternalFileName(int index) = 0;
+		virtual std::string GetInternalFileName(int index) = 0;
 		// Returns -1 if internalFileName is not present in archive.
 		virtual int GetInternalFileIndex(const char *internalFileName) = 0;
 		virtual int GetInternalFileSize(int index) = 0;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -39,11 +39,11 @@ namespace Archives
 		}
 
 		if (!clmHeader.CheckUnknown()) {
-			throw std::runtime_error("Unkown CLM header field is incorrect.");
+			throw std::runtime_error("Unknown field in CLM header is incorrect.");
 		}
 
 		if (clmHeader.packedFilesCount < 1) {
-			throw std::runtime_error("Packed files count must be 1 or greater.");
+			throw std::runtime_error("Packed file count must be 1 or greater.");
 		}
 
 		m_NumberOfPackedFiles = clmHeader.packedFilesCount;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -321,7 +321,7 @@ namespace Archives
 
 	// Compares wave format structures in the waveFormats container
 	// Returns true if they are all the same and false otherwise.
-	bool ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats)
+	bool ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats) const
 	{
 		for (size_t i = 1; i < waveFormats.size(); i++)
 		{
@@ -406,9 +406,8 @@ namespace Archives
 	}
 
 
-
-	const std::array<char, 32> standardFileVersion { 'O', 'P', '2', ' ', 'C', 'l', 'u', 'm', 'p', ' ',
-		'F', 'i', 'l', 'e', ' ', 'V', 'e', 'r', 's', 'i', 'o', 'n', ' ', '1', '.', '0', '\x01A', '\0', '\0', '\0', '\0' };
+	// A null terminator (\0) is automatically assigned to the end of the string when placing it within the std::array
+	const std::array<char, 32> standardFileVersion { "OP2 Clump File Version 1.0\x01A\0\0\0\0" };
 	const std::array<char, 6> standardUnknown { 0, 0, 0, 0, 1, 0 };
 
 	ClmFile::ClmHeader::ClmHeader(WaveFormatEx waveFormat, uint32_t packedFilesCount) {

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -173,7 +173,7 @@ namespace Archives
 		std::vector<std::unique_ptr<FileStreamReader>> filesToPackReaders;
 		try {
 			// Opens all files for packing. If there is a problem opening a file, an exception is raised.
-			for (std::string& fileName : filesToPack) {
+			for (const std::string& fileName : filesToPack) {
 				filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
 			}
 		}
@@ -383,7 +383,7 @@ namespace Archives
 	{
 		std::vector<std::string> strippedExtensions;
 
-		for (std::string& path : paths) {
+		for (const std::string& path : paths) {
 			strippedExtensions.push_back(XFile::ChangeFileExtension(path, ""));
 		}
 
@@ -438,9 +438,6 @@ namespace Archives
 
 	std::string ClmFile::IndexEntry::GetFileName() const {
 		// Find the first instance of the null terminator and return only this portion of the fileName.
-		// Since fileNames smaller than 8 characters will include multiple null terminators, the returned 
-		// std::string's size will include these extra null terminators. 
-		// This will display the string peroperly, but comparison checks may fail because size is different.
 		auto firstNullTerminator = std::find(fileName.begin(), fileName.end(), '\0');
 
 		return std::string(fileName.data(), firstNullTerminator - fileName.begin());

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -2,104 +2,69 @@
 #include "../XFile.h"
 #include <stdexcept>
 #include <algorithm>
-#include <array>
 
 namespace Archives
 {
 	const uint32_t CLM_WRITE_SIZE = 0x00020000;
-	const uint32_t RIFF = 0x46464952;	// "RIFF" Resource Interchange File Format
-	const uint32_t WAVE = 0x45564157;	// "WAVE"
-	const uint32_t FMT  = 0x20746D66;	// "fmt "
-	const uint32_t DATA = 0x61746164;	// "data"
 
 	ClmFile::ClmFile(const char *fileName) : ArchiveFile(fileName)
 	{
-		m_FileName = nullptr;
-		m_IndexEntry = nullptr;
-
-		// Open the file for reading
-		m_FileHandle = CreateFileA(fileName,					// filename
-			GENERIC_READ,				// desired access
-			FILE_SHARE_READ,			// share mode
-			nullptr,					// security attributes
-			OPEN_EXISTING,				// creation disposition
-			FILE_ATTRIBUTE_NORMAL,		// attributes
-			nullptr);					// template
-
-		if (m_FileHandle == INVALID_HANDLE_VALUE) {
+		try {
+			clmFileReader = std::make_unique<FileStreamReader>(fileName);
+		}
+		catch (std::exception& e) {
 			throw std::runtime_error("Could not open clm file " + std::string(fileName) + ".");
 		}
 
-		if (ReadHeader() == false) {
-			throw std::runtime_error("Invalid clm header in " + std::string(fileName) + ".");
-		}
-
-		// Initialize the unknown data
-		memset(m_Unknown, 0, 6);
-		m_Unknown[4] = 1;
-	}
-
-	ClmFile::~ClmFile()
-	{
-		delete[] m_FileName;
-		delete[] m_IndexEntry;
-
-		if (m_FileHandle) {
-			CloseHandle(m_FileHandle);
+		try {
+			ReadHeader();
+		} 
+		catch (std::exception& e) {
+			throw std::runtime_error("Invalid clm header read from file " + std::string(fileName) + ". Internal error message: " + e.what() );
 		}
 	}
+
+	ClmFile::~ClmFile() { }
 
 
 	// Reads in the header when the volume is first opened and does some
 	// basic error checking on the header.
-	// Returns nonzero if the header was read successfully and is intact
-	// Returns zero if an error occured
-	bool ClmFile::ReadHeader()
+	// Throws an error is problems encountered while reading the header.
+	void ClmFile::ReadHeader()
 	{
-		char buff[32];
-		unsigned long numBytes;
-		int i;
-
-		if (ReadFile(m_FileHandle, buff, 32, &numBytes, nullptr) == 0) return false;
-		if (memcmp(buff, "OP2 Clump File Version 1.0\x01A\0\0\0\0", 32)) return false;
-
-		// Read in the WaveFormatEx structure
-		if (ReadFile(m_FileHandle, &m_WaveFormat, sizeof(m_WaveFormat), &numBytes, nullptr) == 0) return false;
-
-		// Read remaining header info
-		if (ReadFile(m_FileHandle, m_Unknown, 6, &numBytes, nullptr) == 0) return false;
-		if (ReadFile(m_FileHandle, &m_NumberOfPackedFiles, 4, &numBytes, nullptr) == 0) return false;
-		if (m_NumberOfPackedFiles < 1) return false;
-
-		// Allocate space
-		m_IndexEntry = new IndexEntry[m_NumberOfPackedFiles];
-		m_FileName = new char[m_NumberOfPackedFiles][9];
-
-		// Read Index info
-		if (ReadFile(m_FileHandle, m_IndexEntry, m_NumberOfPackedFiles * sizeof(IndexEntry), &numBytes, nullptr) == 0)
-		{
-			delete[] m_FileName;
-			delete[] m_IndexEntry;
-			return false;
-		}
-		// Copy file names
-		for (i = 0; i < m_NumberOfPackedFiles; i++)
-		{
-			memcpy(m_FileName[i], &m_IndexEntry[i].fileName, 8);
-			m_FileName[i][8] = 0;	// NULL terminate it
+		clmFileReader->Read((char*)&clmHeader, sizeof(ClmHeader));
+		
+		if (!clmHeader.CheckFileVersion()) {
+			throw std::runtime_error("CLM file version is incorrect.");
 		}
 
-		return true;
+		if (!clmHeader.CheckUnknown()) {
+			throw std::runtime_error("Unkown CLM header field is incorrect.");
+		}
+
+		if (clmHeader.packedFilesCount < 1) {
+			throw std::runtime_error("Packed files count must be 1 or greater.");
+		}
+
+		m_NumberOfPackedFiles = clmHeader.packedFilesCount;
+
+		indexEntries = std::vector<IndexEntry>(m_NumberOfPackedFiles);
+		clmFileReader->Read((char*)indexEntries.data(), m_NumberOfPackedFiles * sizeof(IndexEntry));
+		
+		// Null terminate all packed fileNames.
+		for (IndexEntry& indexEntry : indexEntries) {
+			indexEntry.fileName[8] = 0;
+		}
 	}
 
 
-
-	// Returns the internal file name of the internal file corresponding to index
-	const char* ClmFile::GetInternalFileName(int index)
+	// Returns the internal file name of the packed file corresponding to index.
+	// Throws an error if packed file index is not valid.
+	std::string ClmFile::GetInternalFileName(int index)
 	{
 		CheckPackedFileIndexBounds(index);
 
-		return m_FileName[index];
+		return indexEntries[index].GetFileName();
 	}
 
 	int ClmFile::GetInternalFileIndex(const char *internalFileName)
@@ -119,10 +84,9 @@ namespace Archives
 	{
 		CheckPackedFileIndexBounds(index);
 
-		return m_IndexEntry[index].dataLength;
+		return indexEntries[index].dataLength;
 	}
 
-	
 
 	// Extracts the internal file corresponding to index
 	void ClmFile::ExtractFile(int fileIndex, const std::string& pathOut)
@@ -134,41 +98,32 @@ namespace Archives
 
 		try
 		{
-			FileStreamWriter fileStreamWriter(pathOut);
+			FileStreamWriter waveFileWriter(pathOut);
 
-			fileStreamWriter.Write((char*)&header, sizeof(header));
+			waveFileWriter.Write((char*)&header, sizeof(header));
 
-			// TODO: Replace with a non Windows specific solution
 			// Seek to the beginning of the file data (in the .clm file)
-			if (SetFilePointer(m_FileHandle, m_IndexEntry[fileIndex].dataOffset, nullptr, FILE_BEGIN) == -1) {
-				return;
-			}
+			clmFileReader->Seek(indexEntries[fileIndex].dataOffset);
 
-			// Write the Wave data
-			char buffer[CLM_WRITE_SIZE];
-			unsigned int totalSize = 0;
-			unsigned long numBytesRead = 0;
+			uint32_t numBytesToRead = 0;
+			uint32_t offset = 0; // Max size of CLM IndexEntry::dataLength is 32 bits.
+			std::array<char, CLM_WRITE_SIZE> buffer;
+
 			do
 			{
-				// Will throw an error
-				//MemoryStreamReader streamReader(buffer, CLM_WRITE_SIZE);
-				//streamReader.Read((char*)m_FileHandle, CLM_WRITE_SIZE);
+				numBytesToRead = CLM_WRITE_SIZE;
 
-				// TODO: Replace with a non-Windows specific solution
-				if (ReadFile(m_FileHandle, buffer, CLM_WRITE_SIZE, &numBytesRead, nullptr) == 0)
-				{
-					return;
+				// Check if less than CLM_WRITE_SIZE of data remains for writing to disk.
+				if (offset + numBytesToRead > indexEntries[fileIndex].dataLength) {
+					numBytesToRead = indexEntries[fileIndex].dataLength - offset;
 				}
 
-				if (totalSize + numBytesRead > m_IndexEntry[fileIndex].dataLength) {
-					numBytesRead = m_IndexEntry[fileIndex].dataLength - totalSize;
-				}
+				clmFileReader->Read(buffer.data(), CLM_WRITE_SIZE);
 
-				totalSize += numBytesRead;
+				offset += numBytesToRead;
 
-				fileStreamWriter.Write(buffer, numBytesRead);
-
-			} while (numBytesRead);
+				waveFileWriter.Write(buffer.data(), numBytesToRead);
+			} while (numBytesToRead); // End loop when numBytesRead/Written is equal to 0
 		}
 		catch (std::exception& e)
 		{
@@ -180,15 +135,15 @@ namespace Archives
 	{
 		headerOut.riffHeader.riffTag = RIFF;
 		headerOut.riffHeader.waveTag = WAVE;
-		headerOut.riffHeader.chunkSize = sizeof(headerOut.formatChunk) + 12 + m_IndexEntry[fileIndex].dataLength;
+		headerOut.riffHeader.chunkSize = sizeof(headerOut.riffHeader.waveTag) + sizeof(FormatChunk) + sizeof(ChunkHeader) + indexEntries[fileIndex].dataLength;
 
 		headerOut.formatChunk.fmtTag = FMT;
-		headerOut.formatChunk.formatSize = sizeof(headerOut.formatChunk.waveFormat);
-		headerOut.formatChunk.waveFormat = m_WaveFormat;
+		headerOut.formatChunk.formatSize = sizeof(WaveFormatEx);
+		headerOut.formatChunk.waveFormat = clmHeader.waveFormat;
 		headerOut.formatChunk.waveFormat.cbSize = 0;
 
 		headerOut.dataChunk.formatTag = DATA;
-		headerOut.dataChunk.length = m_IndexEntry[fileIndex].dataLength;
+		headerOut.dataChunk.length = indexEntries[fileIndex].dataLength;
 	}
 
 	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(const char* internalFileName)
@@ -242,7 +197,7 @@ namespace Archives
 		std::vector<std::unique_ptr<FileStreamReader>> filesToPackReaders;
 		try {
 			// Opens all files for packing. If there is a problem opening a file, an exception is raised.
-			for (std::string fileName : filesToPack) {
+			for (std::string& fileName : filesToPack) {
 				filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
 			}
 		}
@@ -384,21 +339,8 @@ namespace Archives
 		const std::vector<std::string>& internalNames,
 		const WaveFormatEx& waveFormat)
 	{
-#pragma pack(push, 1)
-		struct ClmHeader
-		{
-			ClmHeader() { memcpy(fileVersion.data(), "OP2 Clump File Version 1.0\x01A\0\0\0\0", 32); }
-
-			std::array<char, 32> fileVersion;
-			WaveFormatEx waveFormat;
-			std::array<char, 6> unknown { 0, 0, 0, 0, 1, 0 };
-			uint32_t packedFilesCount;
-		};
-#pragma pack(pop)
-
-		ClmHeader header;
-		header.waveFormat = waveFormat;
-		header.packedFilesCount = internalNames.size();
+		// ClmFile cannot contain more than 32 bit size internal file cound.
+		ClmHeader header(waveFormat, static_cast<uint32_t>(internalNames.size()));
 
 		FileStreamWriter clmFileWriter(archiveFileName);
 
@@ -456,10 +398,32 @@ namespace Archives
 	{
 		std::vector<std::string> strippedExtensions;
 
-		for (std::string path : paths) {
+		for (std::string& path : paths) {
 			strippedExtensions.push_back(XFile::ChangeFileExtension(path, ""));
 		}
 
 		return strippedExtensions;
+	}
+
+
+
+	const std::array<char, 32> standardFileVersion { 'O', 'P', '2', ' ', 'C', 'l', 'u', 'm', 'p', ' ',
+		'F', 'i', 'l', 'e', ' ', 'V', 'e', 'r', 's', 'i', 'o', 'n', ' ', '1', '.', '0', '\x01A', '\0', '\0', '\0', '\0' };
+	const std::array<char, 6> standardUnknown { 0, 0, 0, 0, 1, 0 };
+
+	ClmFile::ClmHeader::ClmHeader(WaveFormatEx waveFormat, uint32_t packedFilesCount) {
+		std::memcpy(fileVersion.data(), standardFileVersion.data(), fileVersion.size());
+		std::memcpy(unknown.data(), standardUnknown.data(), unknown.size());
+
+		this->waveFormat = waveFormat;
+		this->packedFilesCount = packedFilesCount;
+	}
+
+	bool ClmFile::ClmHeader::CheckFileVersion() const {
+		return std::memcmp(fileVersion.data(), standardFileVersion.data(), fileVersion.size()) == 0;
+	};
+
+	bool ClmFile::ClmHeader::CheckUnknown() const {
+		return std::memcmp(unknown.data(), standardUnknown.data(), unknown.size()) == 0;
 	}
 }

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -211,7 +211,7 @@ namespace Archives
 				waveFormat = CreateDefaultWaveFormat();
 			}
 
-			WriteArchive(archiveFileName, filesToPackReaders, indexEntries, internalFileNames, waveFormats[0]);
+			WriteArchive(archiveFileName, filesToPackReaders, indexEntries, internalFileNames, waveFormat);
 		}
 		catch (std::exception& e) {
 			return false; // Error writing CLM archive file
@@ -390,18 +390,17 @@ namespace Archives
 		return strippedExtensions;
 	}
 
-	WaveFormatEx ClmFile::CreateDefaultWaveFormat() {
-		WaveFormatEx waveFormat;
-
-		waveFormat.wFormatTag = 1; // WAVE_FORMAT_PCM
-		waveFormat.nChannels = 1; // mono
-		waveFormat.nSamplesPerSec = 22050; // 22.05KHz
-		waveFormat.nAvgBytesPerSec = 44100; // nSamplesPerSec *nBlockAlign
-		waveFormat.nBlockAlign = 2; // 2 bytes/sample = nChannels * wBitsPerSample / 8
-		waveFormat.wBitsPerSample = 16;
-		waveFormat.cbSize = 0;
-
-		return waveFormat;
+	WaveFormatEx ClmFile::CreateDefaultWaveFormat()
+	{
+		return WaveFormatEx{
+			1, // WAVE_FORMAT_PCM
+			1, // mono
+			22050, // 22.05KHz
+			44100, // nSamplesPerSec * nBlockAlign
+			2, // 2 bytes/sample = nChannels * wBitsPerSample / 8
+			16,
+			0
+		};
 	}
 
 
@@ -438,9 +437,12 @@ namespace Archives
 	}
 
 	std::string ClmFile::IndexEntry::GetFileName() const {
-		char fileNameOut[9];
-		strncpy_s(fileNameOut, fileName.data(), 8);
+		// Find the first instance of the null terminator and return only this portion of the fileName.
+		// Since fileNames smaller than 8 characters will include multiple null terminators, the returned 
+		// std::string's size will include these extra null terminators. 
+		// This will display the string peroperly, but comparison checks may fail because size is different.
+		auto firstNullTerminator = std::find(fileName.begin(), fileName.end(), '\0');
 
-		return std::string(fileNameOut);
+		return std::string(fileName.data(), firstNullTerminator - fileName.begin());
 	}
 }

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -71,7 +71,7 @@ namespace Archives
 		void PackFile(StreamWriter& clmWriter, const IndexEntry& entry, StreamReader& fileToPackReader);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
-		WaveFormatEx CreateDefaultWaveFormat();
+		static WaveFormatEx CreateDefaultWaveFormat();
 
 		std::unique_ptr<SeekableStreamReader> clmFileReader;
 		ClmHeader clmHeader;

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -61,7 +61,7 @@ namespace Archives
 		// Private functions for packing files
 		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
 		int FindChunk(uint32_t chunkTag, SeekableStreamReader& seekableStreamReader);
-		bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
+		bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats) const;
 		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
 		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -43,15 +43,18 @@ namespace Archives
 
 			bool CheckFileVersion() const;
 			bool CheckUnknown() const;
+
+			void VerifyFileVersion() const; // Exception raised if invalid version
+			void VerifyUnknown() const; // Exception raised if invalid version
 		};
 
 		struct IndexEntry
 		{
-			char fileName[8];
+			std::array<char, 8> fileName;
 			unsigned int dataOffset;
 			unsigned int dataLength;
 
-			std::string GetFileName() const { return std::string(fileName); }
+			std::string GetFileName() const;
 		};
 #pragma pack(pop)
 
@@ -61,13 +64,14 @@ namespace Archives
 		// Private functions for packing files
 		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
 		int FindChunk(uint32_t chunkTag, SeekableStreamReader& seekableStreamReader);
-		bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats) const;
+		static bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
 		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
 		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
 		void PackFile(StreamWriter& clmWriter, const IndexEntry& entry, StreamReader& fileToPackReader);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
+		WaveFormatEx CreateDefaultWaveFormat();
 
 		std::unique_ptr<SeekableStreamReader> clmFileReader;
 		ClmHeader clmHeader;

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "WaveFile.h"
 #include "ArchiveFile.h"
 #include "../StreamReader.h"
 #include "../StreamWriter.h"
-#include <windows.h>
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <array>
 #include <memory>
 
 namespace Archives
@@ -17,7 +18,7 @@ namespace Archives
 		ClmFile(const char *fileName);
 		virtual ~ClmFile();
 
-		const char* GetInternalFileName(int index);
+		std::string GetInternalFileName(int index);
 		int GetInternalFileIndex(const char *internalFileName);
 		void ExtractFile(int fileIndex, const std::string& pathOut);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
@@ -30,48 +31,18 @@ namespace Archives
 
 	private:
 #pragma pack(push, 1)
-		/*
-		*  extended waveform format structure used for all non-PCM formats. this
-		*  structure is common to all non-PCM formats.
-		*  Identical to Windows.h WAVEFORMATEX typedef contained in mmeapi.h
-		*/
-		struct WaveFormatEx
+		struct ClmHeader
 		{
-			uint16_t wFormatTag;         /* format type */
-			uint16_t nChannels;          /* number of channels (i.e. mono, stereo...) */
-			uint32_t nSamplesPerSec;     /* sample rate */
-			uint32_t nAvgBytesPerSec;    /* for buffer estimation */
-			uint16_t nBlockAlign;        /* block size of data */
-			uint16_t wBitsPerSample;     /* number of bits per sample of mono data */
-			uint16_t cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
-		};
+			ClmHeader() {};
+			ClmHeader(WaveFormatEx waveFormatEx, uint32_t packFileCount);
 
-		struct RiffHeader
-		{
-			int32_t riffTag;
-			uint32_t chunkSize;
-			int32_t waveTag;
-		};
-
-		struct FormatChunk
-		{
-			int fmtTag;
-			int formatSize;
+			std::array<char, 32> fileVersion;
 			WaveFormatEx waveFormat;
-		};
+			std::array<char, 6> unknown;
+			uint32_t packedFilesCount;
 
-		struct ChunkHeader
-		{
-			uint32_t formatTag;
-			uint32_t length;
-		};
-
-	    // http://soundfile.sapp.org/doc/WaveFormat/
-		struct WaveHeader
-		{
-			RiffHeader riffHeader;
-			FormatChunk formatChunk;
-			ChunkHeader dataChunk;
+			bool CheckFileVersion() const;
+			bool CheckUnknown() const;
 		};
 
 		struct IndexEntry
@@ -85,7 +56,7 @@ namespace Archives
 #pragma pack(pop)
 
 		// Private functions for reading archive
-		bool ReadHeader();
+		void ReadHeader();
 
 		// Private functions for packing files
 		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
@@ -98,10 +69,8 @@ namespace Archives
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 
-		HANDLE m_FileHandle;
-		WaveFormatEx m_WaveFormat;
-		char m_Unknown[6];
-		IndexEntry *m_IndexEntry;
-		char(*m_FileName)[9];
+		std::unique_ptr<SeekableStreamReader> clmFileReader;
+		ClmHeader clmHeader;
+		std::vector<IndexEntry> indexEntries;
 	};
 }

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -175,7 +175,7 @@ namespace Archives
 		UnmapFile();
 
 		// Rename the output file to the desired file
-		return ReplaceFileWithFile(m_VolumeFileName, "Temp.vol");
+		return ReplaceFileWithFile(m_VolumeFileName.c_str(), "Temp.vol");
 	}
 
 	bool VolFile::CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack)

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -27,18 +27,18 @@ namespace Archives
 
 
 
-	const char* VolFile::GetInternalFileName(int index)
+	std::string VolFile::GetInternalFileName(int index)
 	{
 		CheckPackedFileIndexBounds(index);
 
-		return m_StringTable + m_Index[index].fileNameOffset;
+		return std::string(m_StringTable + m_Index[index].fileNameOffset);
 	}
 
 	int VolFile::GetInternalFileIndex(const char *internalFileName)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{
-			const char* actualInternalFileName = GetInternalFileName(i);
+			std::string actualInternalFileName = GetInternalFileName(i);
 			if (XFile::PathsAreEqual(actualInternalFileName, internalFileName)) {
 				return i;
 			}

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -20,7 +20,7 @@ namespace Archives
 		~VolFile();
 
 		// Internal file status
-		const char* GetInternalFileName(int index);
+		std::string GetInternalFileName(int index);
 		int GetInternalFileIndex(const char *internalFileName);
 		CompressionType GetInternalCompressionCode(int index);
 		int GetInternalFileSize(int index);

--- a/Archives/WaveFile.h
+++ b/Archives/WaveFile.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Archives
+{
+	const uint32_t RIFF = 0x46464952;	// "RIFF" Resource Interchange File Format
+	const uint32_t WAVE = 0x45564157;	// "WAVE"
+	const uint32_t FMT = 0x20746D66;	// "fmt "
+	const uint32_t DATA = 0x61746164;	// "data"
+
+#pragma pack(push, 1)
+
+	/*
+	*  extended waveform format structure used for all non-PCM formats. this
+	*  structure is common to all non-PCM formats.
+	*  Identical to Windows.h WAVEFORMATEX typedef contained in mmeapi.h
+	*/
+	struct WaveFormatEx
+	{
+		uint16_t wFormatTag;         /* format type */
+		uint16_t nChannels;          /* number of channels (i.e. mono, stereo...) */
+		uint32_t nSamplesPerSec;     /* sample rate */
+		uint32_t nAvgBytesPerSec;    /* for buffer estimation */
+		uint16_t nBlockAlign;        /* block size of data */
+		uint16_t wBitsPerSample;     /* number of bits per sample of mono data */
+		uint16_t cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
+	};
+
+	struct RiffHeader
+	{
+		int32_t riffTag;
+		uint32_t chunkSize;
+		int32_t waveTag;
+	};
+
+	struct FormatChunk
+	{
+		uint32_t fmtTag;
+		uint32_t formatSize;
+		WaveFormatEx waveFormat;
+	};
+
+	struct ChunkHeader
+	{
+		uint32_t formatTag;
+		uint32_t length;
+	};
+
+	// http://soundfile.sapp.org/doc/WaveFormat/
+	struct WaveHeader
+	{
+		RiffHeader riffHeader;
+		FormatChunk formatChunk;
+		ChunkHeader dataChunk;
+	};
+
+#pragma pack(pop)
+}

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -119,6 +119,7 @@
     <ClInclude Include="Archives\ArchiveUnpacker.h" />
     <ClInclude Include="Archives\CompressionType.h" />
     <ClInclude Include="Archives\MemoryMappedFile.h" />
+    <ClInclude Include="Archives\WaveFile.h" />
     <ClInclude Include="Maps\CellType.h" />
     <ClInclude Include="Maps\ClipRect.h" />
     <ClInclude Include="Maps\MapData.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClInclude Include="StreamWriter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Archives\WaveFile.h">
+      <Filter>Archives</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="XFile.cpp">

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -20,6 +20,11 @@ FileStreamReader::~FileStreamReader() {
 }
 
 void FileStreamReader::Read(char* buffer, size_t size) {
+	// Unable to add a std::streampos to a size_t without casting.
+	if (static_cast<size_t>(file.tellg()) + size > Length()) {
+		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");
+	}
+
 	file.read(buffer, size);
 }
 

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -13,6 +13,13 @@ FileStreamReader::FileStreamReader(std::string filename) {
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);
 	}
+
+	// Determine size of file stream
+	uint64_t currentPosition = file.tellg();
+	file.seekg(0, std::ios_base::end);
+	streamSize = file.tellg();
+
+	file.seekg(currentPosition, std::ios_base::beg);
 }
 
 FileStreamReader::~FileStreamReader() {
@@ -29,13 +36,7 @@ void FileStreamReader::Read(char* buffer, size_t size) {
 }
 
 uint64_t FileStreamReader::Length() {
-	uint64_t currentPosition = file.tellg();
-	file.seekg(0, std::ios_base::end);
-	uint64_t length = file.tellg();
-
-	file.seekg(currentPosition, std::ios_base::beg);
-
-	return length;
+	return streamSize;
 }
 
 void FileStreamReader::Seek(uint64_t position) {

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -13,13 +13,6 @@ FileStreamReader::FileStreamReader(std::string filename) {
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);
 	}
-
-	// Determine size of file stream
-	uint64_t currentPosition = file.tellg();
-	file.seekg(0, std::ios_base::end);
-	streamSize = file.tellg();
-
-	file.seekg(currentPosition, std::ios_base::beg);
 }
 
 FileStreamReader::~FileStreamReader() {
@@ -27,15 +20,16 @@ FileStreamReader::~FileStreamReader() {
 }
 
 void FileStreamReader::Read(char* buffer, size_t size) {
-	// Unable to add a std::streampos to a size_t without casting.
-	if (static_cast<size_t>(file.tellg()) + size > Length()) {
-		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");
-	}
-
 	file.read(buffer, size);
 }
 
 uint64_t FileStreamReader::Length() {
+	uint64_t currentPosition = file.tellg();
+	file.seekg(0, std::ios_base::end);
+	uint64_t streamSize = file.tellg();
+
+	file.seekg(currentPosition, std::ios_base::beg);
+
 	return streamSize;
 }
 

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -28,6 +28,12 @@ public:
 	~FileStreamReader();
 
 	void Read(char* buffer, size_t size);
+
+	// Inline templated convenience methods, to easily read arbitrary data types
+	template<typename T> inline void Read(T& object) {
+		Read((char*)&object, sizeof(object));
+	}
+
 	uint64_t Length();
 	void Seek(uint64_t position);
 	void SeekRelative(int64_t offset);
@@ -41,6 +47,12 @@ class MemoryStreamReader : public SeekableStreamReader {
 public:
 	MemoryStreamReader(char* buffer, size_t size);
 	void Read(char* buffer, size_t size);
+
+	// Inline templated convenience methods, to easily read arbitrary data types
+	template<typename T> inline void Read(T& object) {
+		Read((char*)&object, sizeof(object));
+	}
+
 	uint64_t Length();
 	void Seek(uint64_t position);
 	void SeekRelative(int64_t offset);

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -40,7 +40,6 @@ public:
 
 private:
 	std::ifstream file;
-	uint64_t streamSize;
 };
 
 

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -40,6 +40,7 @@ public:
 
 private:
 	std::ifstream file;
+	uint64_t streamSize;
 };
 
 

--- a/StreamWriter.h
+++ b/StreamWriter.h
@@ -23,6 +23,12 @@ public:
 	FileStreamWriter(const std::string& filename);
 	~FileStreamWriter();
 	void Write(const char* buffer, size_t size);
+
+	// Inline templated convenience methods, to easily read arbitrary data types
+	template<typename T> inline void Write(T& object) {
+		Write((char*)&object, sizeof(object));
+	}
+
 	// Change position forward or backword in buffer.
 	void SeekRelative(int offset);
 
@@ -38,6 +44,12 @@ public:
 	MemoryStreamWriter(char* buffer, size_t size);
 
 	void Write(const char* buffer, size_t size);
+
+	// Inline templated convenience methods, to easily read arbitrary data types
+	template<typename T> inline void Write(T& object) {
+		Write((char*)&object, sizeof(object));
+	}
+
 	// Change position forward or backword in buffer.
 	void SeekRelative(int offset);
 

--- a/StringHelper.cpp
+++ b/StringHelper.cpp
@@ -23,12 +23,15 @@ vector<string> StringHelper::RemoveStrings(const vector<string>& stringsToSearch
 {
 	vector<string> stringsToReturn(stringsToSearch);
 
-	auto pred = [&stringsToRemove](const std::string& key) ->bool
-	{
-		return std::find(stringsToRemove.begin(), stringsToRemove.end(), key) != stringsToRemove.end();
-	};
-
-	stringsToReturn.erase(std::remove_if(stringsToReturn.begin(), stringsToReturn.end(), pred), stringsToReturn.end());
+	// i will wrap around to SIZE_MAX  when loop is completed
+	for (size_t i = stringsToSearch.size() - 1; i < stringsToSearch.size(); ++i) {
+		for (const std::string& stringToRemove : stringsToRemove) {
+			if (CheckIfStringsAreEqual(stringsToSearch[i], stringToRemove)) {
+				stringsToReturn.erase(stringsToReturn.begin() + i);
+				break;
+			}
+		}
+	}
 
 	return stringsToReturn;
 }

--- a/StringHelper.cpp
+++ b/StringHelper.cpp
@@ -19,9 +19,9 @@ string StringHelper::ConvertToUpper(const string& str)
 }
 
 // Returns a new vector with matching strings removed. Case insensitive.
-vector<string> StringHelper::RemoveMatchingStrings(const vector<string>& strings, const vector<string>& stringsToRemove)
+vector<string> StringHelper::RemoveStrings(const vector<string>& stringsToSearch, const vector<string>& stringsToRemove)
 {
-	vector<string> stringsToReturn(strings.begin(), strings.end());
+	vector<string> stringsToReturn(stringsToSearch);
 
 	auto pred = [&stringsToRemove](const std::string& key) ->bool
 	{

--- a/StringHelper.h
+++ b/StringHelper.h
@@ -8,7 +8,7 @@ class StringHelper
 public:
 	static void ConvertToUpper(std::string& str);
 	static std::string ConvertToUpper(const std::string& str);
-	static std::vector<std::string> RemoveMatchingStrings(const std::vector<std::string>& strings, const std::vector<std::string>& stringsToRemove);
+	static std::vector<std::string> RemoveStrings(const std::vector<std::string>& stringsToSearch, const std::vector<std::string>& stringsToRemove);
 	static bool CheckIfStringsAreEqual(const std::string& string1, const std::string& string2);
 	static bool ContainsStringCaseInsensitive(std::vector<std::string> stringsToSearch, std::string stringToFind);
 	static bool StringCompareCaseInsensitive(const std::string& string1, const std::string& string2);


### PR DESCRIPTION
 - When opening or extracting from a CLM File, use FileStreamWriter instead of HANDLE
 - Update ClmFile to use C++11/14 practices when opening and extracting CLM files.
 - Use sizeof(X) instead of hardcoded integers when opening or extracting from CLM files.
 - Separate WAVE specific structures and constants into a separate header (WaveFile.h)
 - Clean ArchivePacker.cpp