### PR TITLE
Linux filesystem fixes

### DIFF
--- a/XFile.cpp
+++ b/XFile.cpp
@@ -2,7 +2,7 @@
 #include "StringHelper.h"
 #include <cstddef>
 
-#include <filesystem>
+#include <experimental/filesystem>
 
 namespace fs = std::experimental::filesystem;
 

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -141,11 +141,11 @@ std::string XFile::AppendSubDirectory(const std::string& pathStr, const std::str
 	fs::path filename(p.filename());
 
 	if (p == filename) {
-		return fs::path().append(subDirectory).append(filename).string();
+		return (fs::path() / subDirectory / filename).string();
 	}
 
 	p = p.remove_filename();
-	return p.append(subDirectory).append(filename).string();
+	return (p / subDirectory / filename).string();
 }
 
 std::string XFile::GetFilename(const std::string& pathStr)


### PR DESCRIPTION
This gets the code compiling on Linux.

----

Not part of the PR, but as it relates to these changes:

I don't think we need to `.string()` calls for the return values. At least, it compiles on Linux without them. Not sure how portable that is though to rely on automatic conversion to string, so I left out the changes from the PR. If you're curious to try:
```
	if (p == filename) {
		return fs::path() / subDirectory / filename;
	}

	p = p.remove_filename();
	return p / subDirectory / filename;
```

Additionally, the first `return` I think could be simplified to:
```
		return fs::path(subDirectory) / filename;
```