### PR TITLE
Refactor MapReader/Writer

### DIFF
--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -19,6 +19,8 @@ namespace MapReader {
 		void ReadTileGroups(SeekableStreamReader& streamReader, MapData& mapData);
 		TileGroup ReadTileGroup(StreamReader& streamReader);
 		std::string ReadString(StreamReader& streamReader);
+
+		const std::array<char, 10> tilesetHeader{ "TILE SET\x1a" };
 	}
 
 
@@ -73,7 +75,7 @@ namespace MapReader {
 			std::array<char, 10> buffer;
 			streamReader.Read(buffer);
 
-			if (buffer != std::array<char, 10>{ "TILE SET\x1a" }) {
+			if (buffer != tilesetHeader) {
 				throw std::runtime_error("'TILE SET' string not found.");
 			}
 		}

--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <array>
 #include <cstring>
 
 
@@ -10,9 +11,7 @@ namespace MapReader {
 	// Anonymous namespace to hold private methods
 	namespace {
 		void SkipSaveGameHeader(SeekableStreamReader& streamReader);
-		void ReadHeader(StreamReader& streamReader, MapData& mapData);
 		void ReadTiles(StreamReader& streamReader, MapData& mapData);
-		void ReadClipRect(StreamReader& streamReader, ClipRect& clipRect);
 		void ReadTilesetSources(StreamReader& streamReader, MapData& mapData);
 		void ReadTilesetHeader(StreamReader& streamReader);
 		void ReadTileInfo(StreamReader& streamReader, MapData& mapData);
@@ -40,9 +39,9 @@ namespace MapReader {
 			SkipSaveGameHeader(streamReader);
 		}
 
-		ReadHeader(streamReader, mapData);
+		streamReader.Read(mapData.header);
 		ReadTiles(streamReader, mapData);
-		ReadClipRect(streamReader, mapData.clipRect);
+		streamReader.Read(mapData.clipRect);
 		ReadTilesetSources(streamReader, mapData);
 		ReadTilesetHeader(streamReader);
 		ReadTileInfo(streamReader, mapData);
@@ -63,28 +62,18 @@ namespace MapReader {
 			streamReader.SeekRelative(0x1E025);
 		}
 
-		void ReadHeader(StreamReader& streamReader, MapData& mapData)
-		{
-			streamReader.Read(mapData.header);
-		}
-
 		void ReadTiles(StreamReader& streamReader, MapData& mapData)
 		{
 			mapData.tiles.resize(mapData.header.TileCount());
 			streamReader.Read(&mapData.tiles[0], mapData.tiles.size() * sizeof(TileData));
 		}
 
-		void ReadClipRect(StreamReader& streamReader, ClipRect& clipRect)
-		{
-			streamReader.Read(clipRect);
-		}
-
 		void ReadTilesetHeader(StreamReader& streamReader)
 		{
-			char buffer[10];
-			streamReader.Read(buffer, sizeof(buffer));
+			std::array<char, 10> buffer;
+			streamReader.Read(buffer);
 
-			if (std::strncmp(buffer, "TILE SET\x1a", sizeof(buffer))) {
+			if (buffer != std::array<char, 10>{ "TILE SET\x1a" }) {
 				throw std::runtime_error("'TILE SET' string not found.");
 			}
 		}


### PR DESCRIPTION
 - Remove single line functions from both files
 - Switch from using a c-style array to a std::array in function ReadTilesetHeader
 - When Reading/Writing containers, standardize placing size() before sizeof(X)

I mistakenly committed the first changeset straight to the master. The changeset was standardizing size_t calls in the Map code. See https://github.com/OutpostUniverse/OP2Utility/commit/5b8b693aa8a715a2d6161fac9a00a38b3278e650