### PR TITLE
Re-remove `char*` casts from templates

### DIFF
--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -15,7 +15,7 @@ public:
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Read(T& object) {
-		Read((char*)&object, sizeof(object));
+		Read(&object, sizeof(object));
 	}
 
 	// SeekableStreamReader methods

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -16,7 +16,7 @@ public:
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Write(const T& object) {
-		Write((char*)&object, sizeof(object));
+		Write(&object, sizeof(object));
 	}
 
 	// SeekableStreamWriter methods

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -12,7 +12,7 @@ public:
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Read(T& object) {
-		Read((char*)&object, sizeof(object));
+		Read(&object, sizeof(object));
 	}
 
 	// SeekableStreamReader methods

--- a/Streams/MemoryStreamWriter.h
+++ b/Streams/MemoryStreamWriter.h
@@ -15,7 +15,7 @@ public:
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Write(const T& object) {
-		Write((char*)&object, sizeof(object));
+		Write(&object, sizeof(object));
 	}
 
 	// SeekableStreamWriter methods


### PR DESCRIPTION
These seem to have been accidentally re-introduced during recent refactoring.