### PR TITLE
Use UINT_MAX in check for invalid index entry

### DIFF
--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -4,6 +4,7 @@
 #include "../XFile.h"
 #include <stdexcept>
 #include <algorithm>
+#include <climits>
 
 
 namespace Archives
@@ -479,7 +480,7 @@ namespace Archives
 		for (temp = 0; temp < m_NumberOfIndexEntries; temp++)
 		{
 			// Make sure entry is valid
-			if (m_Index[temp].fileNameOffset == -1u)
+			if (m_Index[temp].fileNameOffset == UINT_MAX)
 				break;
 		}
 		m_NumberOfPackedFiles = temp;		// Store the number of used index entries


### PR DESCRIPTION
Alright, alright, one last fix. Now I'm going to bed. :smiley: 

Removes the `-1u` that was causing the compiler warning, and replaces it with `UINT_MAX` and an include for `<climits>`.
