### PR TITLE
Standardize for loops

### DIFF
--- a/Archives/AdaptHuffTree.cpp
+++ b/Archives/AdaptHuffTree.cpp
@@ -21,7 +21,7 @@ namespace Archives
 
 		// Initialize the tree
 		// Initialize terminal nodes
-		for (i = 0; i < m_NumTerminalNodes; i++)
+		for (i = 0; i < m_NumTerminalNodes; ++i)
 		{
 			m_Data[i] = i + m_NumNodes;						// Initilize data values
 			m_Count[i] = 1;
@@ -30,7 +30,7 @@ namespace Archives
 		}
 		// Initialize non terminal nodes
 		left = 0;
-		for (i = m_NumTerminalNodes; i < m_NumNodes; i++)
+		for (i = m_NumTerminalNodes; i < m_NumNodes; ++i)
 		{
 			m_Data[i] = left;								// Initialize link values
 			m_Count[i] = m_Count[left] + m_Count[left + 1];	// Count is sum of two subtrees

--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -22,7 +22,7 @@ namespace Archives
 		}
 	}
 
-	bool ArchiveUnpacker::ContainsFile(const char* fileName)
+	bool ArchiveUnpacker::ContainsFile(const std::string& fileName)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{

--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -14,11 +14,11 @@ namespace Archives
 
 	ArchiveUnpacker::~ArchiveUnpacker() { }
 
-	void ArchiveUnpacker::ExtractAllFiles(const char* destDirectory)
+	void ArchiveUnpacker::ExtractAllFiles(const std::string& destDirectory)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{
-			ExtractFile(i, XFile::ReplaceFilename(destDirectory, GetInternalFileName(i)).c_str());
+			ExtractFile(i, XFile::ReplaceFilename(destDirectory, GetInternalFileName(i)));
 		}
 	}
 

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -19,7 +19,7 @@ namespace Archives
 		std::string GetVolumeFileName() { return m_ArchiveFileName; };
 		uint64_t GetVolumeFileSize() { return m_ArchiveFileSize; };
 		int GetNumberOfPackedFiles() { return m_NumberOfPackedFiles; };
-		bool ContainsFile(const char* fileName);
+		bool ContainsFile(const std::string& fileName);
 
 		virtual std::string GetInternalFileName(int index) = 0;
 		// Returns -1 if internalFileName is not present in archive.

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -23,10 +23,10 @@ namespace Archives
 
 		virtual std::string GetInternalFileName(int index) = 0;
 		// Returns -1 if internalFileName is not present in archive.
-		virtual int GetInternalFileIndex(const char *internalFileName) = 0;
+		virtual int GetInternalFileIndex(const std::string& internalFileName) = 0;
 		virtual uint32_t GetInternalFileSize(int index) = 0;
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
-		virtual void ExtractAllFiles(const char* destDirectory);
+		virtual void ExtractAllFiles(const std::string& destDirectory);
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;
 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -45,7 +45,7 @@ namespace Archives
 		return indexEntries[index].GetFileName();
 	}
 
