### PR TITLE
Refactor utility classes

### DIFF
--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -138,7 +138,7 @@ void ResourceManager::ExtractAllOfFileType(const std::string& directory, const s
 
 bool ResourceManager::DuplicateFilename(std::vector<std::string>& currentFilenames, std::string pathToCheck)
 {
-	// Brett: When called on a large loop of filenames (60 more more) this function, this will create a bottleneck.
+	// Brett: When called on a large loop of filenames (60 or more), this function will create a bottleneck.
 
 	std::string filename = XFile::GetFilename(pathToCheck);
 

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -10,13 +10,13 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory)
 {
 	std::vector<std::string> volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
 
-	for (const std::string& volFilename : volFilenames) {
+	for (const auto& volFilename : volFilenames) {
 		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename.c_str()));
 	}
 
 	std::vector<std::string> clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
 
-	for (const std::string& clmFilename : clmFilenames) {
+	for (const auto& clmFilename : clmFilenames) {
 		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename.c_str()));
 	}
 }
@@ -33,7 +33,7 @@ std::unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const s
 		return nullptr;
 	}
 
-	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (auto& archiveFile : ArchiveFiles)
 	{
 		std::string internalArchiveFilename = XFile::GetFilename(filename);
 		int internalArchiveIndex = archiveFile->GetInternalFileIndex(internalArchiveFilename.c_str());
@@ -52,7 +52,7 @@ std::vector<std::string> ResourceManager::GetAllFilenames(const std::string& dir
 
 	std::vector<std::string> filenames = XFile::GetFilesFromDirectory(directory, filenameRegex);
 
-	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (auto& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
@@ -125,7 +125,7 @@ bool ResourceManager::ExtractSpecificFile(const std::string& filename, bool over
 
 void ResourceManager::ExtractAllOfFileType(const std::string& directory, const std::string& extension, bool overwrite)
 {
-	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (auto& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
@@ -153,7 +153,7 @@ bool ResourceManager::DuplicateFilename(std::vector<std::string>& currentFilenam
 
 std::string ResourceManager::FindContainingArchiveFile(const std::string& filename)
 {
-	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (auto& archiveFile : ArchiveFiles)
 	{
 		int internalFileIndex = archiveFile->GetInternalFileIndex(filename.c_str());
 

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -8,13 +8,13 @@ using namespace Archives;
 
 ResourceManager::ResourceManager(const std::string& archiveDirectory)
 {
-	std::vector<std::string> volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
+	auto volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
 
 	for (const auto& volFilename : volFilenames) {
 		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename.c_str()));
 	}
 
-	std::vector<std::string> clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
+	auto clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
 
 	for (const auto& clmFilename : clmFilenames) {
 		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename.c_str()));
@@ -33,7 +33,7 @@ std::unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const s
 		return nullptr;
 	}
 
-	for (auto& archiveFile : ArchiveFiles)
+	for (const auto& archiveFile : ArchiveFiles)
 	{
 		std::string internalArchiveFilename = XFile::GetFilename(filename);
 		int internalArchiveIndex = archiveFile->GetInternalFileIndex(internalArchiveFilename.c_str());
@@ -52,7 +52,7 @@ std::vector<std::string> ResourceManager::GetAllFilenames(const std::string& dir
 
 	std::vector<std::string> filenames = XFile::GetFilesFromDirectory(directory, filenameRegex);
 
-	for (auto& archiveFile : ArchiveFiles)
+	for (const auto& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
@@ -73,7 +73,7 @@ std::vector<std::string> ResourceManager::GetAllFilenamesOfType(const std::strin
 		return filenames;
 	}
 
-	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (const auto& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
@@ -125,7 +125,7 @@ bool ResourceManager::ExtractSpecificFile(const std::string& filename, bool over
 
 void ResourceManager::ExtractAllOfFileType(const std::string& directory, const std::string& extension, bool overwrite)
 {
-	for (auto& archiveFile : ArchiveFiles)
+	for (const auto& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
@@ -153,7 +153,7 @@ bool ResourceManager::DuplicateFilename(std::vector<std::string>& currentFilenam
 
 std::string ResourceManager::FindContainingArchiveFile(const std::string& filename)
 {
-	for (auto& archiveFile : ArchiveFiles)
+	for (const auto& archiveFile : ArchiveFiles)
 	{
 		int internalFileIndex = archiveFile->GetInternalFileIndex(filename.c_str());
 

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -4,39 +4,38 @@
 #include "Streams/SeekableStreamReader.h"
 #include "XFile.h"
 
-using namespace std;
 using namespace Archives;
 
-ResourceManager::ResourceManager(const string& archiveDirectory)
+ResourceManager::ResourceManager(const std::string& archiveDirectory)
 {
-	vector<string> volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
+	std::vector<std::string> volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
 
-	for (const string& volFilename : volFilenames) {
-		ArchiveFiles.push_back(make_unique<VolFile>(volFilename.c_str()));
+	for (const std::string& volFilename : volFilenames) {
+		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename.c_str()));
 	}
 
-	vector<string> clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
+	std::vector<std::string> clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
 
-	for (const string& clmFilename : clmFilenames) {
-		ArchiveFiles.push_back(make_unique<ClmFile>(clmFilename.c_str()));
+	for (const std::string& clmFilename : clmFilenames) {
+		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename.c_str()));
 	}
 }
 
 // First searches for resources loosely in provided directory. 
 // Then, if accessArhives = true, searches the preloaded archives for the resource.
-unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const string& filename, bool accessArchives)
+std::unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const std::string& filename, bool accessArchives)
 {
 	if (XFile::PathExists(filename)) {
-		return make_unique<FileStreamReader>(filename);
+		return std::make_unique<FileStreamReader>(filename);
 	}
 
 	if (!accessArchives) {
 		return nullptr;
 	}
 
-	for (unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
 	{
-		string internalArchiveFilename = XFile::GetFilename(filename);
+		std::string internalArchiveFilename = XFile::GetFilename(filename);
 		int internalArchiveIndex = archiveFile->GetInternalFileIndex(internalArchiveFilename.c_str());
 
 		if (internalArchiveIndex > -1) {
@@ -47,17 +46,17 @@ unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const string
 	return nullptr;
 }
 
-vector<string> ResourceManager::GetAllFilenames(const string& directory, const string& filenameRegexStr, bool accessArcives)
+std::vector<std::string> ResourceManager::GetAllFilenames(const std::string& directory, const std::string& filenameRegexStr, bool accessArcives)
 {
-	regex filenameRegex(filenameRegexStr, regex_constants::icase);
+	std::regex filenameRegex(filenameRegexStr, std::regex_constants::icase);
 
-	vector<string> filenames = XFile::GetFilesFromDirectory(directory, filenameRegex);
+	std::vector<std::string> filenames = XFile::GetFilesFromDirectory(directory, filenameRegex);
 
-	for (unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
-			if (regex_search(archiveFile->GetInternalFileName(i), filenameRegex)) {
+			if (std::regex_search(archiveFile->GetInternalFileName(i), filenameRegex)) {
 				filenames.push_back(archiveFile->GetInternalFileName(i));
 			}
 		}
@@ -66,19 +65,19 @@ vector<string> ResourceManager::GetAllFilenames(const string& directory, const s
 	return filenames;
 }
 
-vector<string> ResourceManager::GetAllFilenamesOfType(const string& directory, const string& extension, bool accessArchives)
+std::vector<std::string> ResourceManager::GetAllFilenamesOfType(const std::string& directory, const std::string& extension, bool accessArchives)
 {
-	vector<string> filenames = XFile::GetFilesFromDirectory(directory, extension);
+	std::vector<std::string> filenames = XFile::GetFilesFromDirectory(directory, extension);
 
 	if (!accessArchives) {
 		return filenames;
 	}
 
-	for (unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
-			string internalFilename = archiveFile->GetInternalFileName(i);
+			std::string internalFilename = archiveFile->GetInternalFileName(i);
 
 			if (XFile::ExtensionMatches(internalFilename, extension) && !DuplicateFilename(filenames, internalFilename)) {
 				filenames.push_back(internalFilename);
@@ -89,7 +88,7 @@ vector<string> ResourceManager::GetAllFilenamesOfType(const string& directory, c
 	return filenames;
 }
 
-bool ResourceManager::ExistsInArchives(const string& filename, int& volFileIndexOut, int& internalVolIndexOut)
+bool ResourceManager::ExistsInArchives(const std::string& filename, int& volFileIndexOut, int& internalVolIndexOut)
 {
 	for (std::size_t i = 0; i < ArchiveFiles.size(); ++i)
 	{
@@ -107,7 +106,7 @@ bool ResourceManager::ExistsInArchives(const string& filename, int& volFileIndex
 	return false;
 }
 
-bool ResourceManager::ExtractSpecificFile(const string& filename, bool overwrite)
+bool ResourceManager::ExtractSpecificFile(const std::string& filename, bool overwrite)
 {
 	if (!overwrite && XFile::PathExists(filename)) {
 		return true;
@@ -124,9 +123,9 @@ bool ResourceManager::ExtractSpecificFile(const string& filename, bool overwrite
 	return false;
 }
 
-void ResourceManager::ExtractAllOfFileType(const string& directory, const string& extension, bool overwrite)
+void ResourceManager::ExtractAllOfFileType(const std::string& directory, const std::string& extension, bool overwrite)
 {
-	for (unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
 	{
 		for (int i = 0; i < archiveFile->GetNumberOfPackedFiles(); ++i)
 		{
@@ -137,11 +136,11 @@ void ResourceManager::ExtractAllOfFileType(const string& directory, const string
 	}
 }
 
-bool ResourceManager::DuplicateFilename(vector<string>& currentFilenames, string pathToCheck)
+bool ResourceManager::DuplicateFilename(std::vector<std::string>& currentFilenames, std::string pathToCheck)
 {
 	// Brett: When called on a large loop of filenames (60 more more) this function, this will create a bottleneck.
 
-	string filename = XFile::GetFilename(pathToCheck);
+	std::string filename = XFile::GetFilename(pathToCheck);
 
 	for (std::size_t i = 0; i < currentFilenames.size(); ++i) {
 		if (XFile::PathsAreEqual(XFile::GetFilename(currentFilenames[i]), filename)) {
@@ -152,9 +151,9 @@ bool ResourceManager::DuplicateFilename(vector<string>& currentFilenames, string
 	return false;
 }
 
-string ResourceManager::FindContainingArchiveFile(const string& filename)
+std::string ResourceManager::FindContainingArchiveFile(const std::string& filename)
 {
-	for (unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
+	for (std::unique_ptr<ArchiveFile>& archiveFile : ArchiveFiles)
 	{
 		int internalFileIndex = archiveFile->GetInternalFileIndex(filename.c_str());
 
@@ -163,5 +162,5 @@ string ResourceManager::FindContainingArchiveFile(const string& filename)
 		}
 	}
 
-	return string();
+	return std::string();
 }

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -1,7 +1,7 @@
 #include "ResourceManager.h"
 #include "Archives/VolFile.h"
 #include "Archives/ClmFile.h"
-//#include "Streams/StreamReader.h"
+#include "Streams/SeekableStreamReader.h"
 #include "XFile.h"
 
 using namespace std;
@@ -91,7 +91,7 @@ vector<string> ResourceManager::GetAllFilenamesOfType(const string& directory, c
 
 bool ResourceManager::ExistsInArchives(const string& filename, int& volFileIndexOut, int& internalVolIndexOut)
 {
-	for (size_t i = 0; i < ArchiveFiles.size(); ++i)
+	for (std::size_t i = 0; i < ArchiveFiles.size(); ++i)
 	{
 		for (int j = 0; j < ArchiveFiles[i]->GetNumberOfPackedFiles(); ++j)
 		{
@@ -143,7 +143,7 @@ bool ResourceManager::DuplicateFilename(vector<string>& currentFilenames, string
 
 	string filename = XFile::GetFilename(pathToCheck);
 
-	for (size_t i = 0; i < currentFilenames.size(); ++i) {
+	for (std::size_t i = 0; i < currentFilenames.size(); ++i) {
 		if (XFile::PathsAreEqual(XFile::GetFilename(currentFilenames[i]), filename)) {
 			return true;
 		}

--- a/StringHelper.cpp
+++ b/StringHelper.cpp
@@ -1,5 +1,6 @@
 #include "StringHelper.h"
 #include <algorithm>
+#include <cstddef>
 
 using namespace std;
 
@@ -24,7 +25,7 @@ vector<string> StringHelper::RemoveStrings(const vector<string>& stringsToSearch
 	vector<string> stringsToReturn(stringsToSearch);
 
 	// i will wrap around to SIZE_MAX  when loop is completed
-	for (size_t i = stringsToSearch.size() - 1; i < stringsToSearch.size(); ++i) {
+	for (std::size_t i = stringsToSearch.size() - 1; i < stringsToSearch.size(); ++i) {
 		for (const std::string& stringToRemove : stringsToRemove) {
 			if (CheckIfStringsAreEqual(stringsToSearch[i], stringToRemove)) {
 				stringsToReturn.erase(stringsToReturn.begin() + i);
@@ -42,7 +43,7 @@ bool StringHelper::CheckIfStringsAreEqual(const std::string& string1, const std:
 		return false;
 	}
 
-	for (size_t i = 0; i < string1.size(); ++i) {
+	for (std::size_t i = 0; i < string1.size(); ++i) {
 		if (::tolower(string1[i]) != ::tolower(string2[i])) {
 			return false;
 		}
@@ -61,7 +62,7 @@ bool StringHelper::ContainsStringCaseInsensitive(vector<string> stringsToSearch,
 			return false;
 		}
 
-		for (size_t i = 0; i < s.size(); ++i) {
+		for (std::size_t i = 0; i < s.size(); ++i) {
 			if (::tolower(s[i]) != ::tolower(stringToFind[i])) {
 				return false;
 			}

--- a/StringHelper.cpp
+++ b/StringHelper.cpp
@@ -24,7 +24,7 @@ std::vector<std::string> StringHelper::RemoveStrings(const std::vector<std::stri
 
 	// i will wrap around to SIZE_MAX  when loop is completed
 	for (std::size_t i = stringsToSearch.size() - 1; i < stringsToSearch.size(); ++i) {
-		for (const std::string& stringToRemove : stringsToRemove) {
+		for (const auto& stringToRemove : stringsToRemove) {
 			if (CheckIfStringsAreEqual(stringsToSearch[i], stringToRemove)) {
 				stringsToReturn.erase(stringsToReturn.begin() + i);
 				break;

--- a/StringHelper.cpp
+++ b/StringHelper.cpp
@@ -2,27 +2,25 @@
 #include <algorithm>
 #include <cstddef>
 
-using namespace std;
-
-void StringHelper::ConvertToUpper(string& str)
+void StringHelper::ConvertToUpper(std::string& str)
 {
 	for (auto & c : str) {
 		c = toupper(c);
 	}
 }
 
-string StringHelper::ConvertToUpper(const string& str)
+std::string StringHelper::ConvertToUpper(const std::string& str)
 {
-	string newString = str;
+	std::string newString = str;
 	ConvertToUpper(newString);
 
 	return newString;
 }
 
 // Returns a new vector with matching strings removed. Case insensitive.
-vector<string> StringHelper::RemoveStrings(const vector<string>& stringsToSearch, const vector<string>& stringsToRemove)
+std::vector<std::string> StringHelper::RemoveStrings(const std::vector<std::string>& stringsToSearch, const std::vector<std::string>& stringsToRemove)
 {
-	vector<string> stringsToReturn(stringsToSearch);
+	std::vector<std::string> stringsToReturn(stringsToSearch);
 
 	// i will wrap around to SIZE_MAX  when loop is completed
 	for (std::size_t i = stringsToSearch.size() - 1; i < stringsToSearch.size(); ++i) {
@@ -53,7 +51,7 @@ bool StringHelper::CheckIfStringsAreEqual(const std::string& string1, const std:
 }
 
 // Returns true if the vector contains the given string, ignoring letter casing.
-bool StringHelper::ContainsStringCaseInsensitive(vector<string> stringsToSearch, string stringToFind)
+bool StringHelper::ContainsStringCaseInsensitive(std::vector<std::string> stringsToSearch, std::string stringToFind)
 {
 	auto itr = std::find_if(stringsToSearch.begin(), stringsToSearch.end(),
 		[&](auto &s) {
@@ -95,7 +93,7 @@ bool StringHelper::StringCompareCaseInsensitive(const std::string& string1, cons
 	return (string1.length() < string2.length());
 }
 
-bool StringHelper::ContainsNonAsciiChars(string str)
+bool StringHelper::ContainsNonAsciiChars(std::string str)
 {
 	return std::any_of(str.begin(), str.end(), [](unsigned char i) { return (static_cast<unsigned char>(i) > 127); });
 }

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -73,7 +73,7 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 	auto pathStr = directory.length() > 0 ? directory : "./";
 
 	std::vector<std::string> filenames;
-	for (auto& entry : fs::directory_iterator(pathStr)) {
+	for (const auto& entry : fs::directory_iterator(pathStr)) {
 		filenames.push_back(entry.path().string());
 	}
 

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -5,15 +5,14 @@
 #include <filesystem>
 #include <experimental/filesystem>
 
-using namespace std;
 using namespace std::experimental::filesystem;
 
-string XFile::GetFileExtension(const string& pathStr)
+std::string XFile::GetFileExtension(const std::string& pathStr)
 {
 	return path(pathStr).extension().string();
 }
 
-bool XFile::IsDirectory(const string& pathStr)
+bool XFile::IsDirectory(const std::string& pathStr)
 {
 	if (pathStr.length() == 0) {
 		return true;
@@ -22,17 +21,17 @@ bool XFile::IsDirectory(const string& pathStr)
 	return is_directory(pathStr);
 }
 
-bool XFile::IsFile(const string& path)
+bool XFile::IsFile(const std::string& path)
 {
 	return is_regular_file(path);
 }
 
-bool XFile::ExtensionMatches(const string& pathStr, const string& extension)
+bool XFile::ExtensionMatches(const std::string& pathStr, const std::string& extension)
 {
-	string pathExtension = GetFileExtension(pathStr);
+	std::string pathExtension = GetFileExtension(pathStr);
 	StringHelper::ConvertToUpper(pathExtension);
 
-	string extensionUpper = StringHelper::ConvertToUpper(extension);
+	std::string extensionUpper = StringHelper::ConvertToUpper(extension);
 
 	if (extensionUpper.length() > 0 && extensionUpper[0] != '.') {
 		extensionUpper.insert(0, ".");
@@ -41,22 +40,22 @@ bool XFile::ExtensionMatches(const string& pathStr, const string& extension)
 	return pathExtension == extensionUpper;
 }
 
-string XFile::ChangeFileExtension(const string& filename, const string& newExtension)
+std::string XFile::ChangeFileExtension(const std::string& filename, const std::string& newExtension)
 {
 	return path(filename).replace_extension(newExtension).string();
 }
 
-void XFile::NewDirectory(const string& newPath)
+void XFile::NewDirectory(const std::string& newPath)
 {
 	create_directory(path(newPath));
 }
 
-bool XFile::PathExists(const string& pathStr)
+bool XFile::PathExists(const std::string& pathStr)
 {
 	return exists(path(pathStr));
 }
 
-string XFile::AppendToFilename(const string& filename, const string& valueToAppend)
+std::string XFile::AppendToFilename(const std::string& filename, const std::string& valueToAppend)
 {
 	path newPath(filename);
 	
@@ -68,12 +67,12 @@ string XFile::AppendToFilename(const string& filename, const string& valueToAppe
 	return newPath.string();
 }
 
-vector<string> XFile::GetFilesFromDirectory(const string& directory)
+std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directory)
 {
 	// Brett208 6Aug17: Creating a path with an empty string will prevent the directory_iterator from finding files in the current relative path.
 	auto pathStr = directory.length() > 0 ? directory : "./";
 
-	vector<string> filenames;
+	std::vector<std::string> filenames;
 	for (auto& entry : directory_iterator(pathStr)) {
 		filenames.push_back(entry.path().string());
 	}
@@ -81,13 +80,13 @@ vector<string> XFile::GetFilesFromDirectory(const string& directory)
 	return filenames;
 }
 
-vector<string> XFile::GetFilesFromDirectory(const string& directory, const regex& filenameRegex)
+std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directory, const std::regex& filenameRegex)
 {
-	vector<string> filenames = GetFilesFromDirectory(directory);
+	std::vector<std::string> filenames = GetFilesFromDirectory(directory);
 
 	for (std::size_t i = filenames.size() - 1; i >= 0; i--) 
 	{
-		if (!regex_search(filenames[i], filenameRegex)) {
+		if (!std::regex_search(filenames[i], filenameRegex)) {
 			filenames.erase(filenames.begin() + i);
 		}
 
@@ -99,9 +98,9 @@ vector<string> XFile::GetFilesFromDirectory(const string& directory, const regex
 	return filenames;
 }
 
-vector<string> XFile::GetFilesFromDirectory(const string& directory, const string& fileType)
+std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directory, const std::string& fileType)
 {
-	vector<string> filenames = GetFilesFromDirectory(directory);
+	std::vector<std::string> filenames = GetFilesFromDirectory(directory);
 
 	for (std::size_t i = filenames.size() - 1; i >= 0; --i)
 	{
@@ -109,7 +108,7 @@ vector<string> XFile::GetFilesFromDirectory(const string& directory, const strin
 			return filenames;
 		}
 
-		string extension = path(filenames[i]).extension().string();
+		std::string extension = path(filenames[i]).extension().string();
 		if (extension != fileType) {
 			filenames.erase(filenames.begin() + i);
 		}
@@ -122,12 +121,12 @@ vector<string> XFile::GetFilesFromDirectory(const string& directory, const strin
 	return filenames;
 }
 
-bool XFile::IsRootPath(const string& pathStr)
+bool XFile::IsRootPath(const std::string& pathStr)
 {
 	return path(pathStr).has_root_path();
 }
 
-string XFile::ReplaceFilename(const string& pathStr, const string& filenameStr)
+std::string XFile::ReplaceFilename(const std::string& pathStr, const std::string& filenameStr)
 {
 	path p(pathStr);
 	path filename = path(filenameStr).filename();
@@ -137,7 +136,7 @@ string XFile::ReplaceFilename(const string& pathStr, const string& filenameStr)
 	return p.string() + "/" + filename.string();
 }
 
-string XFile::AppendSubDirectory(const string& pathStr, const string& subDirectory)
+std::string XFile::AppendSubDirectory(const std::string& pathStr, const std::string& subDirectory)
 {
 	path p(pathStr);
 	path filename(p.filename());
@@ -150,17 +149,17 @@ string XFile::AppendSubDirectory(const string& pathStr, const string& subDirecto
 	return p.append(subDirectory).append(filename).string();
 }
 
-string XFile::GetFilename(const string& pathStr)
+std::string XFile::GetFilename(const std::string& pathStr)
 {
 	return path(pathStr).filename().string();
 }
 
-string XFile::RemoveFilename(const string& pathStr)
+std::string XFile::RemoveFilename(const std::string& pathStr)
 {
 	return path(pathStr).remove_filename().string();
 }
 
-bool XFile::PathsAreEqual(string pathStr1, string pathStr2)
+bool XFile::PathsAreEqual(std::string pathStr1, std::string pathStr2)
 {
 	StringHelper::ConvertToUpper(pathStr1);
 	StringHelper::ConvertToUpper(pathStr2);
@@ -178,7 +177,7 @@ bool XFile::PathsAreEqual(string pathStr1, string pathStr2)
 	return path1 == path2;
 }
 
-string XFile::GetDirectory(const string& pathStr)
+std::string XFile::GetDirectory(const std::string& pathStr)
 {
 	path p(pathStr);
 
@@ -198,7 +197,7 @@ string XFile::GetDirectory(const string& pathStr)
 	return "./";
 }
 
-void XFile::DeletePath(const string& pathStr)
+void XFile::DeletePath(const std::string& pathStr)
 {
 	remove_all(pathStr);
 }

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -5,11 +5,11 @@
 #include <filesystem>
 #include <experimental/filesystem>
 
-using namespace std::experimental::filesystem;
+namespace fs = std::experimental::filesystem;
 
 std::string XFile::GetFileExtension(const std::string& pathStr)
 {
-	return path(pathStr).extension().string();
+	return fs::path(pathStr).extension().string();
 }
 
 bool XFile::IsDirectory(const std::string& pathStr)
@@ -18,12 +18,12 @@ bool XFile::IsDirectory(const std::string& pathStr)
 		return true;
 	}
 
-	return is_directory(pathStr);
+	return fs::is_directory(pathStr);
 }
 
 bool XFile::IsFile(const std::string& path)
 {
-	return is_regular_file(path);
+	return fs::is_regular_file(path);
 }
 
 bool XFile::ExtensionMatches(const std::string& pathStr, const std::string& extension)
@@ -42,24 +42,24 @@ bool XFile::ExtensionMatches(const std::string& pathStr, const std::string& exte
 
 std::string XFile::ChangeFileExtension(const std::string& filename, const std::string& newExtension)
 {
-	return path(filename).replace_extension(newExtension).string();
+	return fs::path(filename).replace_extension(newExtension).string();
 }
 
 void XFile::NewDirectory(const std::string& newPath)
 {
-	create_directory(path(newPath));
+	fs::create_directory(fs::path(newPath));
 }
 
 bool XFile::PathExists(const std::string& pathStr)
 {
-	return exists(path(pathStr));
+	return fs::exists(fs::path(pathStr));
 }
 
 std::string XFile::AppendToFilename(const std::string& filename, const std::string& valueToAppend)
 {
-	path newPath(filename);
+	fs::path newPath(filename);
 	
-	path newFilename = newPath.filename().replace_extension("");
+	fs::path newFilename = newPath.filename().replace_extension("");
 	newFilename += valueToAppend + newPath.extension().string();
 
 	newPath.replace_filename(newFilename);
@@ -73,7 +73,7 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 	auto pathStr = directory.length() > 0 ? directory : "./";
 
 	std::vector<std::string> filenames;
-	for (auto& entry : directory_iterator(pathStr)) {
+	for (auto& entry : fs::directory_iterator(pathStr)) {
 		filenames.push_back(entry.path().string());
 	}
 
@@ -108,7 +108,7 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 			return filenames;
 		}
 
-		std::string extension = path(filenames[i]).extension().string();
+		std::string extension = fs::path(filenames[i]).extension().string();
 		if (extension != fileType) {
 			filenames.erase(filenames.begin() + i);
 		}
@@ -123,13 +123,13 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 
 bool XFile::IsRootPath(const std::string& pathStr)
 {
-	return path(pathStr).has_root_path();
+	return fs::path(pathStr).has_root_path();
 }
 
 std::string XFile::ReplaceFilename(const std::string& pathStr, const std::string& filenameStr)
 {
-	path p(pathStr);
-	path filename = path(filenameStr).filename();
+	fs::path p(pathStr);
+	fs::path filename = fs::path(filenameStr).filename();
 	
 	// Brett208 22JUL17: There seems to be a bug in path.replace_filename that removes a directory if it has a space in it on MSVC.
 
@@ -138,11 +138,11 @@ std::string XFile::ReplaceFilename(const std::string& pathStr, const std::string
 
 std::string XFile::AppendSubDirectory(const std::string& pathStr, const std::string& subDirectory)
 {
-	path p(pathStr);
-	path filename(p.filename());
+	fs::path p(pathStr);
+	fs::path filename(p.filename());
 
 	if (p == filename) {
-		return path().append(subDirectory).append(filename).string();
+		return fs::path().append(subDirectory).append(filename).string();
 	}
 
 	p = p.remove_filename();
@@ -151,12 +151,12 @@ std::string XFile::AppendSubDirectory(const std::string& pathStr, const std::str
 
 std::string XFile::GetFilename(const std::string& pathStr)
 {
-	return path(pathStr).filename().string();
+	return fs::path(pathStr).filename().string();
 }
 
 std::string XFile::RemoveFilename(const std::string& pathStr)
 {
-	return path(pathStr).remove_filename().string();
+	return fs::path(pathStr).remove_filename().string();
 }
 
 bool XFile::PathsAreEqual(std::string pathStr1, std::string pathStr2)
@@ -164,12 +164,12 @@ bool XFile::PathsAreEqual(std::string pathStr1, std::string pathStr2)
 	StringHelper::ConvertToUpper(pathStr1);
 	StringHelper::ConvertToUpper(pathStr2);
 
-	path path1(pathStr1);
+	fs::path path1(pathStr1);
 	if (path1.has_relative_path() && path1.relative_path() == path1.filename()) {
 		path1 = ("./" + pathStr1);
 	}
 
-	path path2(pathStr2);
+	fs::path path2(pathStr2);
 	if (path2.has_relative_path() && path2.relative_path() == path2.filename()) {
 		path2 = ("./" + pathStr2);
 	}
@@ -179,7 +179,7 @@ bool XFile::PathsAreEqual(std::string pathStr1, std::string pathStr2)
 
 std::string XFile::GetDirectory(const std::string& pathStr)
 {
-	path p(pathStr);
+	fs::path p(pathStr);
 
 	if (p.has_relative_path()) 
 	{
@@ -199,10 +199,10 @@ std::string XFile::GetDirectory(const std::string& pathStr)
 
 void XFile::DeletePath(const std::string& pathStr)
 {
-	remove_all(pathStr);
+	fs::remove_all(pathStr);
 }
 
 void XFile::RenameFile(const std::string& oldPath, const std::string& newPath) 
 {
-	rename(oldPath, newPath);
+	fs::rename(oldPath, newPath);
 }

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -1,5 +1,6 @@
 #include "XFile.h"
 #include "StringHelper.h"
+#include <cstddef>
 
 #include <filesystem>
 #include <experimental/filesystem>
@@ -84,7 +85,7 @@ vector<string> XFile::GetFilesFromDirectory(const string& directory, const regex
 {
 	vector<string> filenames = GetFilesFromDirectory(directory);
 
-	for (size_t i = filenames.size() - 1; i >= 0; i--) 
+	for (std::size_t i = filenames.size() - 1; i >= 0; i--) 
 	{
 		if (!regex_search(filenames[i], filenameRegex)) {
 			filenames.erase(filenames.begin() + i);
@@ -102,7 +103,7 @@ vector<string> XFile::GetFilesFromDirectory(const string& directory, const strin
 {
 	vector<string> filenames = GetFilesFromDirectory(directory);
 
-	for (size_t i = filenames.size() - 1; i >= 0; --i)
+	for (std::size_t i = filenames.size() - 1; i >= 0; --i)
 	{
 		if (filenames.size() == 0) {
 			return filenames;


### PR DESCRIPTION
 - Standardize use of size_t
 - Remove std using statements
 - Use the fs alias for referencing experimental filesystem namespace
 - Increase use of auto keyword on range based loops

I have no problem including the standard namespace in .cpp files. However, to match the rest of the code base, I thought it would be better to remove it. It also seems to be the prevalent way to write C++ right now. 

With this and the 2 previous branches, we should be able to close out issue #62. 

There is significant room for improvement in these classes, especially `ResourceManager`. I would be okay ignoring the needed work for now in the interest of continuing with other goals.