### PR TITLE
Fix Bugs When Reading and extracting from volume files

### DIFF
--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -3,13 +3,8 @@
 
 namespace Archives
 {
-	ArchiveUnpacker::ArchiveUnpacker(const std::string& fileName)
-	{
-		this->m_ArchiveFileName = fileName;
-
-		m_NumberOfPackedFiles = 0;
-		m_ArchiveFileSize = 0;
-	}
+	ArchiveUnpacker::ArchiveUnpacker(const std::string& fileName) : 
+		m_ArchiveFileName(fileName), m_NumberOfPackedFiles(0), m_ArchiveFileSize(0) { }
 
 	ArchiveUnpacker::~ArchiveUnpacker() { }
 

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -15,7 +15,7 @@ namespace Archives
 		virtual ~ArchiveUnpacker();
 
 		std::string GetVolumeFileName() { return m_ArchiveFileName; };
-		uint32_t GetVolumeFileSize() { return m_ArchiveFileSize; };
+		uint64_t GetVolumeFileSize() { return m_ArchiveFileSize; };
 		int GetNumberOfPackedFiles() { return m_NumberOfPackedFiles; };
 		bool ContainsFile(const char* fileName);
 
@@ -31,8 +31,8 @@ namespace Archives
 	protected:
 		void CheckPackedFileIndexBounds(int fileIndex);
 
-		std::string m_ArchiveFileName;
+		const std::string m_ArchiveFileName;
 		int m_NumberOfPackedFiles;
-		int m_ArchiveFileSize;
+		uint64_t m_ArchiveFileSize;
 	};
 }

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -167,7 +167,7 @@ namespace Archives
 			XFile::RenameFile(tempFileName, m_ArchiveFileName);
 			return true;
 		}
-		catch (std::exception& e) {
+		catch (std::exception&) {
 			return false;
 		}
 	}
@@ -189,7 +189,7 @@ namespace Archives
 				filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
 			}
 		}
-		catch (std::exception& e) {
+		catch (std::exception&) {
 			return false;
 		}
 
@@ -225,7 +225,7 @@ namespace Archives
 
 			WriteArchive(archiveFileName, filesToPackReaders, indexEntries, internalFileNames, waveFormat);
 		}
