### PR TITLE
Fix LZH reading code

### DIFF
--- a/Archives/AdaptHuffTree.cpp
+++ b/Archives/AdaptHuffTree.cpp
@@ -80,7 +80,7 @@ namespace Archives
 			throw std::runtime_error("Index out of range");
 		}
 
-		// Return weather or not this is a terminal node
+		// Return whether or not this is a terminal node
 		return m_Data[nodeIndex] >= m_NumNodes;
 	}
 
@@ -93,7 +93,8 @@ namespace Archives
 			throw std::runtime_error("Index out of range");
 		}
 
-		// Return weather or not this is a terminal node
+		// Return data stored in node translated back to normal form
+		// Note: This assumes the node is a terminal node
 		return m_Data[nodeIndex] - m_NumNodes;
 	}
 

--- a/Archives/BitStream.cpp
+++ b/Archives/BitStream.cpp
@@ -15,7 +15,7 @@ namespace Archives
 		m_WriteBuff = 0;
 	}
 
-	BitStream::BitStream(int bufferSize, char *buffer)
+	BitStream::BitStream(int bufferSize, void *buffer)
 	{
 		// Initialize class variables
 		m_BufferSize = bufferSize;

--- a/Archives/BitStream.h
+++ b/Archives/BitStream.h
@@ -5,7 +5,7 @@ namespace Archives
 	{
 	public:
 		BitStream();				// Construct empty stream
-		BitStream(int bufferSize, char *buffer);// Construct stream around given buffer
+		BitStream(int bufferSize, void *buffer);// Construct stream around given buffer
 
 		bool ReadNextBit();			// Get bit at Read index and advance index
 		int  ReadNext8Bits();		// Get next 8 bits at Read index and advance index

--- a/Archives/HuffLZ.cpp
+++ b/Archives/HuffLZ.cpp
@@ -18,7 +18,7 @@ namespace Archives
 	}
 
 	// Creates an internal bit stream for the buffer
-	HuffLZ::HuffLZ(int bufferSize, char *buffer)
+	HuffLZ::HuffLZ(std::size_t bufferSize, char *buffer)
 	{
 		// Construct the BitStream object
 		m_BitStream = new BitStream(bufferSize, buffer);
@@ -45,10 +45,10 @@ namespace Archives
 	// data is available to fill the buffer, more of the input is decompressed up to
 	// the end of the input stream or until the buffer is filled. Returns the total
 	// number of bytes that were copied.
-	int HuffLZ::GetData(int bufferSize, char *buffer)
+	std::size_t HuffLZ::GetData(std::size_t bufferSize, char *buffer)
 	{
-		int numBytesCopied;
-		int numBytesTotal = 0;
+		std::size_t numBytesCopied;
+		std::size_t numBytesTotal = 0;
 
 		// Try to keep the buffer largely full
 		// This allows allows more memory to be copied at once
@@ -77,7 +77,7 @@ namespace Archives
 	// Note: If the buffer wraps around, the remaining data before the wrap around 
 	//  is returned. A subsequent call will get the data after the wrap around.
 	// Note: If sizeAvailableData == 0 then the end of the stream has been reached
-	const char* HuffLZ::GetInternalBuffer(int *sizeAvailableData)
+	const char* HuffLZ::GetInternalBuffer(std::size_t *sizeAvailableData)
 	{
 		const char* currentPos;
 
@@ -118,10 +118,10 @@ namespace Archives
 
 	// Copies all available data into buff up to a maximum of size bytes
 	// This routine handles the case when the copy must wrap around the circular buffer
-	int HuffLZ::CopyAvailableData(int size, char *buff)
+	std::size_t HuffLZ::CopyAvailableData(std::size_t size, char *buff)
 	{
-		int numBytesToCopy;
-		int numBytesTotal = 0;
+		std::size_t numBytesToCopy;
+		std::size_t numBytesTotal = 0;
 
 		// Check if buffer is empty
 		// Note: This isn't really needed but should speed things up

--- a/Archives/HuffLZ.cpp
+++ b/Archives/HuffLZ.cpp
@@ -18,7 +18,7 @@ namespace Archives
 	}
 
 	// Creates an internal bit stream for the buffer
-	HuffLZ::HuffLZ(std::size_t bufferSize, char *buffer)
+	HuffLZ::HuffLZ(std::size_t bufferSize, void *buffer)
 	{
 		// Construct the BitStream object
 		m_BitStream = new BitStream(bufferSize, buffer);

--- a/Archives/HuffLZ.h
+++ b/Archives/HuffLZ.h
@@ -11,7 +11,7 @@ namespace Archives
 	{
 	public:
 		HuffLZ(BitStream *bitStream);
-		HuffLZ(std::size_t bufferSize, char *buffer);
+		HuffLZ(std::size_t bufferSize, void *buffer);
 		~HuffLZ();
 
 		std::size_t GetData(std::size_t bufferSize, char *buffer);	// Copy decoded data into given buffer.

--- a/Archives/HuffLZ.h
+++ b/Archives/HuffLZ.h
@@ -3,6 +3,7 @@
 
 #include "AdaptHuffTree.h"
 #include "BitStream.h"
+#include <cstddef>
 
 namespace Archives
 {
@@ -10,17 +11,17 @@ namespace Archives
 	{
 	public:
 		HuffLZ(BitStream *bitStream);
-		HuffLZ(int bufferSize, char *buffer);
+		HuffLZ(std::size_t bufferSize, char *buffer);
 		~HuffLZ();
 
-		int GetData(int bufferSize, char *buffer);	// Copy decoded data into given buffer.
+		std::size_t GetData(std::size_t bufferSize, char *buffer);	// Copy decoded data into given buffer.
 													// Returns number of bytes copied
-		const char* GetInternalBuffer(int *sizeAvailableData);
+		const char* GetInternalBuffer(std::size_t *sizeAvailableData);
 		// Give access to internal decompress
 		// buffer (no memory copy required)
 	private:
 		void FillDecompressBuffer();				// Decompress until buffer is near full
-		int CopyAvailableData(int size, char *buff);// Copies already decompressed data
+		std::size_t CopyAvailableData(std::size_t size, char *buff);// Copies already decompressed data
 		bool DecompressCode();	// Decompresses a code and returns false at end of stream
 		int GetNextCode();
 		int GetRepeatOffset();

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -151,7 +151,7 @@ namespace Archives
 
 			// Load data into temporary memory buffer
 			std::size_t length = sectionHeader.length;
-			std::vector<char> buffer(length);
+			std::vector<uint8_t> buffer(length);
 			archiveFileReader.Read(buffer.data(), length);
 
 			HuffLZ decompressor(length, buffer.data());
@@ -160,7 +160,7 @@ namespace Archives
 
 			do
 			{
-				const char *buffer = decompressor.GetInternalBuffer(&length);
+				const void *buffer = decompressor.GetInternalBuffer(&length);
 				fileStreamWriter.Write(buffer, length);
 			} while (length);
 		}

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -146,18 +146,21 @@ namespace Archives
 	{
 		try
 		{
-			char* offset = (char*)m_IndexEntries[fileIndex].dataBlockOffset;
-			int length = *(int*)(offset + 4) & 0x7FFFFFFF;
-			offset += 8;
+			// Calling GetSectionHeader moves the streamReader's position to just past the SectionHeader
+			SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 
-			HuffLZ decompressor(length, offset);
-			const char *buffer = 0;
+			// Load data into temporary memory buffer
+			int length = sectionHeader.length;
+			std::vector<char> buffer(length);
+			archiveFileReader.Read(buffer.data(), length);
+
+			HuffLZ decompressor(length, buffer.data());
 
 			FileStreamWriter fileStreamWriter(pathOut);
 
 			do
 			{
-				buffer = decompressor.GetInternalBuffer(&length);
+				const char *buffer = decompressor.GetInternalBuffer(&length);
 				fileStreamWriter.Write(buffer, length);
 			} while (length);
 		}

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -150,7 +150,7 @@ namespace Archives
 			SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 
 			// Load data into temporary memory buffer
-			int length = sectionHeader.length;
+			std::size_t length = sectionHeader.length;
 			std::vector<char> buffer(length);
 			archiveFileReader.Read(buffer.data(), length);
 


### PR DESCRIPTION
This is untested, but does compile. It's a minimal change to update the
code to more recent conventions, hopefully fixing the break.

This hopefully fixes #85.