### PR TITLE
Remove bool return from create archive

### DIFF
--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -15,10 +15,11 @@ namespace Archives
 
 		// Repack is used to replace the old volume with a new volume created from the
 		// files (in the current directory) that match the internal file names
-		virtual bool Repack() = 0;
+		virtual void Repack() = 0;
+
 		// Create volume is used to create a new volume file with the files specified in filesToPack.
 		// Returns true if successful and false otherwise
-		virtual bool CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack) = 0;
+		virtual void CreateArchive(const std::string& volumeFileName, std::vector<std::string> filesToPack) = 0;
 
 	protected:
 		// Returns the filenames from each path stripping the rest of the path. 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -126,7 +126,7 @@ namespace Archives
 
 	// Repacks the volume using the same files as are specified by the internal file names
 	// Returns nonzero if successful and zero otherwise
-	bool ClmFile::Repack()
+	void ClmFile::Repack()
 	{
 		std::vector<std::string> filesToPack(m_NumberOfPackedFiles);
 		std::vector<std::string> internalNames(m_NumberOfPackedFiles);
@@ -138,39 +138,27 @@ namespace Archives
 		}
 
 		const std::string tempFileName = "temp.clm";
-		if (!CreateArchive(tempFileName, filesToPack)) {
-			return false;
-		}
+		CreateArchive(tempFileName, filesToPack);
 
 		// Rename the output file to the desired file
-		try {
-			XFile::RenameFile(tempFileName, m_ArchiveFileName);
-			return true;
-		}
-		catch (std::exception&) {
-			return false;
-		}
+		XFile::RenameFile(tempFileName, m_ArchiveFileName);
 	}
 
 	// Creates a new Archive file with the file name archiveFileName. The
 	// files listed in the container filesToPack are packed into the archive.
 	// Automatically strips file name extensions from filesToPack. 
 	// Returns nonzero if successful and zero otherwise.
-	bool ClmFile::CreateArchive(std::string archiveFileName, std::vector<std::string> filesToPack)
+	void ClmFile::CreateArchive(const std::string& archiveFileName, std::vector<std::string> filesToPack)
 	{
 		// Sort files alphabetically based on the fileName only (not including the full path).
 		// Packed files must be locatable by a binary search of their fileName.
 		std::sort(filesToPack.begin(), filesToPack.end(), ComparePathFilenames);
 
 		std::vector<std::unique_ptr<FileStreamReader>> filesToPackReaders;
-		try {
-			// Opens all files for packing. If there is a problem opening a file, an exception is raised.
-			for (const auto& fileName : filesToPack) {
-				filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
-			}
-		}
-		catch (std::exception&) {
-			return false;
+
+		// Opens all files for packing. If there is a problem opening a file, an exception is raised.
+		for (const auto& fileName : filesToPack) {
+			filesToPackReaders.push_back(std::make_unique<FileStreamReader>(fileName));
 		}
 
 		// Initialize vectors with default values for the number of files to pack. 
@@ -181,35 +169,16 @@ namespace Archives
 		ReadAllWaveHeaders(filesToPackReaders, waveFormats, indexEntries);
 
 		// Check if all wave formats are the same
-		if (!CompareWaveFormats(waveFormats)) {	
-			return false; // Not all wave formats match
-		}
+		CompareWaveFormats(waveFormats);
 
 		std::vector<std::string> internalFileNames = GetInternalNamesFromPaths(filesToPack);
 		internalFileNames = StripFileNameExtensions(internalFileNames);
 		// Allowing duplicate names when packing may cause unintended results during binary search and file extraction.
-		CheckSortedContainerForDuplicateNames(internalFileNames); 
+		CheckSortedContainerForDuplicateNames(internalFileNames);
 
 		// Write the archive header and copy files into the archive
-		try {
-			WaveFormatEx waveFormat;
-
-			if (waveFormats.size() > 0) {
-				waveFormat = waveFormats[0];
-			}
-			else {
-				waveFormat = CreateDefaultWaveFormat();
-			}
-
-			WriteArchive(archiveFileName, filesToPackReaders, indexEntries, internalFileNames, waveFormat);
-		}
-		catch (std::exception&) {
-			return false; // Error writing CLM archive file
-		}
-
-		return true;
+		WriteArchive(archiveFileName, filesToPackReaders, indexEntries, internalFileNames, PrepareWaveFormat(waveFormats));
 	}
-
 
 	// Reads the beginning of each file and verifies it is formatted as a WAVE file. Locates
 	// the WaveFormatEx structure and start of data. The WaveFormat is stored in the waveFormats container.
@@ -285,21 +254,19 @@ namespace Archives
 	}
 
 	// Compares wave format structures in the waveFormats container