-		catch (std::exception& e) {
+		catch (std::exception&) {
 			return false; // Error writing CLM archive file
 		}
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -73,7 +73,7 @@ namespace Archives
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 		static WaveFormatEx CreateDefaultWaveFormat();
 
-		std::unique_ptr<SeekableStreamReader> clmFileReader;
+		FileStreamReader clmFileReader;
 		ClmHeader clmHeader;
 		std::vector<IndexEntry> indexEntries;
 	};

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -127,7 +127,7 @@ namespace Archives
 		{
 			SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 			
-			std::vector<void*> packedFileBuffer;
+			std::vector<uint8_t> packedFileBuffer;
 			packedFileBuffer.resize(sectionHeader.length);
 			archiveFileReader.Read(packedFileBuffer.data(), sectionHeader.length);
 
@@ -427,10 +427,15 @@ namespace Archives
 	// Returns true is the header structure is valid and false otherwise
 	void VolFile::ReadVolHeader()
 	{
+		// Make sure file is big enough to contain header tag
+		if (archiveFileReader.Length() < sizeof(SectionHeader)) {
+			throw std::runtime_error("The volume file " + m_ArchiveFileName + " is not large enough to contain the 'VOL ' section header");
+		}
+
 		m_HeaderLength = ReadTag(std::array<char, 4> { 'V', 'O', 'L', ' ' });
 
 		// Make sure the file is large enough to contain the header
-		if (archiveFileReader.Length() < m_HeaderLength + sizeof(SectionHeader) * 2) {
+		if (archiveFileReader.Length() < m_HeaderLength + sizeof(SectionHeader)) {
 			throw std::runtime_error("The volume file " + m_ArchiveFileName + " is not large enough to contain the volh section header");
 		}
 

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -52,6 +52,13 @@ namespace Archives
 			int32_t fileSize;
 			CompressionType compressionType;
 		};
+
+		struct SectionHeader
+		{
+			std::array<char, 4> tag;
+			uint32_t length : 31;
+			uint32_t padding : 1; // 0 = 4-byte boundary padding, 1 = 2-byte boundary padding
+		};
 #pragma pack(pop)
 
 		struct CreateVolumeInfo
@@ -83,6 +90,7 @@ namespace Archives
 		bool PrepareHeader(CreateVolumeInfo &volInfo);
 		bool OpenAllInputFiles(CreateVolumeInfo &volInfo);
 		void CleanUpVolumeCreate(CreateVolumeInfo &volInfo);
+		SectionHeader GetSectionHeader(int index);
 
 		std::unique_ptr<SeekableStreamReader> archiveFileReader;
 		uint32_t m_NumberOfIndexEntries;

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -80,7 +80,7 @@ namespace Archives
 
 		uint32_t ReadTag(const std::array<char, 4>& tagName);
 		void WriteTag(StreamWriter& volWriter, uint32_t length, const char *tagText);
-		void CopyFileIntoVolume(StreamWriter& volWriter, HANDLE inputFile, int32_t size);
+		void CopyFileIntoVolume(StreamWriter& volWriter, HANDLE inputFile);
 		void ReadVolHeader();
 		void ReadStringTable();
 		void ReadPackedFileCount();
@@ -92,9 +92,8 @@ namespace Archives
 		void CleanUpVolumeCreate(CreateVolumeInfo &volInfo);
 		SectionHeader GetSectionHeader(int index);
 
-		std::unique_ptr<SeekableStreamReader> archiveFileReader;
+		FileStreamReader archiveFileReader;
 		uint32_t m_NumberOfIndexEntries;
-		//char *m_StringTable;
 		std::vector<std::string> m_StringTable;
 		uint32_t m_HeaderLength;
 		uint32_t m_StringTableLength;

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -74,7 +74,7 @@ namespace Archives
 		uint32_t ReadTag(const std::array<char, 4>& tagName);
 		void WriteTag(StreamWriter& volWriter, uint32_t length, const char *tagText);
 		void CopyFileIntoVolume(StreamWriter& volWriter, HANDLE inputFile, int32_t size);
-		bool ReadVolHeader();
+		void ReadVolHeader();
 		void ReadStringTable();
 		void ReadPackedFileCount();
 		void WriteVolume(const std::string& fileName, const CreateVolumeInfo& volInfo);

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -148,11 +148,13 @@
     <ClCompile Include="Archives\ClmFile.cpp" />
     <ClCompile Include="Archives\HuffLZ.cpp" />
     <ClCompile Include="Archives\VolFile.cpp" />
+    <ClCompile Include="Streams\FileSliceReader.cpp" />
     <ClCompile Include="Streams\FileStreamReader.cpp" />
     <ClCompile Include="Streams\FileStreamWriter.cpp" />
     <ClCompile Include="Streams\MemoryStreamWriter.cpp" />
     <ClCompile Include="Streams\MemoryStreamReader.cpp" />
     <ClInclude Include="OP2Utility.h" />
+    <ClInclude Include="Streams\FileSliceReader.h" />
     <ClInclude Include="Streams\FileStreamReader.h" />
     <ClInclude Include="Streams\FileStreamWriter.h" />
     <ClInclude Include="Streams\MemoryStreamReader.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClInclude Include="Streams\MemoryStreamReader.h">
       <Filter>Streams</Filter>
     </ClInclude>
+    <ClInclude Include="Streams\FileSliceReader.h">
+      <Filter>Streams</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="XFile.cpp">
@@ -174,6 +177,9 @@
       <Filter>Streams</Filter>
     </ClCompile>
     <ClCompile Include="Streams\MemoryStreamReader.cpp">
+      <Filter>Streams</Filter>
+    </ClCompile>
+    <ClCompile Include="Streams\FileSliceReader.cpp">
       <Filter>Streams</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Streams/FileSliceReader.cpp
+++ b/Streams/FileSliceReader.cpp
@@ -1,0 +1,62 @@
+#include "FileSliceReader.h"
+#include <stdexcept>
+
+FileSliceReader::FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength) : fileStreamReader(filename)
+{
+	if (startingOffset + sliceLength < startingOffset) {
+		throw std::runtime_error("The supplied starting offset & length cause the ending offset to wrap past the largest allowed value in the FileSliceReader created on file " + 
+			fileStreamReader.GetFilename());
+	}
+
+	this->startingOffset = startingOffset;
+	this->sliceLength = sliceLength;
+
+	if (startingOffset + sliceLength > fileStreamReader.Length()) {
+		throw std::runtime_error("The ending offset of the FileSliceReader created on " + 
+			fileStreamReader.GetFilename() + "is greater than the file's length");
+	}
+
+	fileStreamReader.Seek(startingOffset);
+}
+
+void FileSliceReader::ReadImplementation(void* buffer, std::size_t size) 
+{
+	if (fileStreamReader.Position() + size > startingOffset + sliceLength) {
+		throw std::runtime_error("File Read request would place the position of the FileSliceReader outside the ending offset of file " + 
+			fileStreamReader.GetFilename());
+	}
+
+	fileStreamReader.Read(buffer, size);
+}
+
+uint64_t FileSliceReader::Length()
+{
+	return sliceLength;
+}
+	
+uint64_t FileSliceReader::Position() 
+{
+	return fileStreamReader.Position() - startingOffset;
+}
+
+void FileSliceReader::Seek(uint64_t position)
+{
+	if (position > sliceLength) {
+		throw std::runtime_error("An absolute offset of " + std::to_string(position) + 
+			" would place the position of the FileSliceReader outside the ending offset of file " + fileStreamReader.GetFilename());
+	}
+
+	fileStreamReader.Seek(startingOffset + position);
+}
+
+void FileSliceReader::SeekRelative(int64_t offset)
+{
+	if (Position() + offset < startingOffset ||
+		Position() + offset > startingOffset + sliceLength)
+	{
+		throw std::runtime_error("A relative offset of " + std::to_string(offset) + 
+			" would place the position of the FileSliceReader outside the slice bounds of file " + fileStreamReader.GetFilename());
+	}
+
+	fileStreamReader.SeekRelative(offset);
+}

--- a/Streams/FileSliceReader.cpp
+++ b/Streams/FileSliceReader.cpp
@@ -1,15 +1,13 @@
 #include "FileSliceReader.h"
 #include <stdexcept>
 
-FileSliceReader::FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength) : fileStreamReader(filename)
+FileSliceReader::FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength) : 
+	fileStreamReader(filename), startingOffset(startingOffset), sliceLength(sliceLength)
 {
 	if (startingOffset + sliceLength < startingOffset) {
 		throw std::runtime_error("The supplied starting offset & length cause the ending offset to wrap past the largest allowed value in the FileSliceReader created on file " + 
 			fileStreamReader.GetFilename());
 	}
-
-	this->startingOffset = startingOffset;
-	this->sliceLength = sliceLength;
 
 	if (startingOffset + sliceLength > fileStreamReader.Length()) {
 		throw std::runtime_error("The ending offset of the FileSliceReader created on " + 

--- a/Streams/FileSliceReader.h
+++ b/Streams/FileSliceReader.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "FileStreamReader.h"
+#include <cstddef>
+#include <string>
+
+class FileSliceReader : public SeekableStreamReader
+{
+public:
+	FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength);
+
+	uint64_t Length() override;
+	uint64_t Position() override;
+	void Seek(uint64_t position) override;
+	void SeekRelative(int64_t offset) override;
+
+protected:
+	void ReadImplementation(void* buffer, std::size_t size) override;
+
+private:
+	FileStreamReader fileStreamReader;
+	uint64_t startingOffset;
+	uint64_t sliceLength;
+};

--- a/Streams/FileSliceReader.h
+++ b/Streams/FileSliceReader.h
@@ -17,7 +17,7 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	inline std::string GetFilename() const {
+	inline const std::string& GetFilename() const {
 		return fileStreamReader.GetFilename();
 	}
 

--- a/Streams/FileSliceReader.h
+++ b/Streams/FileSliceReader.h
@@ -1,24 +1,31 @@
 #pragma once
 
 #include "FileStreamReader.h"
-#include <cstddef>
 #include <string>
+#include <cstddef>
+#include <cstdint>
 
+// Opens a new file stream that is limited to reading from the provided file slice. 
 class FileSliceReader : public SeekableStreamReader
 {
 public:
 	FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength);
 
+	// SeekableStreamReader methods
 	uint64_t Length() override;
 	uint64_t Position() override;
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
+
+	inline std::string GetFilename() const {
+		return fileStreamReader.GetFilename();
+	}
 
 protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
 	FileStreamReader fileStreamReader;
-	uint64_t startingOffset;
-	uint64_t sliceLength;
+	const uint64_t startingOffset;
+	const uint64_t sliceLength;
 };

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -2,9 +2,9 @@
 #include <stdexcept>
 
 // Defers calls to C++ standard library methods
-FileStreamReader::FileStreamReader(std::string filename) {
+FileStreamReader::FileStreamReader(std::string filename) : filename(filename)
+{
 	file = std::ifstream(filename, std::ios::in | std::ios::binary);
-	this->filename = filename;
 
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -4,6 +4,7 @@
 // Defers calls to C++ standard library methods
 FileStreamReader::FileStreamReader(std::string filename) {
 	file = std::ifstream(filename, std::ios::in | std::ios::binary);
+	this->filename = filename;
 
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -17,7 +17,7 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	inline std::string GetFilename() const {
+	inline const std::string& GetFilename() const {
 		return filename;
 	}
 

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -16,9 +16,14 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
+	inline std::string GetFilename() const {
+		return filename;
+	}
+
 protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
 	std::ifstream file;
+	std::string filename;
 };

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -3,6 +3,7 @@
 #include "SeekableStreamReader.h"
 #include <string>
 #include <fstream>
+#include <cstddef>
 #include <cstdint>
 
 class FileStreamReader : public SeekableStreamReader {
@@ -25,5 +26,5 @@ protected:
 
 private:
 	std::ifstream file;
-	std::string filename;
+	const std::string filename;
 };

--- a/Streams/FileStreamWriter.cpp
+++ b/Streams/FileStreamWriter.cpp
@@ -1,7 +1,7 @@
 #include "FileStreamWriter.h"
 #include <stdexcept>
 
-FileStreamWriter::FileStreamWriter(const std::string& filename)
+FileStreamWriter::FileStreamWriter(const std::string& filename) : filename(filename)
 {
 	fileStream.open(filename.c_str(), std::ios::trunc | std::ios::out | std::ios::binary);
 

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "SeekableStreamWriter.h"
-#include <fstream>
 #include <string>
+#include <fstream>
+#include <cstddef>
 #include <cstdint>
 
 class FileStreamWriter : public SeekableStreamWriter
@@ -17,9 +18,14 @@ public:
 	void Seek(uint64_t offset) override;
 	void SeekRelative(int64_t offset) override;
 
+	inline std::string GetFilename() const {
+		return filename;
+	}
+
 protected:
 	void WriteImplementation(const void* buffer, std::size_t size) override;
 
 private:
 	std::fstream fileStream;
+	const std::string filename;
 };

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -18,7 +18,7 @@ public:
 	void Seek(uint64_t offset) override;
 	void SeekRelative(int64_t offset) override;
 
-	inline std::string GetFilename() const {
+	inline const std::string& GetFilename() const {
 		return filename;
 	}
 


### PR DESCRIPTION
A bug remains when attempting to extract a file or open a memory stream to a file's location in a volume.

 - Account for difference in padding and actual size of volume header StringTable
 - Improve error messaging when reading a volume header into memory
 - Remove name of exception when an exception is caught but the exception is not referenced in Archive code.