### PR TITLE
Convert MapReader/Writer from class to namespace

### DIFF
--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -12,7 +12,7 @@ MapData MapReader::Read(std::string filename, bool savedGame)
 
 MapData MapReader::Read(SeekableStreamReader& mapStream, bool savedGame)
 {
-	streamReader = &mapStream;
+	streamReader = mapStream;
 
 	MapData mapData;
 
@@ -35,29 +35,29 @@ MapData MapReader::Read(SeekableStreamReader& mapStream, bool savedGame)
 
 void MapReader::SkipSaveGameHeader()
 {
-	streamReader->SeekRelative(0x1E025);
+	streamReader.SeekRelative(0x1E025);
 }
 
 void MapReader::ReadHeader(MapData& mapData)
 {
-	streamReader->Read(&mapData.header, sizeof(mapData.header));
+	streamReader.Read(&mapData.header, sizeof(mapData.header));
 }
 
 void MapReader::ReadTiles(MapData& mapData)
 {
 	mapData.tiles.resize(mapData.header.TileCount());
-	streamReader->Read(&mapData.tiles[0], mapData.tiles.size() * sizeof(TileData));
+	streamReader.Read(&mapData.tiles[0], mapData.tiles.size() * sizeof(TileData));
 }
 
 void MapReader::ReadClipRect(ClipRect& clipRect)
 {
-	streamReader->Read(&clipRect, sizeof(clipRect));
+	streamReader.Read(&clipRect, sizeof(clipRect));
 }
 
 void MapReader::ReadTilesetHeader()
 {
 	char buffer[10];
-	streamReader->Read(buffer, sizeof(buffer));
+	streamReader.Read(buffer, sizeof(buffer));
 
 	if (std::strncmp(buffer, "TILE SET\x1a", sizeof(buffer))) {
 		throw std::runtime_error("'TILE SET' string not found.");
@@ -77,7 +77,7 @@ void MapReader::ReadTilesetSources(MapData& mapData)
 		}
 
 		if (mapData.tilesetSources[i].tilesetFilename.size() > 0) {
-			streamReader->Read(&mapData.tilesetSources[i].numTiles, sizeof(int));
+			streamReader.Read(&mapData.tilesetSources[i].numTiles, sizeof(int));
 		}
 	}
 }
