### PR TITLE
Fix stream initializer list warnings

### DIFF
--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -3,7 +3,8 @@
 
 // Defers calls to C++ standard library methods
 FileStreamReader::FileStreamReader(std::string filename) : 
-	filename(filename), file(filename, std::ios::in | std::ios::binary)
+	filename(filename),
+	file(filename, std::ios::in | std::ios::binary)
 {
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -25,6 +25,6 @@ protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
-	std::ifstream file;
 	const std::string filename;
+	std::ifstream file;
 };

--- a/Streams/FileStreamWriter.cpp
+++ b/Streams/FileStreamWriter.cpp
@@ -1,10 +1,10 @@
 #include "FileStreamWriter.h"
 #include <stdexcept>
 
-FileStreamWriter::FileStreamWriter(const std::string& filename) : filename(filename)
+FileStreamWriter::FileStreamWriter(const std::string& filename) : 
+	filename(filename),
+	fileStream(filename.c_str(), std::ios::trunc | std::ios::out | std::ios::binary)
 {
-	fileStream.open(filename.c_str(), std::ios::trunc | std::ios::out | std::ios::binary);
-
 	if (!fileStream.is_open()) {
 		throw std::runtime_error("File could not be opened.");
 	}

--- a/Streams/FileStreamWriter.cpp
+++ b/Streams/FileStreamWriter.cpp
@@ -3,42 +3,42 @@
 
 FileStreamWriter::FileStreamWriter(const std::string& filename) : 
 	filename(filename),
-	fileStream(filename.c_str(), std::ios::trunc | std::ios::out | std::ios::binary)
+	file(filename.c_str(), std::ios::trunc | std::ios::out | std::ios::binary)
 {
-	if (!fileStream.is_open()) {
+	if (!file.is_open()) {
 		throw std::runtime_error("File could not be opened.");
 	}
 }
 
 FileStreamWriter::~FileStreamWriter() {
-	fileStream.close();
+	file.close();
 }
 
 void FileStreamWriter::WriteImplementation(const void* buffer, std::size_t size)
 {
-	fileStream.write(static_cast<const char*>(buffer), size);
+	file.write(static_cast<const char*>(buffer), size);
 }
 
 uint64_t FileStreamWriter::Length()
 {
-	auto currentPosition = fileStream.tellp();  // Record current position
-	fileStream.seekp(0, std::ios_base::end);    // Seek to end of file
-	auto length = fileStream.tellp();   // Record current position (length of file)
-	fileStream.seekp(currentPosition);  // Restore position
+	auto currentPosition = file.tellp();  // Record current position
+	file.seekp(0, std::ios_base::end);    // Seek to end of file
+	auto length = file.tellp();   // Record current position (length of file)
+	file.seekp(currentPosition);  // Restore position
 	return length;
 }
 
 uint64_t FileStreamWriter::Position()
 {
-	return fileStream.tellp();  // Return the current put pointer
+	return file.tellp();  // Return the current put pointer
 }
 
 void FileStreamWriter::Seek(uint64_t offset)
 {
-	fileStream.seekp(offset);
+	file.seekp(offset);
 }
 
 void FileStreamWriter::SeekRelative(int64_t offset)
 {
-	fileStream.seekp(offset, std::ios_base::cur);
+	file.seekp(offset, std::ios_base::cur);
 }

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -26,6 +26,6 @@ protected:
 	void WriteImplementation(const void* buffer, std::size_t size) override;
 
 private:
-	std::fstream fileStream;
 	const std::string filename;
+	std::fstream fileStream;
 };

--- a/Streams/FileStreamWriter.h
+++ b/Streams/FileStreamWriter.h
@@ -27,5 +27,5 @@ protected:
 
 private:
 	const std::string filename;
-	std::fstream fileStream;
+	std::fstream file;
 };


### PR DESCRIPTION
This fixes #91.

I went with `file` for the member variable name, since it's largely irrelevant if the member variable provides file access through a stream interface or not. Perhaps at some point in the future it might change to a random access file class.
