### PR TITLE
Use fixed width variables in clm file

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -40,7 +40,7 @@ namespace Archives
 
 	void ArchivePacker::WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength)
 	{
-		uint32_t numBytesToRead;
+		std::size_t numBytesToRead;
 		uint32_t offset = 0;
 		std::array<char, ARCHIVE_WRITE_SIZE> buffer;
 
@@ -50,7 +50,7 @@ namespace Archives
 
 			// Check if less than ARCHIVE_WRITE_SIZE of data remains for writing to disk.
 			if (offset + numBytesToRead > writeLength) {
-				numBytesToRead = writeLength - offset;
+				numBytesToRead = static_cast<std::size_t>(writeLength - offset);
 			}
 
 			// Read the input file

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -24,7 +24,7 @@ namespace Archives
 		virtual std::string GetInternalFileName(int index) = 0;
 		// Returns -1 if internalFileName is not present in archive.
 		virtual int GetInternalFileIndex(const char *internalFileName) = 0;
-		virtual int GetInternalFileSize(int index) = 0;
+		virtual uint32_t GetInternalFileSize(int index) = 0;
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
 		virtual void ExtractAllFiles(const char* destDirectory);
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName) = 0;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -25,7 +25,7 @@ namespace Archives
 			clmHeader.VerifyFileVersion();
 			clmHeader.VerifyUnknown();
 		}
-		catch (std::exception& e) {
+		catch (const std::exception& e) {
 			throw std::runtime_error("Invalid clm header read from file " + m_ArchiveFileName + ". " + e.what());
 		}
 
@@ -147,7 +147,7 @@ namespace Archives
 			XFile::RenameFile(tempFileName, m_ArchiveFileName);
 			return true;
 		}
-		catch (std::exception&) {
+		catch (const std::exception&) {
 			return false;
 		}
 	}
@@ -169,7 +169,7 @@ namespace Archives
 				filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
 			}
 		}
-		catch (std::exception&) {
+		catch (const std::exception&) {
 			return false;
 		}
 
@@ -203,7 +203,7 @@ namespace Archives
 
 			WriteArchive(archiveFileName, filesToPackReaders, indexEntries, internalFileNames, waveFormat);
 		}
-		catch (std::exception&) {
+		catch (const std::exception&) {
 			return false; // Error writing CLM archive file
 		}
 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -58,7 +58,7 @@ namespace Archives
 	}
 
 	// Returns the size of the internal file corresponding to index
-	int ClmFile::GetInternalFileSize(int index)
+	uint32_t ClmFile::GetInternalFileSize(int index)
 	{
 		CheckPackedFileIndexBounds(index);
 
@@ -178,9 +178,7 @@ namespace Archives
 		std::vector<WaveFormatEx> waveFormats(filesToPack.size());
 		std::vector<IndexEntry> indexEntries(filesToPack.size());
 
-		if (!ReadAllWaveHeaders(filesToPackReaders, waveFormats, indexEntries)) {	
-			return false; // Error reading in wave headers. Abort.
-		}
+		ReadAllWaveHeaders(filesToPackReaders, waveFormats, indexEntries);
 
 		// Check if all wave formats are the same
 		if (!CompareWaveFormats(waveFormats)) {	
@@ -216,10 +214,9 @@ namespace Archives
 	// Reads the beginning of each file and verifies it is formatted as a WAVE file. Locates
 	// the WaveFormatEx structure and start of data. The WaveFormat is stored in the waveFormats container.
 	// The current stream position is set to the start of the data chunk.
-	// Returns nonzero if successful and zero otherwise.
 	// Note: This function assumes that all stream positions are initially set to the beginning
 	//  of the file. When reading the wave file header, it does not seek to the file start.
-	bool ClmFile::ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries)
+	void ClmFile::ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries)
 	{
 		RiffHeader header;
 
@@ -229,47 +226,39 @@ namespace Archives
 			// Read the file header
 			filesToPackReaders[i]->Read(header);
 			if (header.riffTag != tagRIFF || header.waveTag != tagWAVE) {
-				return false;		// Error reading header
+				throw std::runtime_error("Error reading header from file " + indexEntries[i].GetFileName());		
 			}
 
 			// Check that the file size makes sense (matches with header chunk length + 8)
 			if (header.chunkSize + 8 != filesToPackReaders[i]->Length()) {
-				return false;
+				throw std::runtime_error("Chunk size does not match file length in " + indexEntries[i].GetFileName());
 			}
 
 			// Read the format tag
-			int fmtChunkLength = FindChunk(tagFMT_, *filesToPackReaders[i]);
-			if (fmtChunkLength == -1) {
-				return false;		// Format chunk not found
-			}
+			uint32_t fmtChunkLength = FindChunk(tagFMT_, *filesToPackReaders[i]);
 
 			// Read in the wave format
 			filesToPackReaders[i]->Read(waveFormats[i]);
 			waveFormats[i].cbSize = 0;
 
 			// Find the start of the data
-			int dataChunkLength = FindChunk(tagDATA, *filesToPackReaders[i]);
-			if (dataChunkLength == -1) {
-				return false;		// Data chunk not found
-			}
+			uint32_t dataChunkLength = FindChunk(tagDATA, *filesToPackReaders[i]);
 
 			// Store the length of the wave data
 			indexEntries[i].dataLength = dataChunkLength;
 			// Note: Current stream position is set to the start of the wave data
 		}
