### PR TITLE
Allow creating archives without opening an existing archive first

### DIFF
--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -17,22 +17,18 @@ namespace Archives
 		// files (in the current directory) that match the internal file names
 		virtual void Repack() = 0;
 
-		// Create volume is used to create a new volume file with the files specified in filesToPack.
-		// Returns true if successful and false otherwise
-		virtual void CreateArchive(const std::string& volumeFileName, std::vector<std::string> filesToPack) = 0;
-
 	protected:
 		// Returns the filenames from each path stripping the rest of the path. 
-		std::vector<std::string> GetInternalNamesFromPaths(const std::vector<std::string>& paths);
+		static std::vector<std::string> GetInternalNamesFromPaths(const std::vector<std::string>& paths);
 
 		// Throws an error if 2 internalNames are identical, case insensitve. 
 		// internalNames must be presorted. 
-		void CheckSortedContainerForDuplicateNames(const std::vector<std::string>& internalNames);
+		static void CheckSortedContainerForDuplicateNames(const std::vector<std::string>& internalNames);
 
 		// Compares 2 filenames case insensitive to determine which comes first alphabetically.
 		// Does not compare the entire path, but only the filename.
 		static bool ComparePathFilenames(const std::string path1, const std::string path2);
 
-		void WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength);
+		static void WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength);
 	};
 }

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -27,7 +27,9 @@ namespace Archives
 		uint32_t GetInternalFileSize(int index);
 
 		void Repack();
-		void CreateArchive(const std::string& archiveFileName, std::vector<std::string> filesToPack);
+
+		// Create a new archive with the files specified in filesToPack
+		static void CreateArchive(const std::string& archiveFileName, std::vector<std::string> filesToPack);
 
 	private:
 #pragma pack(push, 1)
@@ -61,15 +63,16 @@ namespace Archives
 		// Private functions for reading archive
 		void ReadHeader();
 
-		// Private functions for packing files
-		void ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
-		uint32_t FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
-		static void CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormatsconst, const std::vector<std::string>& filesToPack);
-		void WriteArchive(const std::string& archiveFileName, const std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
-			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
-		void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
-		std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		void InitializeWaveHeader(WaveHeader& headerOut, int fileIndex);
+
+		// Private functions for packing files
+		static void ReadAllWaveHeaders(std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
+		static uint32_t FindChunk(std::array<char, 4> chunkTag, SeekableStreamReader& seekableStreamReader);
+		static void CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormatsconst, const std::vector<std::string>& filesToPack);
+		static void WriteArchive(const std::string& archiveFileName, const std::vector<std::unique_ptr<FileStreamReader>>& filesToPackReaders,
+			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& internalNames, const WaveFormatEx& waveFormat);
+		static void PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries);
+		static std::vector<std::string> StripFileNameExtensions(std::vector<std::string> paths);
 		static WaveFormatEx PrepareWaveFormat(const std::vector<WaveFormatEx>& waveFormats);
 
 		FileStreamReader clmFileReader;

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -204,7 +204,7 @@ namespace Archives
 		CheckSortedContainerForDuplicateNames(volInfo.internalNames);
 
 		// Open input files and prepare header and indexing info
-		PrepareHeader(volInfo);
+		PrepareHeader(volInfo, volumeFileName);
 
 		WriteVolume(volumeFileName, volInfo);
 	}
@@ -267,7 +267,7 @@ namespace Archives
 		volWriter.Write(&padding, volInfo.paddedIndexTableLength - volInfo.indexTableLength);
 	}
 
-	void VolFile::OpenAllInputFiles(CreateVolumeInfo &volInfo)
+	void VolFile::OpenAllInputFiles(CreateVolumeInfo &volInfo, const std::string& volumeFileName)
 	{
 		volInfo.fileStreamReaders.clear();
 
@@ -277,14 +277,14 @@ namespace Archives
 			}
 			catch (const std::exception& e) {
 				throw std::runtime_error("Error attempting to open " + filename + 
-					" for reading into volume " + m_ArchiveFileName + ". Internal Error: " + e.what());
+					" for reading into volume " + volumeFileName + ". Internal Error: " + e.what());
 			}
 		}
 	}
 
-	void VolFile::PrepareHeader(CreateVolumeInfo &volInfo)
+	void VolFile::PrepareHeader(CreateVolumeInfo &volInfo, const std::string& volumeFileName)
 	{
-		OpenAllInputFiles(volInfo);
+		OpenAllInputFiles(volInfo, volumeFileName);
 
 		volInfo.stringTableLength = 0;
 
@@ -295,7 +295,8 @@ namespace Archives
 
 			uint64_t fileSize = volInfo.fileStreamReaders[i]->Length();
 			if (fileSize > UINT32_MAX) {
-				throw std::runtime_error("File " + volInfo.filesToPack[i] + " is too large to fit inside a volume archive.");
+				throw std::runtime_error("File " + volInfo.filesToPack[i] + 
+					" is too large to fit inside a volume archive. Writing volume " + volumeFileName + " aborted.");
 			}
 
 			indexEntry.fileSize = static_cast<uint32_t>(volInfo.fileStreamReaders[i]->Length());

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -34,7 +34,9 @@ namespace Archives
 
 		// Volume Creation
 		void Repack();
-		void CreateArchive(const std::string& volumeFileName, std::vector<std::string> filesToPack);
+
+		// Create a new archive with the files specified in filesToPack
+		static void CreateArchive(const std::string& volumeFileName, std::vector<std::string> filesToPack);
 
 	private:
 		int GetInternalFileOffset(int index);
@@ -92,12 +94,13 @@ namespace Archives
 		void ReadVolHeader();
 		void ReadStringTable();
 		void ReadPackedFileCount();
-		void WriteVolume(const std::string& fileName, CreateVolumeInfo& volInfo);
-		void WriteFiles(StreamWriter& volWriter, CreateVolumeInfo &volInfo);
-		void WriteHeader(StreamWriter& volWriter, const CreateVolumeInfo &volInfo);
-		void PrepareHeader(CreateVolumeInfo &volInfo);
-		void OpenAllInputFiles(CreateVolumeInfo &volInfo);
 		SectionHeader GetSectionHeader(int index);
+
+		static void WriteVolume(const std::string& fileName, CreateVolumeInfo& volInfo);
+		static void WriteFiles(StreamWriter& volWriter, CreateVolumeInfo &volInfo);
+		static void WriteHeader(StreamWriter& volWriter, const CreateVolumeInfo &volInfo);
+		static void PrepareHeader(CreateVolumeInfo &volInfo, const std::string& volumeFileName);
+		static void OpenAllInputFiles(CreateVolumeInfo &volInfo, const std::string& volumeFileName);
 
 		FileStreamReader archiveFileReader;
 		uint32_t m_NumberOfIndexEntries;


### PR DESCRIPTION
 - Remove virtual function CreateArchive from ArchivePacker
 - Make ClmFile and VolFile's CreateArchive functions static
 - Make all subfunctions involved in creating an archive static


Closes #29 