@@ -85,21 +85,21 @@ void MapReader::ReadTilesetSources(MapData& mapData)
 void MapReader::ReadTileInfo(MapData& mapData)
 {
 	size_t numTileInfo;
-	streamReader->Read(&numTileInfo, sizeof(numTileInfo));
+	streamReader.Read(&numTileInfo, sizeof(numTileInfo));
 
 	mapData.tileInfos.resize(numTileInfo);
-	streamReader->Read(&mapData.tileInfos[0], numTileInfo * sizeof(TileInfo));
+	streamReader.Read(&mapData.tileInfos[0], numTileInfo * sizeof(TileInfo));
 
 	size_t numTerrainTypes;
-	streamReader->Read(&numTerrainTypes, sizeof(numTerrainTypes));
+	streamReader.Read(&numTerrainTypes, sizeof(numTerrainTypes));
 	mapData.terrainTypes.resize(numTerrainTypes);
-	streamReader->Read(&mapData.terrainTypes[0], numTerrainTypes * sizeof(TerrainType));
+	streamReader.Read(&mapData.terrainTypes[0], numTerrainTypes * sizeof(TerrainType));
 }
 
 void MapReader::ReadVersionTag()
 {
 	int versionTag;
-	streamReader->Read(&versionTag, sizeof(versionTag));
+	streamReader.Read(&versionTag, sizeof(versionTag));
 
 	if (versionTag < 0x1010)
 	{
@@ -110,8 +110,8 @@ void MapReader::ReadVersionTag()
 void MapReader::ReadTileGroups(MapData& mapData)
 {
 	int numTileGroups;
-	streamReader->Read(&numTileGroups, sizeof(numTileGroups));
-	streamReader->SeekRelative(4);
+	streamReader.Read(&numTileGroups, sizeof(numTileGroups));
+	streamReader.SeekRelative(4);
 
 	for (int i = 0; i < numTileGroups; ++i)
 	{
@@ -123,13 +123,13 @@ TileGroup MapReader::ReadTileGroup()
 {
 	TileGroup tileGroup;
 
-	streamReader->Read(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
-	streamReader->Read(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
+	streamReader.Read(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
+	streamReader.Read(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
 
 	int mappingIndex;
 	for (int i = 0; i < tileGroup.tileHeight * tileGroup.tileWidth; ++i)
 	{
-		streamReader->Read(&mappingIndex, sizeof(mappingIndex));
+		streamReader.Read(&mappingIndex, sizeof(mappingIndex));
 		tileGroup.mappingIndices.push_back(mappingIndex);
 	}
 
@@ -142,11 +142,11 @@ TileGroup MapReader::ReadTileGroup()
 std::string MapReader::ReadString()
 {
 	uint32_t stringLength;
-	streamReader->Read(&stringLength, sizeof(stringLength));
+	streamReader.Read(&stringLength, sizeof(stringLength));
 
 	std::string s;
 	s.resize(stringLength);
-	streamReader->Read(&s[0], stringLength);
+	streamReader.Read(&s[0], stringLength);
 
 	return s;
 }

--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -2,6 +2,7 @@
 #include "../Streams/FileStreamReader.h"
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 #include <cstring>
 
 

--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -4,149 +4,175 @@
 #include <stdexcept>
 #include <cstring>
 
-MapData MapReader::Read(std::string filename, bool savedGame)
-{
-	FileStreamReader mapReader(filename);
-	return Read(mapReader, savedGame);
-}
 
-MapData MapReader::Read(SeekableStreamReader& mapStream, bool savedGame)
-{
-	streamReader = mapStream;
-
-	MapData mapData;
-
-	if (savedGame) {
-		SkipSaveGameHeader();
+namespace MapReader {
+	// Anonymous namespace to hold private methods
+	namespace {
+		void SkipSaveGameHeader(SeekableStreamReader& streamReader);
+		void ReadHeader(StreamReader& streamReader, MapData& mapData);
+		void ReadTiles(StreamReader& streamReader, MapData& mapData);
+		void ReadClipRect(StreamReader& streamReader, ClipRect& clipRect);
+		void ReadTilesetSources(StreamReader& streamReader, MapData& mapData);
+		void ReadTilesetHeader(StreamReader& streamReader);
+		void ReadTileInfo(StreamReader& streamReader, MapData& mapData);
+		void ReadVersionTag(StreamReader& streamReader);
+		void ReadTileGroups(SeekableStreamReader& streamReader, MapData& mapData);
+		TileGroup ReadTileGroup(StreamReader& streamReader);
+		std::string ReadString(StreamReader& streamReader);
 	}
 
-	ReadHeader(mapData);
-	ReadTiles(mapData);
-	ReadClipRect(mapData.clipRect);
-	ReadTilesetSources(mapData);
-	ReadTilesetHeader();
-	ReadTileInfo(mapData);
-	ReadVersionTag();
-	ReadVersionTag();
-	ReadTileGroups(mapData);
 
-	return mapData;
-}
+	// ==== Public methohds ====
 
-void MapReader::SkipSaveGameHeader()
-{
-	streamReader.SeekRelative(0x1E025);
-}
 
-void MapReader::ReadHeader(MapData& mapData)
-{
-	streamReader.Read(&mapData.header, sizeof(mapData.header));
-}
-
-void MapReader::ReadTiles(MapData& mapData)
-{
-	mapData.tiles.resize(mapData.header.TileCount());
-	streamReader.Read(&mapData.tiles[0], mapData.tiles.size() * sizeof(TileData));
-}
-
-void MapReader::ReadClipRect(ClipRect& clipRect)
-{
-	streamReader.Read(&clipRect, sizeof(clipRect));
-}
-
-void MapReader::ReadTilesetHeader()
-{
-	char buffer[10];
-	streamReader.Read(buffer, sizeof(buffer));
-
-	if (std::strncmp(buffer, "TILE SET\x1a", sizeof(buffer))) {
-		throw std::runtime_error("'TILE SET' string not found.");
-	}
-}
-
-void MapReader::ReadTilesetSources(MapData& mapData)
-{
-	mapData.tilesetSources.resize(static_cast<size_t>(mapData.header.numTilesets));
-
-	for (unsigned int i = 0; i < mapData.header.numTilesets; ++i)
+	MapData Read(std::string filename, bool savedGame)
 	{
-		mapData.tilesetSources[i].tilesetFilename = ReadString();
+		FileStreamReader mapReader(filename);
+		return Read(mapReader, savedGame);
+	}
 
-		if (mapData.tilesetSources[i].tilesetFilename.size() > 8) {
-			throw std::runtime_error("Tileset name may not be greater than 8 characters in length.");
+	MapData Read(SeekableStreamReader& streamReader, bool savedGame)
+	{
+		MapData mapData;
+
+		if (savedGame) {
+			SkipSaveGameHeader(streamReader);
 		}
 
-		if (mapData.tilesetSources[i].tilesetFilename.size() > 0) {
-			streamReader.Read(&mapData.tilesetSources[i].numTiles, sizeof(int));
+		ReadHeader(streamReader, mapData);
+		ReadTiles(streamReader, mapData);
+		ReadClipRect(streamReader, mapData.clipRect);
+		ReadTilesetSources(streamReader, mapData);
+		ReadTilesetHeader(streamReader);
+		ReadTileInfo(streamReader, mapData);
+		ReadVersionTag(streamReader);
+		ReadVersionTag(streamReader);
+		ReadTileGroups(streamReader, mapData);
+
+		return mapData;
+	}
+
+
+	// == Private methods ==
+
+
+	namespace {
+		void SkipSaveGameHeader(SeekableStreamReader& streamReader)
+		{
+			streamReader.SeekRelative(0x1E025);
+		}
+
+		void ReadHeader(StreamReader& streamReader, MapData& mapData)
+		{
+			streamReader.Read(&mapData.header, sizeof(mapData.header));
+		}
+
+		void ReadTiles(StreamReader& streamReader, MapData& mapData)
+		{
+			mapData.tiles.resize(mapData.header.TileCount());
+			streamReader.Read(&mapData.tiles[0], mapData.tiles.size() * sizeof(TileData));
+		}
+
+		void ReadClipRect(StreamReader& streamReader, ClipRect& clipRect)
+		{
+			streamReader.Read(&clipRect, sizeof(clipRect));
+		}
+
+		void ReadTilesetHeader(StreamReader& streamReader)
+		{
+			char buffer[10];
+			streamReader.Read(buffer, sizeof(buffer));
+
+			if (std::strncmp(buffer, "TILE SET\x1a", sizeof(buffer))) {
+				throw std::runtime_error("'TILE SET' string not found.");
+			}
+		}
+
+		void ReadTilesetSources(StreamReader& streamReader, MapData& mapData)
+		{
+			mapData.tilesetSources.resize(static_cast<size_t>(mapData.header.numTilesets));
+
+			for (unsigned int i = 0; i < mapData.header.numTilesets; ++i)
+			{
+				mapData.tilesetSources[i].tilesetFilename = ReadString(streamReader);
+
+				if (mapData.tilesetSources[i].tilesetFilename.size() > 8) {
+					throw std::runtime_error("Tileset name may not be greater than 8 characters in length.");
+				}
+
+				if (mapData.tilesetSources[i].tilesetFilename.size() > 0) {
+					streamReader.Read(&mapData.tilesetSources[i].numTiles, sizeof(int));
+				}
+			}
+		}
+
+		void ReadTileInfo(StreamReader& streamReader, MapData& mapData)
+		{
+			size_t numTileInfo;
+			streamReader.Read(&numTileInfo, sizeof(numTileInfo));
+
+			mapData.tileInfos.resize(numTileInfo);
+			streamReader.Read(&mapData.tileInfos[0], numTileInfo * sizeof(TileInfo));
+
+			size_t numTerrainTypes;
+			streamReader.Read(&numTerrainTypes, sizeof(numTerrainTypes));
+			mapData.terrainTypes.resize(numTerrainTypes);
+			streamReader.Read(&mapData.terrainTypes[0], numTerrainTypes * sizeof(TerrainType));
+		}
+
+		void ReadVersionTag(StreamReader& streamReader)
+		{
+			int versionTag;
+			streamReader.Read(&versionTag, sizeof(versionTag));
+
+			if (versionTag < 0x1010)
+			{
+				std::cerr << "All instances of version tag in .map and .op2 files should be greater than 0x1010.";
+			}
+		}
+
+		void ReadTileGroups(SeekableStreamReader& streamReader, MapData& mapData)
+		{
+			int numTileGroups;
+			streamReader.Read(&numTileGroups, sizeof(numTileGroups));
+			streamReader.SeekRelative(4);
+
+			for (int i = 0; i < numTileGroups; ++i)
+			{
+				mapData.tileGroups.push_back(ReadTileGroup(streamReader));
+			}
+		}
+
+		TileGroup ReadTileGroup(StreamReader& streamReader)
+		{
+			TileGroup tileGroup;
+
+			streamReader.Read(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
+			streamReader.Read(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
+
+			int mappingIndex;
+			for (int i = 0; i < tileGroup.tileHeight * tileGroup.tileWidth; ++i)
+			{
+				streamReader.Read(&mappingIndex, sizeof(mappingIndex));
+				tileGroup.mappingIndices.push_back(mappingIndex);
+			}
+
+			tileGroup.name = ReadString(streamReader);
+
+			return tileGroup;
+		}
+
+		// String must be stored in file as string length followed by char[].
+		std::string ReadString(StreamReader& streamReader)
+		{
+			uint32_t stringLength;
+			streamReader.Read(&stringLength, sizeof(stringLength));
+
+			std::string s;
+			s.resize(stringLength);
+			streamReader.Read(&s[0], stringLength);
+
+			return s;
 		}
 	}
-}
-
-void MapReader::ReadTileInfo(MapData& mapData)
-{
-	size_t numTileInfo;
-	streamReader.Read(&numTileInfo, sizeof(numTileInfo));
-
-	mapData.tileInfos.resize(numTileInfo);
-	streamReader.Read(&mapData.tileInfos[0], numTileInfo * sizeof(TileInfo));
-
-	size_t numTerrainTypes;
-	streamReader.Read(&numTerrainTypes, sizeof(numTerrainTypes));
-	mapData.terrainTypes.resize(numTerrainTypes);
-	streamReader.Read(&mapData.terrainTypes[0], numTerrainTypes * sizeof(TerrainType));
-}
-
-void MapReader::ReadVersionTag()
-{
-	int versionTag;
-	streamReader.Read(&versionTag, sizeof(versionTag));
-
-	if (versionTag < 0x1010)
-	{
-		std::cerr << "All instances of version tag in .map and .op2 files should be greater than 0x1010.";
-	}
-}
-
-void MapReader::ReadTileGroups(MapData& mapData)
-{
-	int numTileGroups;
-	streamReader.Read(&numTileGroups, sizeof(numTileGroups));
-	streamReader.SeekRelative(4);
-
-	for (int i = 0; i < numTileGroups; ++i)
-	{
-		mapData.tileGroups.push_back(ReadTileGroup());
-	}
-}
-
-TileGroup MapReader::ReadTileGroup()
-{
-	TileGroup tileGroup;
-
-	streamReader.Read(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
-	streamReader.Read(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
-
-	int mappingIndex;
-	for (int i = 0; i < tileGroup.tileHeight * tileGroup.tileWidth; ++i)
-	{
-		streamReader.Read(&mappingIndex, sizeof(mappingIndex));
-		tileGroup.mappingIndices.push_back(mappingIndex);
-	}
-
-	tileGroup.name = ReadString();
-
-	return tileGroup;
-}
-
-// String must be stored in file as string length followed by char[].
-std::string MapReader::ReadString()
-{
-	uint32_t stringLength;
-	streamReader.Read(&stringLength, sizeof(stringLength));
-
-	std::string s;
-	s.resize(stringLength);
-	streamReader.Read(&s[0], stringLength);
-
-	return s;
 }

--- a/Maps/MapReader.h
+++ b/Maps/MapReader.h
@@ -14,7 +14,7 @@ public:
 	MapData Read(SeekableStreamReader& mapStream, bool savedGame = false);
 
 private:
-	SeekableStreamReader* streamReader;
+	SeekableStreamReader& streamReader;
 
 	void SkipSaveGameHeader();
 	void ReadHeader(MapData& mapData);

--- a/Maps/MapReader.h
+++ b/Maps/MapReader.h
@@ -7,24 +7,7 @@
 
 class SeekableStreamReader;
 
-class MapReader
-{
-public:
+namespace MapReader {
 	MapData Read(std::string filename, bool savedGame = false);
 	MapData Read(SeekableStreamReader& mapStream, bool savedGame = false);
-
-private:
-	SeekableStreamReader& streamReader;
-
-	void SkipSaveGameHeader();
-	void ReadHeader(MapData& mapData);
-	void ReadTiles(MapData& mapData);
-	void ReadClipRect(ClipRect& clipRect);
-	void ReadTilesetSources(MapData& mapData);
-	void ReadTilesetHeader();
-	void ReadTileInfo(MapData& mapData);
-	void ReadVersionTag();
-	void ReadTileGroups(MapData& mapData);
-	TileGroup ReadTileGroup();
-	std::string ReadString();
-};
+}

--- a/Maps/MapReader.h
+++ b/Maps/MapReader.h
@@ -10,8 +10,8 @@ class SeekableStreamReader;
 class MapReader
 {
 public:
-	MapData Read(SeekableStreamReader& mapStream, bool savedGame = false);
 	MapData Read(std::string filename, bool savedGame = false);
+	MapData Read(SeekableStreamReader& mapStream, bool savedGame = false);
 
 private:
 	SeekableStreamReader* streamReader;

--- a/Maps/MapReader.h
+++ b/Maps/MapReader.h
@@ -2,8 +2,6 @@
 
 #include "MapData.h"
 #include <string>
-#include <vector>
-#include <memory>
 
 class SeekableStreamReader;
 

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -1,6 +1,12 @@
 #include "MapWriter.h"
 #include "../Streams/FileStreamWriter.h"
 
+void MapWriter::Write(const std::string& filename, const MapData& mapData)
+{
+	FileStreamWriter mapWriter(filename);
+	Write(mapWriter, mapData);
+}
+
 void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData)
 {	
 	streamWriter = &mapStream;
@@ -17,12 +23,6 @@ void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData)
 	WriteVersionTag(mapData.header.versionTag);
 
 	WriteTileGroups(mapData.tileGroups);
-}
-
-void MapWriter::Write(const std::string& filename, const MapData& mapData)
-{
-	FileStreamWriter mapWriter(filename);
-	Write(mapWriter, mapData);
 }
 
 void MapWriter::WriteHeader(const MapHeader& header)

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -9,7 +9,7 @@ void MapWriter::Write(const std::string& filename, const MapData& mapData)
 
 void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData)
 {	
-	streamWriter = &mapStream;
+	streamWriter = mapStream;
 
 	WriteHeader(mapData.header);
 	WriteTiles(mapData.tiles);
@@ -32,22 +32,22 @@ void MapWriter::WriteHeader(const MapHeader& header)
 		throw std::runtime_error("All instances of version tag in .map and .op2 files must be greater than 0x1010.");
 	}
 
-	streamWriter->Write(&header, sizeof(header));
+	streamWriter.Write(&header, sizeof(header));
 }
 
 void MapWriter::WriteVersionTag(int versionTag)
 {
-	streamWriter->Write(&versionTag, sizeof(versionTag));
+	streamWriter.Write(&versionTag, sizeof(versionTag));
 }
 
 void MapWriter::WriteTiles(const std::vector<TileData>& tiles)
 {
-	streamWriter->Write(&tiles[0], tiles.size() * sizeof(TileData));
+	streamWriter.Write(&tiles[0], tiles.size() * sizeof(TileData));
 }
 
 void MapWriter::WriteClipRect(const ClipRect& clipRect)
 {
-	streamWriter->Write(&clipRect, sizeof(clipRect));
+	streamWriter.Write(&clipRect, sizeof(clipRect));
 }
 
 void MapWriter::WriteTilesetSources(const std::vector<TilesetSource>& tileSetSources)
@@ -59,14 +59,14 @@ void MapWriter::WriteTilesetSources(const std::vector<TilesetSource>& tileSetSou
 		// Only include the number of tiles if the tileset contains a filename.
 		if (tilesetSource.tilesetFilename.size() > 0)
 		{
-			streamWriter->Write(&tilesetSource.numTiles, sizeof(int));
+			streamWriter.Write(&tilesetSource.numTiles, sizeof(int));
 		}
 	}
 }
 
 void MapWriter::WriteTilesetHeader()
 {
-	streamWriter->Write("TILE SET\x1a", 10);
+	streamWriter.Write("TILE SET\x1a", 10);
 }
 
 void MapWriter::WriteTileInfo(const std::vector<TileInfo>& tileInfos)
@@ -75,7 +75,7 @@ void MapWriter::WriteTileInfo(const std::vector<TileInfo>& tileInfos)
 
 	for (TileInfo tileInfo : tileInfos)
 	{
-		streamWriter->Write(&tileInfo, sizeof(TileInfo));
+		streamWriter.Write(&tileInfo, sizeof(TileInfo));
 	}
 }
 
@@ -85,7 +85,7 @@ void MapWriter::WriteTerrainType(const std::vector<TerrainType>& terrainTypes)
 
 	for (TerrainType terrainType : terrainTypes)
 	{
-		streamWriter->Write(&terrainType, sizeof(TerrainType));
+		streamWriter.Write(&terrainType, sizeof(TerrainType));
 	}
 }
 
@@ -93,16 +93,16 @@ void MapWriter::WriteTileGroups(const std::vector<TileGroup>& tileGroups)
 {
 	WriteContainerSize(tileGroups.size());
 
-	streamWriter->SeekRelative(sizeof(int));
+	streamWriter.SeekRelative(sizeof(int));
 
 	for (TileGroup tileGroup : tileGroups)
 	{
-		streamWriter->Write(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
-		streamWriter->Write(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
+		streamWriter.Write(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
+		streamWriter.Write(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
 
 		for (int mappingIndex : tileGroup.mappingIndices)
 		{
-			streamWriter->Write(&mappingIndex, sizeof(mappingIndex));
+			streamWriter.Write(&mappingIndex, sizeof(mappingIndex));
 		}
 
 		WriteString(tileGroup.name);
@@ -111,7 +111,7 @@ void MapWriter::WriteTileGroups(const std::vector<TileGroup>& tileGroups)
 
 void MapWriter::WriteContainerSize(size_t size)
 {
-	streamWriter->Write(&size, sizeof(size));
+	streamWriter.Write(&size, sizeof(size));
 }
 
 // String must be stored in file as string length followed by char[].
@@ -120,6 +120,6 @@ void MapWriter::WriteString(const std::string& s)
 	WriteContainerSize(s.size());
 
 	if (s.size() > 0) {
-		streamWriter->Write(s.c_str(), s.size());
+		streamWriter.Write(s.c_str(), s.size());
 	}
 }

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -1,5 +1,7 @@
 #include "MapWriter.h"
 #include "../Streams/FileStreamWriter.h"
+#include <stdexcept>
+#include <vector>
 
 
 namespace MapWriter {

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -1,125 +1,151 @@
 #include "MapWriter.h"
 #include "../Streams/FileStreamWriter.h"
 
-void MapWriter::Write(const std::string& filename, const MapData& mapData)
-{
-	FileStreamWriter mapWriter(filename);
-	Write(mapWriter, mapData);
-}
 
-void MapWriter::Write(SeekableStreamWriter& mapStream, const MapData& mapData)
-{	
-	streamWriter = mapStream;
-
-	WriteHeader(mapData.header);
-	WriteTiles(mapData.tiles);
-	WriteClipRect(mapData.clipRect);
-	WriteTilesetSources(mapData.tilesetSources);
-	WriteTilesetHeader();
-	WriteTileInfo(mapData.tileInfos);
-	WriteTerrainType(mapData.terrainTypes);
-
-	WriteVersionTag(mapData.header.versionTag);
-	WriteVersionTag(mapData.header.versionTag);
-
-	WriteTileGroups(mapData.tileGroups);
-}
-
-void MapWriter::WriteHeader(const MapHeader& header)
-{
-	if (!header.VersionTagValid())
-	{
-		throw std::runtime_error("All instances of version tag in .map and .op2 files must be greater than 0x1010.");
+namespace MapWriter {
+	// Anonymous namespace to hold private methods
+	namespace {
+		void WriteHeader(StreamWriter& streamWriter, const MapHeader& header);
+		void WriteTiles(StreamWriter& streamWriter, const std::vector<TileData>& tiles);
+		void WriteClipRect(StreamWriter& streamWriter, const ClipRect& clipRect);
+		void WriteTilesetSources(StreamWriter& streamWriter, const std::vector<TilesetSource>& tilesetSources);
+		void WriteTilesetHeader(StreamWriter& streamWriter);
+		void WriteTileInfo(StreamWriter& streamWriter, const std::vector<TileInfo>& tileInfos);
+		void WriteTerrainType(StreamWriter& streamWriter, const std::vector<TerrainType>& terrainTypes);
+		void WriteTileGroups(SeekableStreamWriter& streamWriter, const std::vector<TileGroup>& tileGroups);
+		void WriteVersionTag(StreamWriter& streamWriter, int versionTag);
+		void WriteContainerSize(StreamWriter& streamWriter, size_t size);
+		void WriteString(StreamWriter& streamWriter, const std::string& s);
 	}
 
-	streamWriter.Write(&header, sizeof(header));
-}
 
-void MapWriter::WriteVersionTag(int versionTag)
-{
-	streamWriter.Write(&versionTag, sizeof(versionTag));
-}
+	// ==== Public methods ====
 
-void MapWriter::WriteTiles(const std::vector<TileData>& tiles)
-{
-	streamWriter.Write(&tiles[0], tiles.size() * sizeof(TileData));
-}
 
-void MapWriter::WriteClipRect(const ClipRect& clipRect)
-{
-	streamWriter.Write(&clipRect, sizeof(clipRect));
-}
-
-void MapWriter::WriteTilesetSources(const std::vector<TilesetSource>& tileSetSources)
-{
-	for (TilesetSource tilesetSource : tileSetSources)
+	void Write(const std::string& filename, const MapData& mapData)
 	{
-		WriteString(tilesetSource.tilesetFilename);
+		FileStreamWriter mapWriter(filename);
+		Write(mapWriter, mapData);
+	}
 
-		// Only include the number of tiles if the tileset contains a filename.
-		if (tilesetSource.tilesetFilename.size() > 0)
+	void Write(SeekableStreamWriter& streamWriter, const MapData& mapData)
+	{
+		WriteHeader(streamWriter, mapData.header);
+		WriteTiles(streamWriter, mapData.tiles);
+		WriteClipRect(streamWriter, mapData.clipRect);
+		WriteTilesetSources(streamWriter, mapData.tilesetSources);
+		WriteTilesetHeader(streamWriter);
+		WriteTileInfo(streamWriter, mapData.tileInfos);
+		WriteTerrainType(streamWriter, mapData.terrainTypes);
+
+		WriteVersionTag(streamWriter, mapData.header.versionTag);
+		WriteVersionTag(streamWriter, mapData.header.versionTag);
+
+		WriteTileGroups(streamWriter, mapData.tileGroups);
+	}
+
+
+	// == Private methods ==
+
+
+	namespace {
+		void WriteHeader(StreamWriter& streamWriter, const MapHeader& header)
 		{
-			streamWriter.Write(&tilesetSource.numTiles, sizeof(int));
-		}
-	}
-}
+			if (!header.VersionTagValid())
+			{
+				throw std::runtime_error("All instances of version tag in .map and .op2 files must be greater than 0x1010.");
+			}
 
-void MapWriter::WriteTilesetHeader()
-{
-	streamWriter.Write("TILE SET\x1a", 10);
-}
-
-void MapWriter::WriteTileInfo(const std::vector<TileInfo>& tileInfos)
-{
-	WriteContainerSize(tileInfos.size());
-
-	for (TileInfo tileInfo : tileInfos)
-	{
-		streamWriter.Write(&tileInfo, sizeof(TileInfo));
-	}
-}
-
-void MapWriter::WriteTerrainType(const std::vector<TerrainType>& terrainTypes)
-{
-	WriteContainerSize(terrainTypes.size());
-
-	for (TerrainType terrainType : terrainTypes)
-	{
-		streamWriter.Write(&terrainType, sizeof(TerrainType));
-	}
-}
-
-void MapWriter::WriteTileGroups(const std::vector<TileGroup>& tileGroups)
-{
-	WriteContainerSize(tileGroups.size());
-
-	streamWriter.SeekRelative(sizeof(int));
-
-	for (TileGroup tileGroup : tileGroups)
-	{
-		streamWriter.Write(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
-		streamWriter.Write(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
-
-		for (int mappingIndex : tileGroup.mappingIndices)
-		{
-			streamWriter.Write(&mappingIndex, sizeof(mappingIndex));
+			streamWriter.Write(&header, sizeof(header));
 		}
 
-		WriteString(tileGroup.name);
-	}
-}
+		void WriteVersionTag(StreamWriter& streamWriter, int versionTag)
+		{
+			streamWriter.Write(&versionTag, sizeof(versionTag));
+		}
 
-void MapWriter::WriteContainerSize(size_t size)
-{
-	streamWriter.Write(&size, sizeof(size));
-}
+		void WriteTiles(StreamWriter& streamWriter, const std::vector<TileData>& tiles)
+		{
+			streamWriter.Write(&tiles[0], tiles.size() * sizeof(TileData));
+		}
 
-// String must be stored in file as string length followed by char[].
-void MapWriter::WriteString(const std::string& s)
-{
-	WriteContainerSize(s.size());
+		void WriteClipRect(StreamWriter& streamWriter, const ClipRect& clipRect)
+		{
+			streamWriter.Write(&clipRect, sizeof(clipRect));
+		}
 
-	if (s.size() > 0) {
-		streamWriter.Write(s.c_str(), s.size());
+		void WriteTilesetSources(StreamWriter& streamWriter, const std::vector<TilesetSource>& tileSetSources)
+		{
+			for (TilesetSource tilesetSource : tileSetSources)
+			{
+				WriteString(streamWriter, tilesetSource.tilesetFilename);
+
+				// Only include the number of tiles if the tileset contains a filename.
+				if (tilesetSource.tilesetFilename.size() > 0)
+				{
+					streamWriter.Write(&tilesetSource.numTiles, sizeof(int));
+				}
+			}
+		}
+
+		void WriteTilesetHeader(StreamWriter& streamWriter)
+		{
+			streamWriter.Write("TILE SET\x1a", 10);
+		}
+
+		void WriteTileInfo(StreamWriter& streamWriter, const std::vector<TileInfo>& tileInfos)
+		{
+			WriteContainerSize(streamWriter, tileInfos.size());
+
+			for (TileInfo tileInfo : tileInfos)
+			{
+				streamWriter.Write(&tileInfo, sizeof(TileInfo));
+			}
+		}
+
+		void WriteTerrainType(StreamWriter& streamWriter, const std::vector<TerrainType>& terrainTypes)
+		{
+			WriteContainerSize(streamWriter, terrainTypes.size());
+
+			for (TerrainType terrainType : terrainTypes)
+			{
+				streamWriter.Write(&terrainType, sizeof(TerrainType));
+			}
+		}
+
+		void WriteTileGroups(SeekableStreamWriter& streamWriter, const std::vector<TileGroup>& tileGroups)
+		{
+			WriteContainerSize(streamWriter, tileGroups.size());
+
+			streamWriter.SeekRelative(sizeof(int));
+
+			for (TileGroup tileGroup : tileGroups)
+			{
+				streamWriter.Write(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
+				streamWriter.Write(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
+
+				for (int mappingIndex : tileGroup.mappingIndices)
+				{
+					streamWriter.Write(&mappingIndex, sizeof(mappingIndex));
+				}
+
+				WriteString(streamWriter, tileGroup.name);
+			}
+		}
+
+		void WriteContainerSize(StreamWriter& streamWriter, size_t size)
+		{
+			streamWriter.Write(&size, sizeof(size));
+		}
+
+		// String must be stored in file as string length followed by char[].
+		void WriteString(StreamWriter& streamWriter, const std::string& s)
+		{
+			WriteContainerSize(streamWriter, s.size());
+
+			if (s.size() > 0) {
+				streamWriter.Write(s.c_str(), s.size());
+			}
+		}
 	}
 }

--- a/Maps/MapWriter.h
+++ b/Maps/MapWriter.h
@@ -2,8 +2,6 @@
 
 #include "MapData.h"
 #include <string>
-#include <vector>
-#include <memory>
 
 class SeekableStreamWriter;
 

--- a/Maps/MapWriter.h
+++ b/Maps/MapWriter.h
@@ -11,8 +11,8 @@ class SeekableStreamWriter;
 class MapWriter
 {
 public:
-	void Write(SeekableStreamWriter& mapStream, const MapData& mapData);
 	void Write(const std::string& filename, const MapData& mapData);
+	void Write(SeekableStreamWriter& mapStream, const MapData& mapData);
 
 private:
 	SeekableStreamWriter* streamWriter;

--- a/Maps/MapWriter.h
+++ b/Maps/MapWriter.h
@@ -8,24 +8,7 @@
 class SeekableStreamWriter;
 
 // Writes an Outpost 2 map to file.
-class MapWriter
-{
-public:
+namespace MapWriter {
 	void Write(const std::string& filename, const MapData& mapData);
 	void Write(SeekableStreamWriter& mapStream, const MapData& mapData);
-
-private:
-	SeekableStreamWriter& streamWriter;
-
-	void WriteHeader(const MapHeader& header);
-	void WriteTiles(const std::vector<TileData>& tiles);
-	void WriteClipRect(const ClipRect& clipRect);
-	void WriteTilesetSources(const std::vector<TilesetSource>& tilesetSources);
-	void WriteTilesetHeader();
-	void WriteTileInfo(const std::vector<TileInfo>& tileInfos);
-	void WriteTerrainType(const std::vector<TerrainType>& terrainTypes);
-	void WriteTileGroups(const std::vector<TileGroup>& tileGroups);
-	void WriteVersionTag(int versionTag);
-	void WriteContainerSize(size_t size);
-	void WriteString(const std::string& s);
-};
+}

--- a/Maps/MapWriter.h
+++ b/Maps/MapWriter.h
@@ -15,7 +15,7 @@ public:
 	void Write(SeekableStreamWriter& mapStream, const MapData& mapData);
 
 private:
-	SeekableStreamWriter* streamWriter;
+	SeekableStreamWriter& streamWriter;
 
 	void WriteHeader(const MapHeader& header);
 	void WriteTiles(const std::vector<TileData>& tiles);


### PR DESCRIPTION
At this point, this pull request is more to start a code review and discussion about a work in progress relating to issue #46. I don't recommend it be merged at this point, as the code generates warnings.

This branch includes changes from the map-reader-writer-updates branch, as it depends on those changes.

The question, is how might these changes proceed, and the warnings be resolved. One possibility is to refactor the Read/Write methods into MapReader/MapWriter constructors. Another possibility is to refactor the MapReader/MapWriter into namespaces rather than classes. The code might also be left as is, or undergo some other refactoring.

An example warning from the current intermediate step is:

> Maps/MapReader.h:17:24: warning: non-static reference ‘SeekableStreamReader& MapReader::streamReader’ in class without a constructor [-Wuninitialized]
  SeekableStreamReader& streamReader;
