### PR TITLE
Improve section tag constants in archives

### DIFF
--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -113,16 +113,16 @@ namespace Archives
 
 	void ClmFile::InitializeWaveHeader(WaveHeader& headerOut, int fileIndex)
 	{
-		headerOut.riffHeader.riffTag = RIFF;
-		headerOut.riffHeader.waveTag = WAVE;
+		headerOut.riffHeader.riffTag = tagRIFF;
+		headerOut.riffHeader.waveTag = tagWAVE;
 		headerOut.riffHeader.chunkSize = sizeof(headerOut.riffHeader.waveTag) + sizeof(FormatChunk) + sizeof(ChunkHeader) + indexEntries[fileIndex].dataLength;
 
-		headerOut.formatChunk.fmtTag = FMT;
+		headerOut.formatChunk.fmtTag = tagFMT_;
 		headerOut.formatChunk.formatSize = sizeof(headerOut.formatChunk.waveFormat);
 		headerOut.formatChunk.waveFormat = clmHeader.waveFormat;
 		headerOut.formatChunk.waveFormat.cbSize = 0;
 
-		headerOut.dataChunk.formatTag = DATA;
+		headerOut.dataChunk.formatTag = tagDATA;
 		headerOut.dataChunk.length = indexEntries[fileIndex].dataLength;
 	}
 
