### PR TITLE
Update VolFile::CreateVolumeInfo Struct to use STL Containers

### DIFF
--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -347,7 +347,7 @@ namespace Archives
 		// Calculate offsets to the files
 		for (std::size_t i = 1; i < volInfo.fileCount(); i++)
 		{
-			IndexEntry previousIndex = volInfo.indexEntries[i - 1];
+			const IndexEntry& previousIndex = volInfo.indexEntries[i - 1];
 			volInfo.indexEntries[i].dataBlockOffset = (previousIndex.dataBlockOffset + previousIndex.fileSize + 11) & ~3;
 		}
 

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -55,9 +55,8 @@ namespace Archives
 
 		struct CreateVolumeInfo
 		{
-			IndexEntry *indexEntry;
-			int *fileNameLength;
-			HANDLE *fileHandle;
+			std::vector<IndexEntry> indexEntries;
+			std::vector<HANDLE> fileHandles;
 			std::vector<std::string> filesToPack;
 			std::vector<std::string> internalNames;
 			int stringTableLength;


### PR DESCRIPTION
 - Replace pointers to c-style arrays with std::vector
 - Remove member container int* fileNameLength
 - Update container names to be plural
 - Remove some no longer required memory management
 - Refactor VolFile::PrepareHeader