### PR TITLE
Eliminate use of manual memory management

### DIFF
--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -141,27 +141,12 @@ TileGroup MapReader::ReadTileGroup()
 // String must be stored in file as string length followed by char[].
 std::string MapReader::ReadString()
 {
-	size_t stringLength;
+	uint32_t stringLength;
 	streamReader->Read(&stringLength, sizeof(stringLength));
 
-	if (stringLength == 0) {
-		return std::string();
-	}
+	std::string s;
+	s.resize(stringLength);
+	streamReader->Read(&s[0], stringLength);
 
-	char* cString = new char[stringLength];
-
-	try
-	{
-		streamReader->Read(cString, stringLength);
-		std::string s(cString, stringLength);
-		delete cString;
-
-		return s;
-	}
-	catch (std::exception e)
-	{
-		delete cString;
-
-		throw e;
-	}
+	return s;
 }


### PR DESCRIPTION
This code contained a bug, mixing new[] with delete instead of delete[].
This could potentially cause memory corruption under some C++ runtimes.

New code uses std::string with reserve to avoid manual memory
management. This is more correct, and simpler.