### PR TITLE
Remove windows.h from ArchivePacker.cpp

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -1,7 +1,7 @@
 #include "ArchivePacker.h"
 #include "../XFile.h"
 #include "../StringHelper.h"
-#include <windows.h>
+#include <cstdio>
 #include <stdexcept>
 
 namespace Archives
@@ -9,20 +9,30 @@ namespace Archives
 	ArchivePacker::ArchivePacker() { }
 	ArchivePacker::~ArchivePacker() { }
 
-	// newFile has it's name changed to that of fileToReplace and the old file is deleted.
-	// Returns true if successful and false otherwise
-	bool ArchivePacker::ReplaceFileWithFile(const char *fileToReplace, const char *newFile)
+	// newFile has its name changed to fileToReplace and the old file is deleted.
+	void ArchivePacker::ReplaceFileWithFile(const std::string& fileToReplace, const std::string& newFile)
 	{
-		std::string tempFileName("Temporary.vol");
-		MoveFileA(fileToReplace, tempFileName.c_str());
-		
-		if (MoveFileA(newFile, fileToReplace) == 0) {
-			return false;
+		// If C++17 filesystem comes out of experimental status on both MSVC and Linux compilers, 
+		// consider switching to std::filesystem::rename & std::filesystem::remove
+		  
+		const std::string tempFileName("Temporary.vol");
+
+		if (!std::rename(fileToReplace.c_str(), tempFileName.c_str())) {
+			throw std::runtime_error("Unable to move original version of file to " + tempFileName);
 		}
-
-		DeleteFileA(tempFileName.c_str());
-
-		return true;
+		
+		if (!std::rename(newFile.c_str(), fileToReplace.c_str())) {
+			// Attempt to restore original file.
+			if (!std::rename(tempFileName.c_str(), fileToReplace.c_str())) {
+				throw std::runtime_error("Unable to move new file into original filename. Attempting to restore original file failed. The original file may be found at " + tempFileName);
+			}
+			
+			throw std::runtime_error("Unable to move new file into original version of filename. Original file was restored.");
+		}
+		
+		if (!std::remove(tempFileName.c_str())) {
+			throw std::runtime_error("Unable to delete temporary file named " + tempFileName + ". Consider manually deleting.");
+		}
 	}
 
 	std::vector<std::string> ArchivePacker::GetInternalNamesFromPaths(std::vector<std::string> paths)

--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -1,7 +1,6 @@
 #include "ArchivePacker.h"
 #include "../XFile.h"
 #include "../StringHelper.h"
-#include <cstdio>
 #include <stdexcept>
 
 namespace Archives
@@ -9,33 +8,7 @@ namespace Archives
 	ArchivePacker::ArchivePacker() { }
 	ArchivePacker::~ArchivePacker() { }
 
-	// newFile has its name changed to fileToReplace and the old file is deleted.
-	void ArchivePacker::ReplaceFileWithFile(const std::string& fileToReplace, const std::string& newFile)
-	{
-		// If C++17 filesystem comes out of experimental status on both MSVC and Linux compilers, 
-		// consider switching to std::filesystem::rename & std::filesystem::remove
-		  
-		const std::string tempFileName("Temporary.vol");
-
-		if (!std::rename(fileToReplace.c_str(), tempFileName.c_str())) {
-			throw std::runtime_error("Unable to move original version of file to " + tempFileName);
-		}
-		
-		if (!std::rename(newFile.c_str(), fileToReplace.c_str())) {
-			// Attempt to restore original file.
-			if (!std::rename(tempFileName.c_str(), fileToReplace.c_str())) {
-				throw std::runtime_error("Unable to move new file into original filename. Attempting to restore original file failed. The original file may be found at " + tempFileName);
-			}
-			
-			throw std::runtime_error("Unable to move new file into original version of filename. Original file was restored.");
-		}
-		
-		if (!std::remove(tempFileName.c_str())) {
-			throw std::runtime_error("Unable to delete temporary file named " + tempFileName + ". Consider manually deleting.");
-		}
-	}
-
-	std::vector<std::string> ArchivePacker::GetInternalNamesFromPaths(std::vector<std::string> paths)
+	std::vector<std::string> ArchivePacker::GetInternalNamesFromPaths(const std::vector<std::string>& paths)
 	{
 		std::vector<std::string> fileNames;
 

--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -19,7 +19,7 @@ namespace Archives
 		virtual bool CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack) = 0;
 
 	protected:
-		bool ReplaceFileWithFile(const char *fileToReplace, const char *newFile);
+		void ReplaceFileWithFile(const std::string& fileToReplace, const std::string& newFile);
 
 		// Returns the filenames from each path stripping the rest of the path. 
 		std::vector<std::string> GetInternalNamesFromPaths(std::vector<std::string> paths);

--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -19,10 +19,8 @@ namespace Archives
 		virtual bool CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack) = 0;
 
 	protected:
-		void ReplaceFileWithFile(const std::string& fileToReplace, const std::string& newFile);
-
 		// Returns the filenames from each path stripping the rest of the path. 
-		std::vector<std::string> GetInternalNamesFromPaths(std::vector<std::string> paths);
+		std::vector<std::string> GetInternalNamesFromPaths(const std::vector<std::string>& paths);
 
 		// Throws an error if 2 internalNames are identical, case insensitve. 
 		// internalNames must be presorted. 