-	int ClmFile::GetInternalFileIndex(const char *internalFileName)
+	int ClmFile::GetInternalFileIndex(const std::string& internalFileName)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{
@@ -131,7 +131,7 @@ namespace Archives
 		std::vector<std::string> filesToPack(m_NumberOfPackedFiles);
 		std::vector<std::string> internalNames(m_NumberOfPackedFiles);
 
-		for (int i = 0; i < m_NumberOfPackedFiles; i++)
+		for (int i = 0; i < m_NumberOfPackedFiles; ++i)
 		{
 			//Filename is equivalent to internalName since filename is a relative path from current directory.
 			filesToPack[i] = GetInternalFileName(i) + ".wav";
@@ -190,7 +190,7 @@ namespace Archives
 		RiffHeader header;
 
 		// Read in all the headers and find start of data
-		for (std::size_t i = 0; i < filesToPackReaders.size(); i++)
+		for (std::size_t i = 0; i < filesToPackReaders.size(); ++i)
 		{
 			// Read the file header
 			filesToPackReaders[i]->Read(header);
@@ -253,7 +253,7 @@ namespace Archives
 	// If 2 wave formats are discovered of different type, an error is thrown.
 	void ClmFile::CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormats, const std::vector<std::string>& filesToPack)
 	{
-		for (std::size_t i = 0; i < waveFormats.size(); i++)
+		for (std::size_t i = 0; i < waveFormats.size(); ++i)
 		{
 			if (memcmp(&waveFormats[0], &waveFormats[i], sizeof(WaveFormatEx))) {
 				throw std::runtime_error("Files " + filesToPack[0] + " and " + filesToPack[i] + 
@@ -280,7 +280,7 @@ namespace Archives
 		clmFileWriter.Write(indexEntries.data(), header.packedFilesCount * sizeof(IndexEntry));
 
 		// Copy files into the archive
-		for (std::size_t i = 0; i < header.packedFilesCount; i++) {
+		for (std::size_t i = 0; i < header.packedFilesCount; ++i) {
 			ArchivePacker::WriteFromStream(clmFileWriter, *filesToPackReaders[i], indexEntries[i].dataLength);
 		}
 	}
@@ -288,7 +288,7 @@ namespace Archives
 	void ClmFile::PrepareIndex(int headerSize, const std::vector<std::string>& internalNames, std::vector<IndexEntry>& indexEntries)
 	{
 		uint32_t offset = headerSize + internalNames.size() * sizeof(IndexEntry);
-		for (std::size_t i = 0; i < internalNames.size(); i++)
+		for (std::size_t i = 0; i < internalNames.size(); ++i)
 		{
 			// Copy the filename into the entry
 			strncpy((char*)&indexEntries[i].fileName, internalNames[i].c_str(), 8);

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -19,7 +19,7 @@ namespace Archives
 		virtual ~ClmFile();
 
 		std::string GetInternalFileName(int index);
-		int GetInternalFileIndex(const char *internalFileName);
+		int GetInternalFileIndex(const std::string& internalFileName);
 		void ExtractFile(int fileIndex, const std::string& pathOut);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);

--- a/Archives/HuffLZ.cpp
+++ b/Archives/HuffLZ.cpp
@@ -189,8 +189,9 @@ namespace Archives
 			start = (m_BuffWriteIndex - offset - 1) & 0x0FFF;
 
 			// Copy for length = (code - 253) bytes
-			for (code -= 253; code; code--, start = (start + 1) & 0x0FFF)
+			for (code -= 253; code; code--, start = (start + 1) & 0x0FFF) {
 				WriteCharToBuffer(m_DecompressBuffer[start]);
+			}
 		}
 
 		// Check for the end of the stream
@@ -242,8 +243,9 @@ namespace Archives
 		else mod = (offset - 0xC0);
 
 		// Read in the extra bits
-		for (; numExtraBits; numExtraBits--)
+		for (; numExtraBits; numExtraBits--) {
 			offset = (offset << 1) + m_BitStream->ReadNextBit();
+		}
 		offset &= 0x3F;			// Mask upper bits (keep lower 6)
 
 		// Apply the modifier

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -33,7 +33,7 @@ namespace Archives
 		return m_StringTable[index];
 	}
 
-	int VolFile::GetInternalFileIndex(const char *internalFileName)
+	int VolFile::GetInternalFileIndex(const std::string& internalFileName)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
 		{
@@ -176,7 +176,7 @@ namespace Archives
 	{
 		std::vector<std::string> filesToPack(m_NumberOfPackedFiles);
 
-		for (int i = 0; i < m_NumberOfPackedFiles; i++)
+		for (int i = 0; i < m_NumberOfPackedFiles; ++i)
 		{
 			//Filename is equivalent to internalName since filename is a relative path from current directory.
 			filesToPack.push_back(GetInternalFileName(i));
@@ -220,7 +220,7 @@ namespace Archives
 	void VolFile::WriteFiles(StreamWriter& volWriter, CreateVolumeInfo &volInfo)
 	{
 		// Write each file header and contents
-		for (std::size_t i = 0; i < volInfo.fileCount(); i++)
+		for (std::size_t i = 0; i < volInfo.fileCount(); ++i)
 		{
 			volWriter.Write(SectionHeader(TagVBLK, volInfo.indexEntries[i].fileSize));
 
@@ -251,7 +251,7 @@ namespace Archives
 		volWriter.Write(&volInfo.stringTableLength, sizeof(volInfo.stringTableLength));
 
 		// Write out all internal file name strings (including NULL terminator)
-		for (std::size_t i = 0; i < volInfo.fileCount(); i++) {
+		for (std::size_t i = 0; i < volInfo.fileCount(); ++i) {
 			// Account for the null terminator in the size.
 			volWriter.Write(volInfo.internalNames[i].c_str(), volInfo.internalNames[i].size() + 1);
 		}
@@ -289,7 +289,7 @@ namespace Archives
 		volInfo.stringTableLength = 0;
 
 		// Get file sizes and calculate length of string table
-		for (std::size_t i = 0; i < volInfo.fileCount(); i++)
+		for (std::size_t i = 0; i < volInfo.fileCount(); ++i)
 		{
 			IndexEntry indexEntry;
 
@@ -317,7 +317,7 @@ namespace Archives
 		volInfo.indexEntries[0].dataBlockOffset = volInfo.paddedStringTableLength + volInfo.paddedIndexTableLength + 32;
 		
 		// Calculate offsets to the files
-		for (std::size_t i = 1; i < volInfo.fileCount(); i++)
+		for (std::size_t i = 1; i < volInfo.fileCount(); ++i)
 		{
 			const IndexEntry& previousIndex = volInfo.indexEntries[i - 1];
 			volInfo.indexEntries[i].dataBlockOffset = (previousIndex.dataBlockOffset + previousIndex.fileSize + 11) & ~3;
@@ -399,7 +399,7 @@ namespace Archives
 		archiveFileReader.Read(&charBuffer[0], actualStringTableLength);
 
 		m_StringTable.push_back("");
-		for (std::size_t i = 0; i < charBuffer.size(); i++)
+		for (std::size_t i = 0; i < charBuffer.size(); ++i)
 		{
 			if (charBuffer[i] == '\0') {
 				m_StringTable.push_back("");
@@ -419,7 +419,7 @@ namespace Archives
 	{
 		// Count the number of valid entries
 		uint32_t packedFileCount = 0;
-		for (; packedFileCount < m_NumberOfIndexEntries; packedFileCount++)
+		for (; packedFileCount < m_NumberOfIndexEntries; ++packedFileCount)
 		{
 			// Make sure entry is valid
 			if (m_IndexEntries[packedFileCount].fileNameOffset == UINT_MAX) {

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -23,7 +23,7 @@ namespace Archives
 
 		// Internal file status
 		std::string GetInternalFileName(int index);
-		int GetInternalFileIndex(const char *internalFileName);
+		int GetInternalFileIndex(const std::string& internalFileName);
 		CompressionType GetInternalCompressionCode(int index);
 		uint32_t GetInternalFileSize(int index);
 

--- a/Maps/MapReader.cpp
+++ b/Maps/MapReader.cpp
@@ -84,16 +84,16 @@ namespace MapReader {
 		{
 			mapData.tilesetSources.resize(static_cast<std::size_t>(mapData.header.numTilesets));
 
-			for (unsigned int i = 0; i < mapData.header.numTilesets; ++i)
+			for (auto& tilesetSource : mapData.tilesetSources)
 			{
-				mapData.tilesetSources[i].tilesetFilename = ReadString(streamReader);
+				tilesetSource.tilesetFilename = ReadString(streamReader);
 
-				if (mapData.tilesetSources[i].tilesetFilename.size() > 8) {
+				if (tilesetSource.tilesetFilename.size() > 8) {
 					throw std::runtime_error("Tileset name may not be greater than 8 characters in length.");
 				}
 
-				if (mapData.tilesetSources[i].tilesetFilename.size() > 0) {
-					streamReader.Read(mapData.tilesetSources[i].numTiles);
+				if (tilesetSource.tilesetFilename.size() > 0) {
+					streamReader.Read(tilesetSource.numTiles);
 				}
 			}
 		}

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -142,8 +142,8 @@ bool ResourceManager::DuplicateFilename(std::vector<std::string>& currentFilenam
 
 	std::string filename = XFile::GetFilename(pathToCheck);
 
-	for (std::size_t i = 0; i < currentFilenames.size(); ++i) {
-		if (XFile::PathsAreEqual(XFile::GetFilename(currentFilenames[i]), filename)) {
+	for (const auto& currentFilename : currentFilenames) {
+		if (XFile::PathsAreEqual(XFile::GetFilename(currentFilename), filename)) {
 			return true;
 		}
 	}

--- a/StringHelper.cpp
+++ b/StringHelper.cpp
@@ -18,21 +18,19 @@ std::string StringHelper::ConvertToUpper(const std::string& str)
 }
 
 // Returns a new vector with matching strings removed. Case insensitive.
-std::vector<std::string> StringHelper::RemoveStrings(const std::vector<std::string>& stringsToSearch, const std::vector<std::string>& stringsToRemove)
+std::vector<std::string> StringHelper::RemoveStrings(std::vector<std::string> stringsToSearch, const std::vector<std::string>& stringsForRemoval)
 {
-	std::vector<std::string> stringsToReturn(stringsToSearch);
-
-	// i will wrap around to SIZE_MAX  when loop is completed
-	for (std::size_t i = stringsToSearch.size() - 1; i < stringsToSearch.size(); ++i) {
-		for (const auto& stringToRemove : stringsToRemove) {
+	// Loop starts at index size - 1 and ends after index 0 executes
+	for (std::size_t i = stringsToSearch.size(); i-- > 0; ) {
+		for (const auto& stringToRemove : stringsForRemoval) {
 			if (CheckIfStringsAreEqual(stringsToSearch[i], stringToRemove)) {
-				stringsToReturn.erase(stringsToReturn.begin() + i);
+				stringsToSearch.erase(stringsToSearch.begin() + i);
 				break;
 			}
 		}
 	}
 
-	return stringsToReturn;
+	return stringsToSearch;
 }
 
 bool StringHelper::CheckIfStringsAreEqual(const std::string& string1, const std::string& string2)

--- a/StringHelper.h
+++ b/StringHelper.h
@@ -8,7 +8,7 @@ class StringHelper
 public:
 	static void ConvertToUpper(std::string& str);
 	static std::string ConvertToUpper(const std::string& str);
-	static std::vector<std::string> RemoveStrings(const std::vector<std::string>& stringsToSearch, const std::vector<std::string>& stringsToRemove);
+	static std::vector<std::string> RemoveStrings(std::vector<std::string> stringsToSearch, const std::vector<std::string>& stringsForRemoval);
 	static bool CheckIfStringsAreEqual(const std::string& string1, const std::string& string2);
 	static bool ContainsStringCaseInsensitive(std::vector<std::string> stringsToSearch, std::string stringToFind);
 	static bool StringCompareCaseInsensitive(const std::string& string1, const std::string& string2);

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -83,7 +83,8 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 {
 	std::vector<std::string> filenames = GetFilesFromDirectory(directory);
 
-	for (std::size_t i = filenames.size() - 1; i >= 0; i--) 
+	// Loop starts at index size - 1 and ends after index 0 executes
+	for (std::size_t i = filenames.size(); i-- > 0; )
 	{
 		if (!std::regex_search(filenames[i], filenameRegex)) {
 			filenames.erase(filenames.begin() + i);
@@ -101,7 +102,8 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 {
 	std::vector<std::string> filenames = GetFilesFromDirectory(directory);
 
-	for (std::size_t i = filenames.size() - 1; i >= 0; --i)
+	// Loop starts at index size - 1 and ends after index 0 executes
+	for (std::size_t i = filenames.size(); i-- > 0; )
 	{
 		if (filenames.size() == 0) {
 			return filenames;

--- a/XFile.cpp
+++ b/XFile.cpp
@@ -89,10 +89,6 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 		if (!std::regex_search(filenames[i], filenameRegex)) {
 			filenames.erase(filenames.begin() + i);
 		}
-
-		if (i == 0) {
-			break;
-		}
 	}
 
 	return filenames;
@@ -112,10 +108,6 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 		std::string extension = fs::path(filenames[i]).extension().string();
 		if (extension != fileType) {
 			filenames.erase(filenames.begin() + i);
-		}
-
-		if (i == 0) {
-			break;
 		}
 	}
 


### PR DESCRIPTION
 - In For loops, use --/++i instead of i--/++
 - Change function ArchiveUnpacker::ExtractAllFiles argument to be a string instead of a char*
 - Remove unnessary c_str() call on string inside function ArchiveUnpacker::ExtractAllFiles
 - Change function ArchiveUnpacker::GetInternalFileIndex's argument to be a string instead of a char*
 - Increase use of range based loops and auto keyword in range based loops
 - Fix bug in StringHelper::RemoveStrings that only removed the first string marked for removal
 - Standardize use of loop for (std::size_t i = filenames.size(); i-- > 0; ) when counting down from size to 0

Tested by Extracting a Vol, and clm. Extracted a compressed sheets.vol. REMOVED 2 files from a clm file.

Closes #96 