### PR TITLE
Void ptr streams

### DIFF
--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -19,8 +19,8 @@ FileStreamReader::~FileStreamReader() {
 	file.close();
 }
 
-void FileStreamReader::Read(char* buffer, size_t size) {
-	file.read(buffer, size);
+void FileStreamReader::Read(void* buffer, size_t size) {
+	file.read(static_cast<char*>(buffer), size);
 }
 
 uint64_t FileStreamReader::Length() {
@@ -50,7 +50,7 @@ MemoryStreamReader::MemoryStreamReader(char* buffer, size_t size) {
 	position = 0;
 }
 
-void MemoryStreamReader::Read(char* buffer, size_t size) 
+void MemoryStreamReader::Read(void* buffer, size_t size)
 {
 	if (position + size > streamSize) {
 		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");

--- a/StreamReader.cpp
+++ b/StreamReader.cpp
@@ -44,8 +44,8 @@ void FileStreamReader::SeekRelative(int64_t offset) {
 }
 
 
-MemoryStreamReader::MemoryStreamReader(char* buffer, size_t size) {
-	streamBuffer = buffer;
+MemoryStreamReader::MemoryStreamReader(void* buffer, size_t size) {
+	streamBuffer = static_cast<char*>(buffer);
 	streamSize = size;
 	position = 0;
 }

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -49,7 +49,7 @@ private:
 
 class MemoryStreamReader : public SeekableStreamReader {
 public:
-	MemoryStreamReader(char* buffer, size_t size);
+	MemoryStreamReader(void* buffer, size_t size);
 
 	// StreamReader methods
 	void Read(void* buffer, size_t size) override;

--- a/StreamReader.h
+++ b/StreamReader.h
@@ -7,7 +7,7 @@
 class StreamReader {
 public:
 	virtual ~StreamReader() = 0;
-	virtual void Read(char* buffer, size_t size) = 0;
+	virtual void Read(void* buffer, size_t size) = 0;
 };
 
 class SeekableStreamReader : public StreamReader {
@@ -29,7 +29,7 @@ public:
 
 	// StreamReader methods
 	~FileStreamReader() override;
-	void Read(char* buffer, size_t size) override;
+	void Read(void* buffer, size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Read(T& object) {
@@ -52,7 +52,7 @@ public:
 	MemoryStreamReader(char* buffer, size_t size);
 
 	// StreamReader methods
-	void Read(char* buffer, size_t size) override;
+	void Read(void* buffer, size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Read(T& object) {

--- a/StreamWriter.cpp
+++ b/StreamWriter.cpp
@@ -17,9 +17,9 @@ FileStreamWriter::~FileStreamWriter() {
 	fileStream.close();
 }
 
-void FileStreamWriter::Write(const char* buffer, size_t size)
+void FileStreamWriter::Write(const void* buffer, size_t size)
 {
-	fileStream.write(buffer, size);
+	fileStream.write(static_cast<const char*>(buffer), size);
 }
 
 uint64_t FileStreamWriter::Length()
@@ -54,7 +54,7 @@ MemoryStreamWriter::MemoryStreamWriter(char* buffer, size_t size)
 	offset = 0;
 }
 
-void MemoryStreamWriter::Write(const char* buffer, size_t size)
+void MemoryStreamWriter::Write(const void* buffer, size_t size)
 {
 	if (offset + size > streamSize) {
 		throw std::runtime_error("Size of bytes to write exceeds remaining size of buffer.");

--- a/StreamWriter.cpp
+++ b/StreamWriter.cpp
@@ -47,9 +47,9 @@ void FileStreamWriter::SeekRelative(int64_t offset)
 }
 
 
-MemoryStreamWriter::MemoryStreamWriter(char* buffer, size_t size)
+MemoryStreamWriter::MemoryStreamWriter(void* buffer, size_t size)
 {
-	streamBuffer = buffer;
+	streamBuffer = static_cast<char*>(buffer);
 	streamSize = size;
 	offset = 0;
 }

--- a/StreamWriter.h
+++ b/StreamWriter.h
@@ -55,7 +55,7 @@ class MemoryStreamWriter : public SeekableStreamWriter
 public:
 	// buffer: where data will be written to.
 	// size: Amount of space allocated in the buffer for writing into.
-	MemoryStreamWriter(char* buffer, size_t size);
+	MemoryStreamWriter(void* buffer, size_t size);
 
 	// StreamWriter methods
 	void Write(const void* buffer, size_t size) override;

--- a/StreamWriter.h
+++ b/StreamWriter.h
@@ -7,7 +7,7 @@ class StreamWriter
 {
 public:
 	virtual ~StreamWriter() = 0;
-	virtual void Write(const char* buffer, size_t size) = 0;
+	virtual void Write(const void* buffer, size_t size) = 0;
 };
 
 class SeekableStreamWriter : public StreamWriter
@@ -33,7 +33,7 @@ public:
 
 	// StreamWriter methods
 	~FileStreamWriter() override;
-	void Write(const char* buffer, size_t size) override;
+	void Write(const void* buffer, size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Write(T& object) {
@@ -58,7 +58,7 @@ public:
 	MemoryStreamWriter(char* buffer, size_t size);
 
 	// StreamWriter methods
-	void Write(const char* buffer, size_t size) override;
+	void Write(const void* buffer, size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Write(T& object) {


### PR DESCRIPTION
This changes Stream interfaces to use `void*` instead of `char*`.

This should allow the caller to pass a pointer to any datatype without needing to cast at the call site. This simplifies usage of the library interface.

This is based on the seekable-stream-updates branch, which in turn is based on the stream-template-helpers branch. When reviewing, it may be easier to check the diff from that base (assuming it hasn't already been merged into master).