### PR TITLE
Move stream helper templates to base classes try2

### DIFF
--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -25,8 +25,9 @@ namespace Archives
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{
-			if (XFile::PathsAreEqual(GetInternalFileName(i), fileName))
+			if (XFile::PathsAreEqual(GetInternalFileName(i), fileName)) {
 				return true;
+			}
 		}
 
 		return false;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -21,7 +21,7 @@ namespace Archives
 	// Throws an error is problems encountered while reading the header.
 	void ClmFile::ReadHeader()
 	{
-		clmFileReader->Read(&clmHeader, sizeof(ClmHeader));
+		clmFileReader->Read(clmHeader);
 		
 		try {
 			clmHeader.VerifyFileVersion();
@@ -301,7 +301,7 @@ namespace Archives
 		do
 		{
 			// Read the tag
-			seekableStreamReader.Read(&header, sizeof(header));
+			seekableStreamReader.Read(header);
 			
 			// Check if this is the right header
 			if (header.formatTag == chunkTag) {

--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -65,7 +65,7 @@ namespace MapReader {
 
 		void ReadHeader(StreamReader& streamReader, MapData& mapData)
 		{
-			streamReader.Read(&mapData.header, sizeof(mapData.header));
+			streamReader.Read(mapData.header);
 		}
 
 		void ReadTiles(StreamReader& streamReader, MapData& mapData)
@@ -76,7 +76,7 @@ namespace MapReader {
 
 		void ReadClipRect(StreamReader& streamReader, ClipRect& clipRect)
 		{
-			streamReader.Read(&clipRect, sizeof(clipRect));
+			streamReader.Read(clipRect);
 		}
 
 		void ReadTilesetHeader(StreamReader& streamReader)
@@ -102,29 +102,29 @@ namespace MapReader {
 				}
 
 				if (mapData.tilesetSources[i].tilesetFilename.size() > 0) {
-					streamReader.Read(&mapData.tilesetSources[i].numTiles, sizeof(int));
+					streamReader.Read(mapData.tilesetSources[i].numTiles);
 				}
 			}
 		}
 
 		void ReadTileInfo(StreamReader& streamReader, MapData& mapData)
 		{
-			size_t numTileInfo;
-			streamReader.Read(&numTileInfo, sizeof(numTileInfo));
+			std::size_t numTileInfo;
+			streamReader.Read(numTileInfo);
 
 			mapData.tileInfos.resize(numTileInfo);
 			streamReader.Read(&mapData.tileInfos[0], numTileInfo * sizeof(TileInfo));
 
-			size_t numTerrainTypes;
-			streamReader.Read(&numTerrainTypes, sizeof(numTerrainTypes));
+			std::size_t numTerrainTypes;
+			streamReader.Read(numTerrainTypes);
 			mapData.terrainTypes.resize(numTerrainTypes);
 			streamReader.Read(&mapData.terrainTypes[0], numTerrainTypes * sizeof(TerrainType));
 		}
 
 		void ReadVersionTag(StreamReader& streamReader)
 		{
-			int versionTag;
-			streamReader.Read(&versionTag, sizeof(versionTag));
+			uint32_t versionTag;
+			streamReader.Read(versionTag);
 
 			if (versionTag < 0x1010)
 			{
@@ -134,11 +134,11 @@ namespace MapReader {
 
 		void ReadTileGroups(SeekableStreamReader& streamReader, MapData& mapData)
 		{
-			int numTileGroups;
-			streamReader.Read(&numTileGroups, sizeof(numTileGroups));
+			uint32_t numTileGroups;
+			streamReader.Read(numTileGroups);
 			streamReader.SeekRelative(4);
 
-			for (int i = 0; i < numTileGroups; ++i)
+			for (uint32_t i = 0; i < numTileGroups; ++i)
 			{
 				mapData.tileGroups.push_back(ReadTileGroup(streamReader));
 			}
@@ -148,13 +148,13 @@ namespace MapReader {
 		{
 			TileGroup tileGroup;
 
-			streamReader.Read(&tileGroup.tileWidth, sizeof(tileGroup.tileWidth));
-			streamReader.Read(&tileGroup.tileHeight, sizeof(tileGroup.tileHeight));
+			streamReader.Read(tileGroup.tileWidth);
+			streamReader.Read(tileGroup.tileHeight);
 
 			int mappingIndex;
 			for (int i = 0; i < tileGroup.tileHeight * tileGroup.tileWidth; ++i)
 			{
-				streamReader.Read(&mappingIndex, sizeof(mappingIndex));
+				streamReader.Read(mappingIndex);
 				tileGroup.mappingIndices.push_back(mappingIndex);
 			}
 
@@ -167,7 +167,7 @@ namespace MapReader {
 		std::string ReadString(StreamReader& streamReader)
 		{
 			uint32_t stringLength;
-			streamReader.Read(&stringLength, sizeof(stringLength));
+			streamReader.Read(stringLength);
 
 			std::string s;
 			s.resize(stringLength);

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -14,7 +14,7 @@ FileStreamReader::~FileStreamReader() {
 	file.close();
 }
 
-void FileStreamReader::Read(void* buffer, std::size_t size) {
+void FileStreamReader::ReadImplementation(void* buffer, std::size_t size) {
 	file.read(static_cast<char*>(buffer), size);
 }
 

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -8,21 +8,16 @@
 class FileStreamReader : public SeekableStreamReader {
 public:
 	FileStreamReader(std::string fileName);
-
-	// StreamReader methods
 	~FileStreamReader() override;
-	void Read(void* buffer, std::size_t size) override;
-
-	// Inline templated convenience methods, to easily read arbitrary data types
-	template<typename T> inline void Read(T& object) {
-		Read(&object, sizeof(object));
-	}
 
 	// SeekableStreamReader methods
 	uint64_t Length() override;
 	uint64_t Position() override;
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
+
+protected:
+	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
 	std::ifstream file;

--- a/Streams/FileStreamWriter.cpp
+++ b/Streams/FileStreamWriter.cpp
@@ -14,7 +14,7 @@ FileStreamWriter::~FileStreamWriter() {
 	fileStream.close();
 }
 
-void FileStreamWriter::Write(const void* buffer, std::size_t size)
+void FileStreamWriter::WriteImplementation(const void* buffer, std::size_t size)
 {
 	fileStream.write(static_cast<const char*>(buffer), size);
 }

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -9,21 +9,16 @@ class FileStreamWriter : public SeekableStreamWriter
 {
 public:
 	FileStreamWriter(const std::string& filename);
-
-	// StreamWriter methods
 	~FileStreamWriter() override;
-	void Write(const void* buffer, std::size_t size) override;
-
-	// Inline templated convenience methods, to easily read arbitrary data types
-	template<typename T> inline void Write(const T& object) {
-		Write(&object, sizeof(object));
-	}
 
 	// SeekableStreamWriter methods
 	uint64_t Length() override;
 	uint64_t Position() override;
 	void Seek(uint64_t offset) override;
 	void SeekRelative(int64_t offset) override;
+
+protected:
+	void WriteImplementation(const void* buffer, std::size_t size) override;
 
 private:
 	std::fstream fileStream;

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -9,7 +9,7 @@ MemoryStreamReader::MemoryStreamReader(void* buffer, std::size_t size) {
 	position = 0;
 }
 
-void MemoryStreamReader::Read(void* buffer, std::size_t size)
+void MemoryStreamReader::ReadImplementation(void* buffer, std::size_t size)
 {
 	if (position + size > streamSize) {
 		throw std::runtime_error("Size of bytes to read exceeds remaining size of buffer.");

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -7,19 +7,15 @@ class MemoryStreamReader : public SeekableStreamReader {
 public:
 	MemoryStreamReader(void* buffer, std::size_t size);
 
-	// StreamReader methods
-	void Read(void* buffer, std::size_t size) override;
-
-	// Inline templated convenience methods, to easily read arbitrary data types
-	template<typename T> inline void Read(T& object) {
-		Read(&object, sizeof(object));
-	}
-
 	// SeekableStreamReader methods
 	uint64_t Length() override;
 	uint64_t Position() override;
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
+
+protected:
+	// StreamReader methods
+	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
 	char* streamBuffer;

--- a/Streams/MemoryStreamWriter.cpp
+++ b/Streams/MemoryStreamWriter.cpp
@@ -9,7 +9,7 @@ MemoryStreamWriter::MemoryStreamWriter(void* buffer, std::size_t size)
 	offset = 0;
 }
 
-void MemoryStreamWriter::Write(const void* buffer, std::size_t size)
+void MemoryStreamWriter::WriteImplementation(const void* buffer, std::size_t size)
 {
 	if (offset + size > streamSize) {
 		throw std::runtime_error("Size of bytes to write exceeds remaining size of buffer.");

--- a/Streams/MemoryStreamWriter.h
+++ b/Streams/MemoryStreamWriter.h
@@ -10,19 +10,14 @@ public:
 	// size: Amount of space allocated in the buffer for writing into.
 	MemoryStreamWriter(void* buffer, std::size_t size);
 
-	// StreamWriter methods
-	void Write(const void* buffer, std::size_t size) override;
-
-	// Inline templated convenience methods, to easily read arbitrary data types
-	template<typename T> inline void Write(const T& object) {
-		Write(&object, sizeof(object));
-	}
-
 	// SeekableStreamWriter methods
 	uint64_t Length() override;
 	uint64_t Position() override;
 	void Seek(uint64_t offset) override;
 	void SeekRelative(int64_t offset) override;
+
+protected:
+	void WriteImplementation(const void* buffer, std::size_t size) override;
 
 private:
 	// Memory location to write data into.

--- a/Streams/StreamReader.h
+++ b/Streams/StreamReader.h
@@ -5,5 +5,18 @@
 class StreamReader {
 public:
 	virtual ~StreamReader() = default;
-	virtual void Read(void* buffer, std::size_t size) = 0;
+
+	inline void Read(void* buffer, std::size_t size) {
+		ReadImplementation(buffer, size);
+	}
+
+	// Inline templated convenience methods, to easily read arbitrary data types
+	template<typename T> inline void Read(T& object) {
+		ReadImplementation(&object, sizeof(object));
+	}
+
+protected:
+	// When creating child classes, override this function to implement new read functionality
+	// This function is required because to allow the base class to contain the Read template function.
+	virtual void ReadImplementation(void* buffer, std::size_t size) = 0;
 };

--- a/Streams/StreamWriter.h
+++ b/Streams/StreamWriter.h
@@ -5,5 +5,18 @@
 class StreamWriter {
 public:
 	virtual ~StreamWriter() = default;
-	virtual void Write(const void* buffer, std::size_t size) = 0;
+
+	inline void Write(const void* buffer, std::size_t size) {
+		WriteImplementation(buffer, size);
+	}
+
+	// Inline templated convenience methods, to easily write arbitrary data types
+	template<typename T> inline void Write(const T& object) {
+		WriteImplementation(&object, sizeof(object));
+	}
+
+protected:
+	// When creating child classes, override this function to implement new write functionality
+	// This function is required because to allow the base class to contain the Write template function.
+	virtual void WriteImplementation(const void* buffer, std::size_t size) = 0;
 };


### PR DESCRIPTION
**Move stream helper templates to base classes**

 - add a protected virtual Read/Write function to facilitate the template functions existing in the base classes without compilation errors.
 - Update ClmFile and MapReader to use new template.
 - Update some MapReader types to be fixed width
 - Add std namespace prefix to some size_t calls in MapReader.cpp
 - Add some fixed size variables to MapWriter.cpp
 - Refactor ranged based loops to use auto and const & where appropriate
 - Remove some range based loops when writing data

This resolves issue #38 