### PR TITLE
Remove Final Windows.h Include

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -3,9 +3,12 @@
 #include "../StringHelper.h"
 #include <cstddef>
 #include <stdexcept>
+#include <array>
 
 namespace Archives
 {
+	const uint32_t ARCHIVE_WRITE_SIZE = 0x00020000;
+
 	ArchivePacker::ArchivePacker() { }
 	ArchivePacker::~ArchivePacker() { }
 
@@ -33,5 +36,28 @@ namespace Archives
 	bool ArchivePacker::ComparePathFilenames(const std::string path1, const std::string path2)
 	{
 		return StringHelper::StringCompareCaseInsensitive(XFile::GetFilename(path1), XFile::GetFilename(path2));
+	}
+
+	void ArchivePacker::PackFile(StreamWriter& streamWriter, StreamReader& fileToPackReader, const uint64_t fileToPackSize)
+	{
+		uint32_t numBytesToRead;
+		uint32_t offset = 0;
+		std::array<char, ARCHIVE_WRITE_SIZE> buffer;
+
+		do
+		{
+			numBytesToRead = ARCHIVE_WRITE_SIZE;
+
+			// Check if less than ARCHIVE_WRITE_SIZE of data remains for writing to disk.
+			if (offset + numBytesToRead > fileToPackSize) {
+				numBytesToRead = fileToPackSize - offset;
+			}
+
+			// Read the input file
+			fileToPackReader.Read(buffer.data(), numBytesToRead);
+			offset += numBytesToRead;
+
+			streamWriter.Write(buffer.data(), numBytesToRead);
+		} while (numBytesToRead); // End loop when numBytesRead/Written is equal to 0
 	}
 }

--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../Streams/StreamReader.h"
+#include "../Streams/StreamWriter.h"
 #include <string>
 #include <vector>
 
@@ -29,5 +31,7 @@ namespace Archives
 		// Compares 2 filenames case insensitive to determine which comes first alphabetically.
 		// Does not compare the entire path, but only the filename.
 		static bool ComparePathFilenames(const std::string path1, const std::string path2);
+
+		void ArchivePacker::PackFile(StreamWriter& streamWriter, StreamReader& fileToPackReader, const uint64_t fileToPackSize);
 	};
 }

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -349,7 +349,7 @@ namespace Archives
 
 		// Copy files into the archive
 		for (std::size_t i = 0; i < header.packedFilesCount; i++) {
-			PackFile(clmFileWriter, indexEntries[i], *filesToPackReaders[i]);
+			PackFile(clmFileWriter, *filesToPackReaders[i], indexEntries[i].dataLength);
 		}
 	}
 
@@ -365,30 +365,6 @@ namespace Archives
 			indexEntries[i].dataOffset = offset;
 			offset += indexEntries[i].dataLength;
 		}
-	}
-
-	// Write file into the Clm Archive by using the fixed memory size of CLM_WRITE_SIZE.
-	void ClmFile::PackFile(StreamWriter& clmWriter, const IndexEntry& indexEntry, StreamReader& fileToPackReader)
-	{
-		uint32_t numBytesToRead;
-		uint32_t offset = 0; // Max size of CLM IndexEntry::dataLength is 32 bits.
-		std::array<char, CLM_WRITE_SIZE> buffer;
-
-		do
-		{
-			numBytesToRead = CLM_WRITE_SIZE;
-
-			// Check if less than CLM_WRITE_SIZE of data remains for writing to disk.
-			if (offset + numBytesToRead > indexEntry.dataLength) {
-				numBytesToRead = indexEntry.dataLength - offset;
-			}
-
-			// Read the input file
-			fileToPackReader.Read(buffer.data(), numBytesToRead);
-			offset += numBytesToRead;
-
-			clmWriter.Write(buffer.data(), numBytesToRead);
-		} while (numBytesToRead); // End loop when numBytesRead/Written is equal to 0
 	}
 
 	std::vector<std::string> ClmFile::StripFileNameExtensions(std::vector<std::string> paths)

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -68,7 +68,6 @@ namespace Archives
 		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
 		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
-		void PackFile(StreamWriter& clmWriter, const IndexEntry& entry, StreamReader& fileToPackReader);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
 		static WaveFormatEx CreateDefaultWaveFormat();

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -3,9 +3,8 @@
 #include "HuffLZ.h"
 #include "ArchiveFile.h"
 #include "CompressionType.h"
-#include "../Streams/StreamWriter.h"
+#include "../Streams/FileStreamWriter.h"
 #include "../Streams/FileStreamReader.h"
-#include <windows.h>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -75,7 +74,7 @@ namespace Archives
 		struct CreateVolumeInfo
 		{
 			std::vector<IndexEntry> indexEntries;
-			std::vector<HANDLE> fileHandles;
+			std::vector<std::unique_ptr<SeekableStreamReader>> fileStreamReaders;
 			std::vector<std::string> filesToPack;
 			std::vector<std::string> internalNames;
 			uint32_t stringTableLength;
@@ -90,16 +89,14 @@ namespace Archives
 		};
 
 		uint32_t ReadTag(std::array<char, 4> tagName);
-		void CopyFileIntoVolume(StreamWriter& volWriter, HANDLE inputFile);
 		void ReadVolHeader();
 		void ReadStringTable();
 		void ReadPackedFileCount();
-		void WriteVolume(const std::string& fileName, const CreateVolumeInfo& volInfo);
-		void WriteFiles(StreamWriter& volWriter, const CreateVolumeInfo &volInfo);
+		void WriteVolume(const std::string& fileName, CreateVolumeInfo& volInfo);
+		void WriteFiles(StreamWriter& volWriter, CreateVolumeInfo &volInfo);
 		void WriteHeader(StreamWriter& volWriter, const CreateVolumeInfo &volInfo);
-		bool PrepareHeader(CreateVolumeInfo &volInfo);
-		bool OpenAllInputFiles(CreateVolumeInfo &volInfo);
-		void CleanUpVolumeCreate(CreateVolumeInfo &volInfo);
+		void PrepareHeader(CreateVolumeInfo &volInfo);
+		void OpenAllInputFiles(CreateVolumeInfo &volInfo);
 		SectionHeader GetSectionHeader(int index);
 
 		FileStreamReader archiveFileReader;


### PR DESCRIPTION
 - Change Volume CreateVolInfo HANDLE out with a FileStreamReader
 - Standardize packing of files to disk between VolFile and ClmFile

And there may be much rejoicing, if it works on Linux...

Closes #56.
Closes #30.

Tested by packing and unpacking both a volume and clm file.