--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -5,10 +5,10 @@ namespace Archives
 {
 	ArchiveUnpacker::ArchiveUnpacker(const std::string& fileName)
 	{
-		this->m_VolumeFileName = fileName;
+		this->m_ArchiveFileName = fileName;
 
 		m_NumberOfPackedFiles = 0;
-		m_VolumeFileSize = 0;
+		m_ArchiveFileSize = 0;
 	}
 
 	ArchiveUnpacker::~ArchiveUnpacker() { }

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -13,8 +13,8 @@ namespace Archives
 		ArchiveUnpacker(const std::string& fileName);
 		virtual ~ArchiveUnpacker();
 
-		std::string GetVolumeFileName() { return m_VolumeFileName; };
-		int GetVolumeFileSize() { return m_VolumeFileSize; };
+		std::string GetVolumeFileName() { return m_ArchiveFileName; };
+		int GetVolumeFileSize() { return m_ArchiveFileSize; };
 		int GetNumberOfPackedFiles() { return m_NumberOfPackedFiles; };
 		bool ContainsFile(const char* fileName);
 
@@ -30,8 +30,8 @@ namespace Archives
 	protected:
 		void CheckPackedFileIndexBounds(int fileIndex);
 
-		std::string m_VolumeFileName;
+		std::string m_ArchiveFileName;
 		int m_NumberOfPackedFiles;
-		int m_VolumeFileSize;
+		int m_ArchiveFileSize;
 	};
 }

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -157,14 +157,14 @@ namespace Archives
 			filesToPack[i] = GetInternalFileName(i) + ".wav";
 		}
 
-		std::string tempFileName = "temp.clm";
+		const std::string tempFileName = "temp.clm";
 		if (!CreateArchive(tempFileName, filesToPack)) {
 			return false;
 		}
 
 		// Rename the output file to the desired file
 		try {
-			ReplaceFileWithFile(m_ArchiveFileName, tempFileName);
+			XFile::RenameFile(tempFileName, m_ArchiveFileName);
 			return true;
 		}
 		catch (std::exception& e) {

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -28,7 +28,7 @@ namespace Archives
 			clmHeader.VerifyUnknown();
 		}
 		catch (std::exception& e) {
-			throw std::runtime_error("Invalid clm header read from file " + m_VolumeFileName + ". " + e.what());
+			throw std::runtime_error("Invalid clm header read from file " + m_ArchiveFileName + ". " + e.what());
 		}
 
 		m_NumberOfPackedFiles = clmHeader.packedFilesCount;
@@ -157,7 +157,19 @@ namespace Archives
 			filesToPack[i] = GetInternalFileName(i) + ".wav";
 		}
 
-		return CreateArchive("temp.clm", filesToPack);
+		std::string tempFileName = "temp.clm";
+		if (!CreateArchive(tempFileName, filesToPack)) {
+			return false;
+		}
+
+		// Rename the output file to the desired file
+		try {
+			ReplaceFileWithFile(m_ArchiveFileName, tempFileName);
+			return true;
+		}
+		catch (std::exception& e) {
+			return false;
+		}
 	}
 
 	// Creates a new Archive file with the file name archiveFileName. The

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -15,7 +15,7 @@ namespace Archives
 			throw std::runtime_error("Could not open vol file " + std::string(fileName) + ".");
 		}
 
-		m_VolumeFileSize = m_MappedFileSize;
+		m_ArchiveFileSize = m_MappedFileSize;
 
 		if (!ReadVolHeader()) {
 			throw std::runtime_error("Invalid vol header in " + std::string(fileName) + ".");
@@ -168,7 +168,8 @@ namespace Archives
 			filesToPack.push_back(GetInternalFileName(i));
 		}
 
-		if (!CreateArchive("Temp.vol", filesToPack)) {
+		const std::string tempFileName("Temp.vol");
+		if (!CreateArchive(tempFileName, filesToPack)) {
 			return false;
 		}
 
@@ -176,7 +177,13 @@ namespace Archives
 		UnmapFile();
 
 		// Rename the output file to the desired file
-		return ReplaceFileWithFile(m_VolumeFileName.c_str(), "Temp.vol");
+		try {
+			ReplaceFileWithFile(m_ArchiveFileName, tempFileName);
+			return true;
+		}
+		catch (std::exception& e) {
+			return false;
+		}
 	}
 
 	bool VolFile::CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack)

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -168,7 +168,7 @@ namespace Archives
 			filesToPack.push_back(GetInternalFileName(i));
 		}
 
-		const std::string tempFileName("Temp.vol");
+		const std::string tempFileName("temp.vol");
 		if (!CreateArchive(tempFileName, filesToPack)) {
 			return false;
 		}
@@ -178,7 +178,7 @@ namespace Archives
 
 		// Rename the output file to the desired file
 		try {
-			ReplaceFileWithFile(m_ArchiveFileName, tempFileName);
+			XFile::RenameFile(tempFileName, m_ArchiveFileName);
 			return true;
 		}
 		catch (std::exception& e) {

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -201,3 +201,8 @@ void XFile::DeletePath(const string& pathStr)
 {
 	remove_all(pathStr);
 }
+
+void XFile::RenameFile(const std::string& oldPath, const std::string& newPath) 
+{
+	rename(oldPath, newPath);
+}

--- a/XFile.h
+++ b/XFile.h
@@ -51,4 +51,6 @@ namespace XFile
 	std::string GetDirectory(const std::string& pathStr);
 
 	void DeletePath(const std::string& pathStr);
+
+	void RenameFile(const std::string& oldPath, const std::string& newPath);
 }


### PR DESCRIPTION
 - Improve error handling and rollback of files on failure in ArchivePacker::ReplaceFileWithFile
 - Rename ArchiveUnpacker class variables as ArchiveX instead of VolumeX
 - Hook ClmFile::Repack into ArchivePacker::ReplaceFileWithFile