@@ -248,7 +248,7 @@ namespace Archives
 		{
 			// Read the file header
 			filesToPackReaders[i]->Read(header);
-			if (header.riffTag != RIFF || header.waveTag != WAVE) {
+			if (header.riffTag != tagRIFF || header.waveTag != tagWAVE) {
 				return false;		// Error reading header
 			}
 
@@ -258,7 +258,7 @@ namespace Archives
 			}
 
 			// Read the format tag
-			int fmtChunkLength = FindChunk(FMT, *filesToPackReaders[i]);
+			int fmtChunkLength = FindChunk(tagFMT_, *filesToPackReaders[i]);
 			if (fmtChunkLength == -1) {
 				return false;		// Format chunk not found
 			}
@@ -268,7 +268,7 @@ namespace Archives
 			waveFormats[i].cbSize = 0;
 
 			// Find the start of the data
-			int dataChunkLength = FindChunk(DATA, *filesToPackReaders[i]);
+			int dataChunkLength = FindChunk(tagDATA, *filesToPackReaders[i]);
 			if (dataChunkLength == -1) {
 				return false;		// Data chunk not found
 			}
@@ -284,7 +284,7 @@ namespace Archives
 	// Searches through the wave file to find the given chunk length
 	// The current stream position is set the the first byte after the chunk header
 	// Returns the chunk length if found or -1 otherwise
-	int ClmFile::FindChunk(uint32_t chunkTag, SeekableStreamReader& seekableStreamReader)
+	int ClmFile::FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader)
 	{
 		uint64_t fileSize = seekableStreamReader.Length();
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -63,7 +63,7 @@ namespace Archives
 
 		// Private functions for packing files
 		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
-		int FindChunk(uint32_t chunkTag, SeekableStreamReader& seekableStreamReader);
+		int FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
 		static bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
 		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -19,8 +19,6 @@ namespace Archives
 
 	VolFile::VolFile(const char *fileName) : ArchiveFile(fileName), archiveFileReader(fileName)
 	{
-		static_assert(sizeof(SectionHeader) == 8, "SectionHeader not of required size");
-
 		m_ArchiveFileSize = archiveFileReader.Length();
 
 		ReadVolHeader();

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -9,6 +9,14 @@
 
 namespace Archives
 {
+	// Volume section header tags
+	const std::array<char, 4> TagVOL_{ 'V', 'O', 'L', ' ' }; // Volume file tag
+	const std::array<char, 4> TagVOLH{ 'v', 'o', 'l', 'h' }; // Header tag
+	const std::array<char, 4> TagVOLS{ 'v', 'o', 'l', 's' }; // Filename table tag
+	const std::array<char, 4> TagVOLI{ 'v', 'o', 'l', 'i' }; // Index table tag
+	const std::array<char, 4> TagVBLK{ 'V', 'B', 'L', 'K' }; // Packed file tag
+
+
 	VolFile::VolFile(const char *fileName) : ArchiveFile(fileName), archiveFileReader(fileName)
 	{
 		m_ArchiveFileSize = archiveFileReader.Length();
@@ -95,7 +103,7 @@ namespace Archives
 		archiveFileReader.Read(sectionHeader);
 
 		//Volume Block
-		if (sectionHeader.tag != std::array<char, 4>{'V', 'B', 'L', 'K'}) {
+		if (sectionHeader.tag != TagVBLK) {
 			throw std::runtime_error("Archive file " + m_ArchiveFileName +
 				" is missing VBLK tag for requested file at index " + std::to_string(index));
 		}
@@ -245,7 +253,7 @@ namespace Archives
 		// Write each file header and contents
 		for (std::size_t i = 0; i < volInfo.fileCount(); i++)
 		{
-			WriteTag(volWriter, volInfo.indexEntries[i].fileSize, "VBLK");
+			WriteTag(volWriter, volInfo.indexEntries[i].fileSize, TagVBLK);
 
 			try {
 				CopyFileIntoVolume(volWriter, volInfo.fileHandles[i]);
@@ -264,12 +272,13 @@ namespace Archives
 	void VolFile::WriteHeader(StreamWriter& volWriter, const CreateVolumeInfo &volInfo)
 	{
 		// Write the header
-		WriteTag(volWriter, volInfo.paddedStringTableLength + volInfo.paddedIndexTableLength + 24, "VOL ");
+		WriteTag(volWriter, volInfo.paddedStringTableLength + volInfo.paddedIndexTableLength + 24, TagVOL_);
 
-		WriteTag(volWriter, 0, "volh");
+		WriteTag(volWriter, 0, TagVOLH);
+		//WriteTag(volWriter, 0, "volh");
 
 		// Write the string table
-		WriteTag(volWriter, volInfo.paddedStringTableLength, "vols");
+		WriteTag(volWriter, volInfo.paddedStringTableLength, TagVOLS);
 
 		volWriter.Write(&volInfo.stringTableLength, sizeof(volInfo.stringTableLength));
 
@@ -283,7 +292,7 @@ namespace Archives
 		volWriter.Write(&padding, volInfo.paddedStringTableLength - (volInfo.stringTableLength + 4));
 
 		// Write the index table
-		WriteTag(volWriter, volInfo.indexTableLength, "voli");
+		WriteTag(volWriter, volInfo.indexTableLength, TagVOLI);
 
 		volWriter.Write(volInfo.indexEntries.data(), volInfo.indexTableLength);
 
@@ -378,49 +387,37 @@ namespace Archives
 	}
 
 	// Writes a section tag to the open output file.
-	void VolFile::WriteTag(StreamWriter& volWriter, uint32_t length, const char *tagText)
+	void VolFile::WriteTag(StreamWriter& volWriter, uint32_t length, const std::array<char, 4>& tagName)
 	{
-		int buffer[2];
-
-		buffer[0] = *(int*)tagText;
-		// Set padding bit to indicate 4 byte padding
-		buffer[1] = length | 0x80000000;
+		SectionHeader sectionHeader(tagName, length);
 
 		try {
-			volWriter.Write(buffer, sizeof(buffer));
+			volWriter.Write(sectionHeader);
 		}
 		catch (std::exception& e) {
-			throw std::runtime_error("Unable to write tag " + std::string(tagText) + ". Internal Error: " + e.what());
+			throw std::runtime_error("Unable to write tag " + std::string(tagName.data(), tagName.size()) + ". Internal Error: " + e.what());
 		}
 	}
 
-
 	// Reads a tag in the .vol file and returns the length of that section.
-	// If tagText does not match what is in the file or if the length is 
-	// invalid then an error is thrown.
+	// If tag does not match what is in the file or if the length is invalid then an error is thrown.
 	uint32_t VolFile::ReadTag(const std::array<char, 4>& tagName)
 	{
-		// Tags are 4 chars in length and do not include a null terminator
-		std::array<char, 4> tagFromFile;
-		archiveFileReader.Read(tagFromFile);
+		SectionHeader tag;
+		archiveFileReader.Read(tag);
 
-		if (tagFromFile != tagName) {
+		if (tag.tag != tagName) {
 			throw std::runtime_error("The tag " + std::string(tagName.data(), tagName.size()) + 
 				" was not found in the proper position in volume " + m_ArchiveFileName);
 		}
 
-		uint32_t length = 0;
-		archiveFileReader.Read(&length, sizeof(length));
-
-		// Check for the tag (MSB set)
-		if ((length & 0x80000000) != 0x80000000) {
+		if (tag.padding == VolPadding::TwoByte) {
 			throw std::runtime_error("The tag " + std::string(tagName.data(), tagName.size()) + 
 				" from volume " + m_ArchiveFileName + 
 				" uses 2 byte padding, which is not supported. Only 4 byte padding is supported.");
 		}
 
-		// Mask out the tag and return the length.
-		return length & 0x7FFFFFFF;					
+		return tag.length;
 	}
 
 	// Reads the header structure of the .vol file and sets up indexing/structure variables
@@ -432,19 +429,19 @@ namespace Archives
 			throw std::runtime_error("The volume file " + m_ArchiveFileName + " is not large enough to contain the 'VOL ' section header");
 		}
 
-		m_HeaderLength = ReadTag(std::array<char, 4> { 'V', 'O', 'L', ' ' });
+		m_HeaderLength = ReadTag(TagVOL_);
 
 		// Make sure the file is large enough to contain the header
 		if (archiveFileReader.Length() < m_HeaderLength + sizeof(SectionHeader)) {
 			throw std::runtime_error("The volume file " + m_ArchiveFileName + " is not large enough to contain the volh section header");
 		}
 
-		uint32_t volhSize = ReadTag(std::array<char, 4> { 'v', 'o', 'l', 'h' });
+		uint32_t volhSize = ReadTag(TagVOLH);
 		if (volhSize != 0) {
 			throw std::runtime_error("The length associated with tag volh is not zero in volume " + m_ArchiveFileName);
 		}
 
-		m_StringTableLength = ReadTag(std::array<char, 4> { 'v', 'o', 'l', 's' });
+		m_StringTableLength = ReadTag(TagVOLS);
 
 		if (m_HeaderLength < m_StringTableLength + sizeof(SectionHeader) * 2 + sizeof(m_StringTableLength)) {
 			throw std::runtime_error("The string table does not fit in the header of volume " + m_ArchiveFileName);
@@ -452,7 +449,7 @@ namespace Archives
 
 		ReadStringTable();
 
-		m_IndexTableLength = ReadTag(std::array<char, 4> { 'v', 'o', 'l', 'i' });
+		m_IndexTableLength = ReadTag(TagVOLI);
 		m_NumberOfIndexEntries = m_IndexTableLength / sizeof(IndexEntry);
 
 		if (m_IndexTableLength > 0) {
@@ -506,4 +503,8 @@ namespace Archives
 		}
 		m_NumberOfPackedFiles = packedFileCount;
 	}
+
+	VolFile::SectionHeader::SectionHeader() {}
+	VolFile::SectionHeader::SectionHeader(std::array<char, 4> tag, uint32_t length, VolPadding padding) 
+		: tag(tag), length(length), padding(padding) {}
 }

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -57,7 +57,8 @@ namespace Archives
 		enum class VolPadding : uint32_t
 		{
 			TwoByte = 0,
-			FourByte = 1 // Default value
+			FourByte = 1,
+			default = FourByte
 		};
 
 		struct SectionHeader
@@ -87,9 +88,7 @@ namespace Archives
 			}
 		};
 
-		uint32_t ReadTag(const std::array<char, 4>& tagName);
-		//void WriteTag(StreamWriter& volWriter, uint32_t length, const char *tagText);
-		void VolFile::WriteTag(StreamWriter& volWriter, uint32_t length, const std::array<char, 4>& tagName);
+		uint32_t ReadTag(std::array<char, 4> tagName);
 		void CopyFileIntoVolume(StreamWriter& volWriter, HANDLE inputFile);
 		void ReadVolHeader();
 		void ReadStringTable();

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -57,8 +57,7 @@ namespace Archives
 		enum class VolPadding : uint32_t
 		{
 			TwoByte = 0,
-			FourByte = 1,
-			default = FourByte
+			FourByte = 1
 		};
 
 		struct SectionHeader
@@ -70,6 +69,8 @@ namespace Archives
 			VolPadding padding : 1;
 		};
 #pragma pack(pop)
+
+		static_assert(sizeof(SectionHeader) == 8, "SectionHeader not of required size");
 
 		struct CreateVolumeInfo
 		{

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -53,11 +53,20 @@ namespace Archives
 			CompressionType compressionType;
 		};
 
+		// Specify boundary padding for a volume file section
+		enum class VolPadding : uint32_t
+		{
+			TwoByte = 0,
+			FourByte = 1 // Default value
+		};
+
 		struct SectionHeader
 		{
+			SectionHeader();
+			SectionHeader(std::array<char, 4> tag, uint32_t length, VolPadding padding = VolPadding::FourByte);
 			std::array<char, 4> tag;
 			uint32_t length : 31;
-			uint32_t padding : 1; // 0 = 4-byte boundary padding, 1 = 2-byte boundary padding
+			VolPadding padding : 1;
 		};
 #pragma pack(pop)
 
@@ -79,7 +88,8 @@ namespace Archives
 		};
 
 		uint32_t ReadTag(const std::array<char, 4>& tagName);
-		void WriteTag(StreamWriter& volWriter, uint32_t length, const char *tagText);
+		//void WriteTag(StreamWriter& volWriter, uint32_t length, const char *tagText);
+		void VolFile::WriteTag(StreamWriter& volWriter, uint32_t length, const std::array<char, 4>& tagName);
 		void CopyFileIntoVolume(StreamWriter& volWriter, HANDLE inputFile);
 		void ReadVolHeader();
 		void ReadStringTable();

--- a/Archives/WaveFile.h
+++ b/Archives/WaveFile.h
@@ -1,13 +1,14 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 
 namespace Archives
 {
-	const uint32_t RIFF = 0x46464952;	// "RIFF" Resource Interchange File Format
-	const uint32_t WAVE = 0x45564157;	// "WAVE"
-	const uint32_t FMT = 0x20746D66;	// "fmt "
-	const uint32_t DATA = 0x61746164;	// "data"
+	const std::array<char, 4> tagRIFF{ 'R', 'I', 'F', 'F' };
+	const std::array<char, 4> tagWAVE{ 'W', 'A', 'V', 'E' };
+	const std::array<char, 4> tagFMT_{ 'f', 'm', 't', ' ' };
+	const std::array<char, 4> tagDATA{ 'd', 'a', 't', 'a' };
 
 #pragma pack(push, 1)
 
@@ -29,21 +30,21 @@ namespace Archives
 
 	struct RiffHeader
 	{
-		int32_t riffTag;
+		std::array<char, 4> riffTag;
 		uint32_t chunkSize;
-		int32_t waveTag;
+		std::array<char, 4> waveTag;
 	};
 
 	struct FormatChunk
 	{
-		uint32_t fmtTag;
+		std::array<char, 4> fmtTag;
 		uint32_t formatSize;
 		WaveFormatEx waveFormat;
 	};
 
 	struct ChunkHeader
 	{
-		uint32_t formatTag;
+		std::array<char, 4> formatTag;
 		uint32_t length;
 	};
 


### PR DESCRIPTION
See commit messages for details. This should close out issue #58. 

Tested by listing contents of a volume, and packing a new clm file.