### PR TITLE
Improve stream classes member variable initialization

### DIFF
--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -2,10 +2,9 @@
 #include <stdexcept>
 
 // Defers calls to C++ standard library methods
-FileStreamReader::FileStreamReader(std::string filename) : filename(filename)
+FileStreamReader::FileStreamReader(std::string filename) : 
+	filename(filename), file(filename, std::ios::in | std::ios::binary)
 {
-	file = std::ifstream(filename, std::ios::in | std::ios::binary);
-
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);
 	}

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -30,7 +30,7 @@ void MemoryStreamReader::Seek(uint64_t position) {
 	}
 
 	// position is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
-	this->position = static_cast<size_t>(position);
+	this->position = static_cast<std::size_t>(position);
 }
 
 void MemoryStreamReader::SeekRelative(int64_t offset)
@@ -46,5 +46,5 @@ void MemoryStreamReader::SeekRelative(int64_t offset)
 	}
 
 	// offset is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
-	this->position += static_cast<size_t>(offset); 
+	this->position += static_cast<std::size_t>(offset); 
 }

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -3,11 +3,8 @@
 #include <cstring> //memcpy
 #include <stdexcept>
 
-MemoryStreamReader::MemoryStreamReader(void* buffer, std::size_t size) {
-	streamBuffer = static_cast<char*>(buffer);
-	streamSize = size;
-	position = 0;
-}
+MemoryStreamReader::MemoryStreamReader(void* buffer, std::size_t size) : 
+	streamBuffer(static_cast<char*>(buffer)), streamSize(size), position(0) { }
 
 void MemoryStreamReader::ReadImplementation(void* buffer, std::size_t size)
 {

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -18,7 +18,7 @@ protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
-	char* streamBuffer;
-	size_t streamSize;
+	const char* streamBuffer;
+	const size_t streamSize;
 	size_t position;
 };

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SeekableStreamReader.h"
+#include <cstddef>
 #include <cstdint>
 
 class MemoryStreamReader : public SeekableStreamReader {
@@ -19,6 +20,6 @@ protected:
 
 private:
 	const char* streamBuffer;
-	const size_t streamSize;
-	size_t position;
+	const std::size_t streamSize;
+	std::size_t position;
 };

--- a/Streams/MemoryStreamWriter.cpp
+++ b/Streams/MemoryStreamWriter.cpp
@@ -2,12 +2,8 @@
 #include <cstring> //memcpy
 #include <stdexcept>
 
-MemoryStreamWriter::MemoryStreamWriter(void* buffer, std::size_t size)
-{
-	streamBuffer = static_cast<char*>(buffer);
-	streamSize = size;
-	offset = 0;
-}
+MemoryStreamWriter::MemoryStreamWriter(void* buffer, std::size_t size) :
+	streamBuffer(static_cast<char*>(buffer)), streamSize(size), offset(0) { }
 
 void MemoryStreamWriter::WriteImplementation(const void* buffer, std::size_t size)
 {

--- a/Streams/MemoryStreamWriter.cpp
+++ b/Streams/MemoryStreamWriter.cpp
@@ -33,7 +33,7 @@ void MemoryStreamWriter::Seek(uint64_t offset)
 		throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 	}
 
-	this->offset = static_cast<size_t>(offset);
+	this->offset = static_cast<std::size_t>(offset);
 }
 
 void MemoryStreamWriter::SeekRelative(int64_t offset)

--- a/Streams/MemoryStreamWriter.h
+++ b/Streams/MemoryStreamWriter.h
@@ -24,7 +24,7 @@ private:
 	char* streamBuffer;
 
 	// Size of the provided streamBuffer.
-	size_t streamSize;
+	const size_t streamSize;
 
 	// Current location in the streamBuffer.
 	size_t offset;

--- a/Streams/MemoryStreamWriter.h
+++ b/Streams/MemoryStreamWriter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "SeekableStreamWriter.h"
+#include <cstddef>
 #include <cstdint>
 
 class MemoryStreamWriter : public SeekableStreamWriter
@@ -24,8 +25,8 @@ private:
 	char* streamBuffer;
 
 	// Size of the provided streamBuffer.
-	const size_t streamSize;
+	const std::size_t streamSize;
 
 	// Current location in the streamBuffer.
-	size_t offset;
+	std::size_t offset;
 };


### PR DESCRIPTION
This should improve error checking in case we ever try to set what should be a const variable after initialization. I'm not sure, but there may be some minor efficiency gains by using const and constructor initialization.

Also took this opportunity to standardize use of size_t in stream code.