### PR TITLE
Refactor to include suggested changes on merge request

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -38,7 +38,7 @@ namespace Archives
 		return StringHelper::StringCompareCaseInsensitive(XFile::GetFilename(path1), XFile::GetFilename(path2));
 	}
 
-	void ArchivePacker::PackFile(StreamWriter& streamWriter, StreamReader& fileToPackReader, const uint64_t fileToPackSize)
+	void ArchivePacker::WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength)
 	{
 		uint32_t numBytesToRead;
 		uint32_t offset = 0;
@@ -49,12 +49,12 @@ namespace Archives
 			numBytesToRead = ARCHIVE_WRITE_SIZE;
 
 			// Check if less than ARCHIVE_WRITE_SIZE of data remains for writing to disk.
-			if (offset + numBytesToRead > fileToPackSize) {
-				numBytesToRead = fileToPackSize - offset;
+			if (offset + numBytesToRead > writeLength) {
+				numBytesToRead = writeLength - offset;
 			}
 
 			// Read the input file
-			fileToPackReader.Read(buffer.data(), numBytesToRead);
+			streamReader.Read(buffer.data(), numBytesToRead);
 			offset += numBytesToRead;
 
 			streamWriter.Write(buffer.data(), numBytesToRead);

--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -32,6 +32,6 @@ namespace Archives
 		// Does not compare the entire path, but only the filename.
 		static bool ComparePathFilenames(const std::string path1, const std::string path2);
 
-		void ArchivePacker::PackFile(StreamWriter& streamWriter, StreamReader& fileToPackReader, const uint64_t fileToPackSize);
+		void WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength);
 	};
 }

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -349,7 +349,7 @@ namespace Archives
 
 		// Copy files into the archive
 		for (std::size_t i = 0; i < header.packedFilesCount; i++) {
-			PackFile(clmFileWriter, *filesToPackReaders[i], indexEntries[i].dataLength);
+			WriteFromStream(clmFileWriter, *filesToPackReaders[i], indexEntries[i].dataLength);
 		}
 	}
 


### PR DESCRIPTION
 - Move setting StringTableLength to 0 to inside PrepareHeader
 - Rename function ArchivePacker::PackFile to WriteFromStream.
 - Clear volInfo::fileStreamReaders before adding streams
 - Throw an error is a file larger than UINT32_MAX is attempted to be packed in a volume
 - Remove class prefix from function prototype

Sorry, I forgot to push these changes before closing the initial merge request.