-	// Returns true if they are all the same and false otherwise.
-	bool ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats)
+	// If 2 wave formats are discovered of different type, an error is thrown.
+	void ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats)
 	{
-		for (std::size_t i = 1; i < waveFormats.size(); i++)
+		for (const auto& waveFormat : waveFormats)
 		{
-			if (memcmp(&waveFormats[i], &waveFormats[0], sizeof(WaveFormatEx))) {
-				return false;
+			if (memcmp(&waveFormat, &waveFormats[0], sizeof(WaveFormatEx))) {
+				throw std::runtime_error("Operation aborted. Two files contain separate wave file formats.");
 			}
 		}
-
-		return true;
 	}
 
-	void ClmFile::WriteArchive(std::string& archiveFileName,
-		std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
+	void ClmFile::WriteArchive(const std::string& archiveFileName,
+		const std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 		std::vector<IndexEntry>& indexEntries,
 		const std::vector<std::string>& internalNames,
 		const WaveFormatEx& waveFormat)
@@ -346,17 +313,21 @@ namespace Archives
 		return strippedExtensions;
 	}
 
-	WaveFormatEx ClmFile::CreateDefaultWaveFormat()
+	WaveFormatEx ClmFile::PrepareWaveFormat(const std::vector<WaveFormatEx>& waveFormats) 
 	{
-		return WaveFormatEx{
-			1, // WAVE_FORMAT_PCM
-			1, // mono
-			22050, // 22.05KHz
-			44100, // nSamplesPerSec * nBlockAlign
-			2, // 2 bytes/sample = nChannels * wBitsPerSample / 8
-			16,
-			0
-		};
+		if (waveFormats.empty()) {
+			return WaveFormatEx{
+				1, // WAVE_FORMAT_PCM
+				1, // mono
+				22050, // 22.05KHz
+				44100, // nSamplesPerSec * nBlockAlign
+				2, // 2 bytes/sample = nChannels * wBitsPerSample / 8
+				16,
+				0
+			};
+		}
+
+		return waveFormats.front();
 	}
 
 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -169,7 +169,7 @@ namespace Archives
 		ReadAllWaveHeaders(filesToPackReaders, waveFormats, indexEntries);
 
 		// Check if all wave formats are the same
-		CompareWaveFormats(waveFormats);
+		CompareWaveFormats(waveFormats, filesToPack);
 
 		std::vector<std::string> internalFileNames = GetInternalNamesFromPaths(filesToPack);
 		internalFileNames = StripFileNameExtensions(internalFileNames);
@@ -255,12 +255,13 @@ namespace Archives
 
 	// Compares wave format structures in the waveFormats container
 	// If 2 wave formats are discovered of different type, an error is thrown.
-	void ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats)
+	void ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats, const std::vector<std::string>& filesToPack)
 	{
-		for (const auto& waveFormat : waveFormats)
+		for (std::size_t i = 0; i < waveFormats.size(); i++)
 		{
-			if (memcmp(&waveFormat, &waveFormats[0], sizeof(WaveFormatEx))) {
-				throw std::runtime_error("Operation aborted. Two files contain separate wave file formats.");
+			if (memcmp(&waveFormats[0], &waveFormats[i], sizeof(WaveFormatEx))) {
+				throw std::runtime_error("Files " + filesToPack[0] + " and " + filesToPack[i] + 
+					" contain differnt wave formats. Clm files cannot contain 2 wave files with different formats.");
 			}
 		}
 	}

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -26,8 +26,8 @@ namespace Archives
 
 		uint32_t GetInternalFileSize(int index);
 
-		bool Repack();
-		bool CreateArchive(std::string archiveFileName, std::vector<std::string> filesToPack);
+		void Repack();
+		void CreateArchive(const std::string& archiveFileName, std::vector<std::string> filesToPack);
 
 	private:
 #pragma pack(push, 1)
@@ -64,13 +64,13 @@ namespace Archives
 		// Private functions for packing files
 		void ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
 		uint32_t FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
-		static bool CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
-		void WriteArchive(std::string& archiveFileName, std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
+		static void CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
+		void WriteArchive(const std::string& archiveFileName, const std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
 		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
 		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
-		static WaveFormatEx CreateDefaultWaveFormat();
+		static WaveFormatEx PrepareWaveFormat(const std::vector<WaveFormatEx>& waveFormats);
 
 		FileStreamReader clmFileReader;
 		ClmHeader clmHeader;

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -64,7 +64,7 @@ namespace Archives
 		// Private functions for packing files
 		void ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
 		uint32_t FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
-		static void CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats);
+		static void CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormatsconst, const std::vector<std::string>& filesToPack);
 		void WriteArchive(const std::string& archiveFileName, const std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
 		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -169,7 +169,7 @@ namespace Archives
 
 
 
-	bool VolFile::Repack()
+	void VolFile::Repack()
 	{
 		std::vector<std::string> filesToPack(m_NumberOfPackedFiles);
 
@@ -180,21 +180,13 @@ namespace Archives
 		}
 
 		const std::string tempFileName("temp.vol");
-		if (!CreateArchive(tempFileName, filesToPack)) {
-			return false;
-		}
+		CreateArchive(tempFileName, filesToPack);
 
 		// Rename the output file to the desired file
-		try {
-			XFile::RenameFile(tempFileName, m_ArchiveFileName);
-			return true;
-		}
-		catch (std::exception&) {
-			return false;
-		}
+		XFile::RenameFile(tempFileName, m_ArchiveFileName);
 	}
 
-	bool VolFile::CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack)
+	void VolFile::CreateArchive(const std::string& volumeFileName, std::vector<std::string> filesToPack)
 	{
 		// Sort files alphabetically based on the fileName only (not including the full path).
 		// Packed files must be locatable by a binary search of their fileName.
@@ -211,14 +203,7 @@ namespace Archives
 		// Open input files and prepare header and indexing info
 		PrepareHeader(volInfo);
 
-		try {
-			WriteVolume(volumeFileName, volInfo);
-		}
-		catch (std::exception&) {
-			return false;
-		}
-
-		return true;
+		WriteVolume(volumeFileName, volInfo);
 	}
 
 	void VolFile::WriteVolume(const std::string& fileName, CreateVolumeInfo& volInfo) 

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -33,8 +33,8 @@ namespace Archives
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
 		// Volume Creation
-		bool Repack();
-		bool CreateArchive(std::string volumeFileName, std::vector<std::string> filesToPack);
+		void Repack();
+		void CreateArchive(const std::string& volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
 		int GetInternalFileOffset(int index);


### PR DESCRIPTION
In addition to the title:

 - Set argument volumeFileName in CreateArchive as a const reference
 - Replace bool return from CompareWaveFormats to throw an exception if WaveFormats do not match
 - Move code to select proper WaveFormat when Writing a ClmFile into a subfunction
 - Provide filenames of offending files when WaveFormat does not match 

Closes #44. 