### PR TITLE
Map reader writer updates

### DIFF
--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -6,16 +6,13 @@
 
 MapData MapReader::Read(std::string filename, bool savedGame)
 {
-	return Read(std::make_unique<FileStreamReader>(filename), savedGame);
+	FileStreamReader mapReader(filename);
+	return Read(mapReader, savedGame);
 }
 
-MapData MapReader::Read(std::unique_ptr<SeekableStreamReader> mapStream, bool savedGame)
+MapData MapReader::Read(SeekableStreamReader& mapStream, bool savedGame)
 {
-	if (!mapStream) {
-		throw std::runtime_error("Provided map or save stream does not exist or is malformed.");
-	}
-
-	streamReader = std::move(mapStream);
+	streamReader = &mapStream;
 
 	MapData mapData;
 

--- a/Maps/MapReader.h
+++ b/Maps/MapReader.h
@@ -10,11 +10,11 @@ class SeekableStreamReader;
 class MapReader
 {
 public:
-	MapData Read(std::unique_ptr<SeekableStreamReader> mapStream, bool savedGame = false);
+	MapData Read(SeekableStreamReader& mapStream, bool savedGame = false);
 	MapData Read(std::string filename, bool savedGame = false);
 
 private:
-	std::unique_ptr<SeekableStreamReader> streamReader;
+	SeekableStreamReader* streamReader;
 
 	void SkipSaveGameHeader();
 	void ReadHeader(MapData& mapData);

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -21,7 +21,8 @@ void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData)
 
 void MapWriter::Write(const std::string& filename, const MapData& mapData)
 {
-	Write(FileStreamWriter(filename), mapData);
+	FileStreamWriter mapWriter(filename);
+	Write(mapWriter, mapData);
 }
 
 void MapWriter::WriteHeader(const MapHeader& header)


### PR DESCRIPTION
This fixes reference issues with the MapReader and MapWriter classes.

A non-const lvalue-reference is taken by MapWriter, but a temporary was being passed in, which causes an error on conforming compilers. The workaround is to create a local variable.

The MapReader used `unique_ptr` in the interface, which burdens the caller. The workaround is the same as above, using lvalue-references and named variables.
