### PR TITLE
Make destructor virtual instead of pure virtual

### DIFF
--- a/Streams/StreamReader.h
+++ b/Streams/StreamReader.h
@@ -4,6 +4,6 @@
 
 class StreamReader {
 public:
-	virtual ~StreamReader();
+	virtual ~StreamReader() = default;
 	virtual void Read(void* buffer, size_t size) = 0;
 };

--- a/Streams/StreamReader.h
+++ b/Streams/StreamReader.h
@@ -4,6 +4,6 @@
 
 class StreamReader {
 public:
-	virtual ~StreamReader() = 0 { };
+	virtual ~StreamReader();
 	virtual void Read(void* buffer, size_t size) = 0;
 };

--- a/Streams/StreamWriter.h
+++ b/Streams/StreamWriter.h
@@ -4,6 +4,6 @@
 
 class StreamWriter {
 public:
-	virtual ~StreamWriter();
+	virtual ~StreamWriter() = default;
 	virtual void Write(const void* buffer, size_t size) = 0;
 };

--- a/Streams/StreamWriter.h
+++ b/Streams/StreamWriter.h
@@ -4,6 +4,6 @@
 
 class StreamWriter {
 public:
-	virtual ~StreamWriter() = 0 { };
+	virtual ~StreamWriter();
 	virtual void Write(const void* buffer, size_t size) = 0;
 };


### PR DESCRIPTION
Adding both pure virtual (= 0), and an explicit implementation ({}) to a
definition violates the C++ standard. Such code may be accepted by MSVC,
though causes an error in g++.

The point of a pure virtual method is that it allows the method
definition to be omitted, and marks the class as abstract, preventing
instances from being directly instantiated. Marking any method as pure
virtual is enough to mark a class as abstract.

A pure virtual method can still be optionally defined. It may be
accessed using the scope resolution operator. This might allow a derived
class to call a default implementation from the base class. Naturally
the base class method must be defined in such a case:
```
// Abstract base class
class Base {
public:
  virtual void someMethod() = 0; // Pure virtual
};

void Base::someMethod() {
  // Some default implementation
}

class Derived : public Base {
public:
  virtual void someMethod() override {
    Base::someMethod(); // Explicit call to base class implementation
  }
};
```

In the case of a destructor, the derived class destructor will have an
implicit call to the base class destructor. As such, `Base::~Base` must
be defined. Hence the implementation of a pure virtual destructor in a
base class is not really optional. Omitting the base class destructor
results in an unresolved external symbol error from the linker when
trying to link any derived class destructors.

By not marking a virtual base class destructor as pure, it will be
provided with a default (essentially empty) implementation, which will
satify calls from derived class destructors. As such, there is little
reason to mark a base class virtual destructor as pure, unless you need
to do so to make the class abstract. Since marking any method as pure
virtual makes the class abstract, you only need to select the destructor
if there is no other suitable method that can be marked as pure virtual.

----

The StreamReader and StreamWriter base classes are already abstract by
virtual of haing a pure virtual Read or Write method. As such, there is
no reason to also make the destructor pure virtual.