-
-		return true;
 	}
 
 	// Searches through the wave file to find the given chunk length
 	// The current stream position is set the the first byte after the chunk header
 	// Returns the chunk length if found or -1 otherwise
-	int ClmFile::FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader)
+	uint32_t ClmFile::FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader)
 	{
 		uint64_t fileSize = seekableStreamReader.Length();
 
 		if (fileSize < sizeof(RiffHeader) + sizeof(ChunkHeader)) {
-			return -1;
+			throw std::runtime_error("There is not enough space in the file to represent the Riff Header and Chunk Header");
 		}
 
 		// Seek to beginning of first internal chunk (provided it exists)
@@ -280,7 +269,6 @@ namespace Archives
 		ChunkHeader header;
 		do
 		{
-			// Read the tag
 			seekableStreamReader.Read(header);
 			
 			// Check if this is the right header
@@ -293,7 +281,7 @@ namespace Archives
 			seekableStreamReader.Seek(currentPosition);
 		} while (currentPosition < fileSize);
 
-		return -1;	// Failed to find the tag
+		throw std::runtime_error("Unable to find the tag " + std::string(chunkTag.data(), chunkTag.size()));
 	}
 
 	// Compares wave format structures in the waveFormats container

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -5,8 +5,6 @@
 
 namespace Archives
 {
-	const uint32_t CLM_WRITE_SIZE = 0x00020000;
-
 	ClmFile::ClmFile(const char *fileName) : ArchiveFile(fileName), clmFileReader(fileName)
 	{
 		m_ArchiveFileSize = clmFileReader.Length();

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -24,7 +24,7 @@ namespace Archives
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
-		int GetInternalFileSize(int index);
+		uint32_t GetInternalFileSize(int index);
 
 		bool Repack();
 		bool CreateArchive(std::string archiveFileName, std::vector<std::string> filesToPack);
@@ -51,8 +51,8 @@ namespace Archives
 		struct IndexEntry
 		{
 			std::array<char, 8> fileName;
-			unsigned int dataOffset;
-			unsigned int dataLength;
+			uint32_t dataOffset;
+			uint32_t dataLength;
 
 			std::string GetFileName() const;
 		};
@@ -62,8 +62,8 @@ namespace Archives
 		void ReadHeader();
 
 		// Private functions for packing files
-		bool ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
-		int FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
+		void ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
+		uint32_t FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
 		static bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
 		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -53,7 +53,7 @@ namespace Archives
 		return m_IndexEntries[index].compressionType;
 	}
 
-	int VolFile::GetInternalFileSize(int index)
+	uint32_t VolFile::GetInternalFileSize(int index)
 	{
 		CheckPackedFileIndexBounds(index);
 

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -136,7 +136,7 @@ namespace Archives
 
 			ArchiveUnpacker::WriteFromStream(pathOut, archiveFileReader, sectionHeader.length);
 		}
-		catch (std::exception& e)
+		catch (const std::exception& e)
 		{
 			throw std::runtime_error("Error attempting to extracted uncompressed file " + pathOut + ". Internal Error Message: " + e.what());
 		}
@@ -189,7 +189,7 @@ namespace Archives
 			XFile::RenameFile(tempFileName, m_ArchiveFileName);
 			return true;
 		}
-		catch (std::exception&) {
+		catch (const std::exception&) {
 			return false;
 		}
 	}
@@ -214,7 +214,7 @@ namespace Archives
 		try {
 			WriteVolume(volumeFileName, volInfo);
 		}
-		catch (std::exception&) {
+		catch (const std::exception&) {
 			return false;
 		}
 
@@ -244,7 +244,7 @@ namespace Archives
 				// Use a bitmask to quickly calculate the modulo 4 (remainder) of fileSize
 				volWriter.Write(&padding, (-volInfo.indexEntries[i].fileSize) & 3);
 			}
-			catch (std::exception& e) {
+			catch (const std::exception& e) {
 				throw std::runtime_error("Unable to pack file " + volInfo.internalNames[i] + ". Internal error: " + e.what());
 			}
 		}

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -136,7 +136,7 @@ namespace Archives
 
 			ArchiveUnpacker::WriteFromStream(pathOut, archiveFileReader, sectionHeader.length);
 		}
-		catch (std::exception e)
+		catch (std::exception& e)
 		{
 			throw std::runtime_error("Error attempting to extracted uncompressed file " + pathOut + ". Internal Error Message: " + e.what());
 		}
@@ -161,7 +161,7 @@ namespace Archives
 				fileStreamWriter.Write(buffer, length);
 			} while (length);
 		}
-		catch (std::exception e)
+		catch (const std::exception& e)
 		{
 			throw std::runtime_error("Error attempting to extract LZH compressed file " + pathOut + ". Internal Error Message: " + e.what());
 		}

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -25,7 +25,7 @@ namespace Archives
 		std::string GetInternalFileName(int index);
 		int GetInternalFileIndex(const char *internalFileName);
 		CompressionType GetInternalCompressionCode(int index);
-		int GetInternalFileSize(int index);
+		uint32_t GetInternalFileSize(int index);
 
 		// Extraction
 		void ExtractFile(int fileIndex, const std::string& pathOut);


### PR DESCRIPTION
Remove Unused Variabe CLM_WRITE_SIZE

Use Fixed Width Variables in stream related code in ClmFile … 
 - Switch functions ReadAllWaveHeaders & FindChunk to throw errors on failure instead of boolean return

Switch to catching exceptions by reference in VolFile.

Closes #82 
