### PR TITLE
Linux makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 x64
 Debug
 Release
+build/
 /*.user
 .vs

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -479,7 +479,7 @@ namespace Archives
 		for (temp = 0; temp < m_NumberOfIndexEntries; temp++)
 		{
 			// Make sure entry is valid
-			if (m_Index[temp].fileNameOffset == -1)
+			if (m_Index[temp].fileNameOffset == -1u)
 				break;
 		}
 		m_NumberOfPackedFiles = temp;		// Store the number of used index entries

--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -2,6 +2,7 @@
 #include "../StreamReader.h"
 #include <iostream>
 #include <stdexcept>
+#include <cstring>
 
 MapData MapReader::Read(std::string filename, bool savedGame)
 {
@@ -61,7 +62,7 @@ void MapReader::ReadTilesetHeader()
 	char buffer[10];
 	streamReader->Read(buffer, sizeof(buffer));
 
-	if (strncmp(buffer, "TILE SET\x1a", sizeof(buffer))) {
+	if (std::strncmp(buffer, "TILE SET\x1a", sizeof(buffer))) {
 		throw std::runtime_error("'TILE SET' string not found.");
 	}
 }

--- a/Maps/MapReader.h
+++ b/Maps/MapReader.h
@@ -10,8 +10,8 @@ class SeekableStreamReader;
 class MapReader
 {
 public:
-	MapData MapReader::Read(std::unique_ptr<SeekableStreamReader> mapStream, bool savedGame = false);
-	MapData MapReader::Read(std::string filename, bool savedGame = false);
+	MapData Read(std::unique_ptr<SeekableStreamReader> mapStream, bool savedGame = false);
+	MapData Read(std::string filename, bool savedGame = false);
 
 private:
 	std::unique_ptr<SeekableStreamReader> streamReader;

--- a/Maps/MapWriter.h
+++ b/Maps/MapWriter.h
@@ -11,8 +11,8 @@ class SeekableStreamWriter;
 class MapWriter
 {
 public:
-	void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData);
-	void MapWriter::Write(const std::string& filename, const MapData& mapData);
+	void Write(SeekableStreamWriter& mapStream, const MapData& mapData);
+	void Write(const std::string& filename, const MapData& mapData);
 
 private:
 	SeekableStreamWriter* streamWriter;

--- a/makefile
+++ b/makefile
@@ -1,0 +1,55 @@
+
+# Set compiler default to mingw
+# Can still override from command line or environment variables
+ifeq ($(origin CXX),default)
+	CXX := i686-w64-mingw32-g++
+endif
+
+SRCDIR := .
+BUILDDIR := build
+BINDIR := $(BUILDDIR)/bin
+OBJDIR := $(BUILDDIR)/obj
+DEPDIR := $(BUILDDIR)/deps
+EXE := $(BINDIR)/op2utility
+
+CFLAGS := -std=c++14 -g -Wall -Wno-unknown-pragmas
+LDFLAGS := -lstdc++ -lm
+
+DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
+
+COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CFLAGS) $(TARGET_ARCH) -c
+POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
+
+SRCS := $(shell find $(SRCDIR) -name '*.cpp')
+OBJS := $(patsubst $(SRCDIR)/%.cpp,$(OBJDIR)/%.o,$(SRCS))
+FOLDERS := $(sort $(dir $(SRCS)))
+
+all: $(EXE)
+
+$(EXE): $(OBJS)
+	@mkdir -p ${@D}
+	$(CXX) $^ $(LDFLAGS) -o $@
+
+$(OBJS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp $(DEPDIR)/%.d | build-folder
+	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
+	$(POSTCOMPILE)
+
+.PHONY:build-folder
+build-folder:
+	@mkdir -p $(patsubst $(SRCDIR)/%,$(OBJDIR)/%, $(FOLDERS))
+	@mkdir -p $(patsubst $(SRCDIR)/%,$(DEPDIR)/%, $(FOLDERS))
+
+$(DEPDIR)/%.d: ;
+.PRECIOUS: $(DEPDIR)/%.d
+
+include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS)))
+
+.PHONY:clean, clean-deps, clean-all
+clean:
+	-rm -fr $(OBJDIR)
+	-rm -fr $(DEPDIR)
+	-rm -fr $(BINDIR)
+clean-deps:
+	-rm -fr $(DEPDIR)
+clean-all:
+	-rm -rf $(BUILDDIR)


### PR DESCRIPTION
Add a Linux makefile. This should help accelerate and standardize testing on Linux, which was previously done with ad-hoc compile commands.

Includes fixes a few other issues I didn't catch with my initial Linux testing, since I wasn't trying to build files from sub-folders with the ad-hoc testing.