### PR TITLE
Conform Archives size_t calls to Clang Compiler Requirements

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -1,6 +1,7 @@
 #include "ArchivePacker.h"
 #include "../XFile.h"
 #include "../StringHelper.h"
+#include <cstddef>
 #include <stdexcept>
 
 namespace Archives
@@ -21,7 +22,7 @@ namespace Archives
 
 	void ArchivePacker::CheckSortedContainerForDuplicateNames(const std::vector<std::string>& internalNames) 
 	{
-		for (size_t i = 1; i < internalNames.size(); ++i)
+		for (std::size_t i = 1; i < internalNames.size(); ++i)
 		{
 			if (StringHelper::CheckIfStringsAreEqual(internalNames[i - 1], internalNames[i])) {
 				throw std::runtime_error("Unable to create an archive containing files with the same filename. Duplicate filename: " + internalNames[i]);

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -185,7 +185,7 @@ namespace Archives
 		std::vector<std::unique_ptr<FileStreamReader>> filesToPackReaders;
 		try {
 			// Opens all files for packing. If there is a problem opening a file, an exception is raised.
-			for (const std::string& fileName : filesToPack) {
+			for (const auto& fileName : filesToPack) {
 				filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
 			}
 		}
@@ -244,7 +244,7 @@ namespace Archives
 		RiffHeader header;
 
 		// Read in all the headers and find start of data
-		for (size_t i = 0; i < filesToPackReaders.size(); i++)
+		for (std::size_t i = 0; i < filesToPackReaders.size(); i++)
 		{
 			// Read the file header
 			filesToPackReaders[i]->Read(header);
@@ -320,7 +320,7 @@ namespace Archives
 	// Returns true if they are all the same and false otherwise.
 	bool ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats)
 	{
-		for (size_t i = 1; i < waveFormats.size(); i++)
+		for (std::size_t i = 1; i < waveFormats.size(); i++)
 		{
 			if (memcmp(&waveFormats[i], &waveFormats[0], sizeof(WaveFormatEx))) {
 				return false;
@@ -348,7 +348,7 @@ namespace Archives
 		clmFileWriter.Write(indexEntries.data(), header.packedFilesCount * sizeof(IndexEntry));
 
 		// Copy files into the archive
-		for (size_t i = 0; i < header.packedFilesCount; i++) {
+		for (std::size_t i = 0; i < header.packedFilesCount; i++) {
 			PackFile(clmFileWriter, indexEntries[i], *filesToPackReaders[i]);
 		}
 	}
@@ -356,7 +356,7 @@ namespace Archives
 	void ClmFile::PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries)
 	{
 		uint32_t offset = headerSize + internalNames.size() * sizeof(IndexEntry);
-		for (size_t i = 0; i < internalNames.size(); i++)
+		for (std::size_t i = 0; i < internalNames.size(); i++)
 		{
 			// Copy the filename into the entry
 			strncpy((char*)&indexEntries[i].fileName, internalNames[i].c_str(), 8);
@@ -395,7 +395,7 @@ namespace Archives
 	{
 		std::vector<std::string> strippedExtensions;
 
-		for (const std::string& path : paths) {
+		for (const auto& path : paths) {
 			strippedExtensions.push_back(XFile::ChangeFileExtension(path, ""));
 		}
 

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -6,6 +6,7 @@
 #include "CompressionType.h"
 #include "../Streams/StreamWriter.h"
 #include <windows.h>
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <memory>
@@ -39,8 +40,8 @@ namespace Archives
 		int GetInternalFileOffset(int index);
 		int GetInternalFileNameOffset(int index);
 
-		void ExtractFileUncompressed(size_t index, const std::string& filename);
-		void ExtractFileLzh(size_t index, const std::string& filename);
+		void ExtractFileUncompressed(std::size_t index, const std::string& filename);
+		void ExtractFileLzh(std::size_t index, const std::string& filename);
 
 #pragma pack(push, 1)
 		struct IndexEntry
@@ -64,7 +65,7 @@ namespace Archives
 			int paddedStringTableLength;
 			int paddedIndexTableLength;
 
-			size_t fileCount() const
+			std::size_t fileCount() const
 			{
 				return filesToPack.size();
 			}

--- a/Maps/MapWriter.cpp
+++ b/Maps/MapWriter.cpp
@@ -1,5 +1,6 @@
 #include "MapWriter.h"
 #include "../Streams/FileStreamWriter.h"
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
 
@@ -16,7 +17,7 @@ namespace MapWriter {
 		void WriteTerrainType(StreamWriter& streamWriter, const std::vector<TerrainType>& terrainTypes);
 		void WriteTileGroups(SeekableStreamWriter& streamWriter, const std::vector<TileGroup>& tileGroups);
 		void WriteVersionTag(StreamWriter& streamWriter, int versionTag);
-		void WriteContainerSize(StreamWriter& streamWriter, size_t size);
+		void WriteContainerSize(StreamWriter& streamWriter, uint32_t size);
 		void WriteString(StreamWriter& streamWriter, const std::string& s);
 	}
 
@@ -135,7 +136,7 @@ namespace MapWriter {
 			}
 		}
 
-		void WriteContainerSize(StreamWriter& streamWriter, size_t size)
+		void WriteContainerSize(StreamWriter& streamWriter, uint32_t size)
 		{
 			streamWriter.Write(&size, sizeof(size));
 		}

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -14,7 +14,7 @@ FileStreamReader::~FileStreamReader() {
 	file.close();
 }
 
-void FileStreamReader::Read(void* buffer, size_t size) {
+void FileStreamReader::Read(void* buffer, std::size_t size) {
 	file.read(static_cast<char*>(buffer), size);
 }
 

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -11,7 +11,7 @@ public:
 
 	// StreamReader methods
 	~FileStreamReader() override;
-	void Read(void* buffer, size_t size) override;
+	void Read(void* buffer, std::size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Read(T& object) {

--- a/Streams/FileStreamWriter.cpp
+++ b/Streams/FileStreamWriter.cpp
@@ -14,7 +14,7 @@ FileStreamWriter::~FileStreamWriter() {
 	fileStream.close();
 }
 
-void FileStreamWriter::Write(const void* buffer, size_t size)
+void FileStreamWriter::Write(const void* buffer, std::size_t size)
 {
 	fileStream.write(static_cast<const char*>(buffer), size);
 }

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -12,7 +12,7 @@ public:
 
 	// StreamWriter methods
 	~FileStreamWriter() override;
-	void Write(const void* buffer, size_t size) override;
+	void Write(const void* buffer, std::size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Write(const T& object) {

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -3,13 +3,13 @@
 #include <cstring> //memcpy
 #include <stdexcept>
 
-MemoryStreamReader::MemoryStreamReader(void* buffer, size_t size) {
+MemoryStreamReader::MemoryStreamReader(void* buffer, std::size_t size) {
 	streamBuffer = static_cast<char*>(buffer);
 	streamSize = size;
 	position = 0;
 }
 
-void MemoryStreamReader::Read(void* buffer, size_t size)
+void MemoryStreamReader::Read(void* buffer, std::size_t size)
 {
 	if (position + size > streamSize) {
 		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");
@@ -32,7 +32,7 @@ void MemoryStreamReader::Seek(uint64_t position) {
 		throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 	}
 
-	// position is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of size_t)
+	// position is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
 	this->position = static_cast<size_t>(position);
 }
 
@@ -48,6 +48,6 @@ void MemoryStreamReader::SeekRelative(int64_t offset)
 		throw std::runtime_error("Change in offset puts read position outside bounds of buffer.");
 	}
 
-	// offset is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of size_t)
+	// offset is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
 	this->position += static_cast<size_t>(offset); 
 }

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -5,10 +5,10 @@
 
 class MemoryStreamReader : public SeekableStreamReader {
 public:
-	MemoryStreamReader(void* buffer, size_t size);
+	MemoryStreamReader(void* buffer, std::size_t size);
 
 	// StreamReader methods
-	void Read(void* buffer, size_t size) override;
+	void Read(void* buffer, std::size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Read(T& object) {

--- a/Streams/MemoryStreamWriter.cpp
+++ b/Streams/MemoryStreamWriter.cpp
@@ -2,14 +2,14 @@
 #include <cstring> //memcpy
 #include <stdexcept>
 
-MemoryStreamWriter::MemoryStreamWriter(void* buffer, size_t size)
+MemoryStreamWriter::MemoryStreamWriter(void* buffer, std::size_t size)
 {
 	streamBuffer = static_cast<char*>(buffer);
 	streamSize = size;
 	offset = 0;
 }
 
-void MemoryStreamWriter::Write(const void* buffer, size_t size)
+void MemoryStreamWriter::Write(const void* buffer, std::size_t size)
 {
 	if (offset + size > streamSize) {
 		throw std::runtime_error("Size of bytes to write exceeds remaining size of buffer.");

--- a/Streams/MemoryStreamWriter.h
+++ b/Streams/MemoryStreamWriter.h
@@ -8,10 +8,10 @@ class MemoryStreamWriter : public SeekableStreamWriter
 public:
 	// buffer: where data will be written to.
 	// size: Amount of space allocated in the buffer for writing into.
-	MemoryStreamWriter(void* buffer, size_t size);
+	MemoryStreamWriter(void* buffer, std::size_t size);
 
 	// StreamWriter methods
-	void Write(const void* buffer, size_t size) override;
+	void Write(const void* buffer, std::size_t size) override;
 
 	// Inline templated convenience methods, to easily read arbitrary data types
 	template<typename T> inline void Write(const T& object) {

--- a/Streams/StreamReader.h
+++ b/Streams/StreamReader.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 
 class StreamReader {
 public:
 	virtual ~StreamReader() = default;
-	virtual void Read(void* buffer, size_t size) = 0;
+	virtual void Read(void* buffer, std::size_t size) = 0;
 };

--- a/Streams/StreamWriter.h
+++ b/Streams/StreamWriter.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 
 class StreamWriter {
 public:
 	virtual ~StreamWriter() = default;
-	virtual void Write(const void* buffer, size_t size) = 0;
+	virtual void Write(const void* buffer, std::size_t size) = 0;
 };


### PR DESCRIPTION
Also works with MSVC without warnings

 - Add std namespace prefix to all size_t calls
 - Ensure all files containing size_t include a header that defines size_t
 - Add brackets to all single line if and for statements in VolFile.cpp
 - Use auto keyword where appropriate in loops