### PR TITLE
Reduce charStar usage

### DIFF
--- a/Archives/ArchiveFile.h
+++ b/Archives/ArchiveFile.h
@@ -8,7 +8,7 @@ namespace Archives
 	class ArchiveFile : public ArchiveUnpacker, public ArchivePacker
 	{
 	public:
-		ArchiveFile(const char *fileName) : ArchiveUnpacker(fileName) {};
+		ArchiveFile(const std::string& fileName) : ArchiveUnpacker(fileName) {};
 		virtual ~ArchiveFile() {};
 	};
 }

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -27,7 +27,7 @@ namespace Archives
 		virtual uint32_t GetInternalFileSize(int index) = 0;
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
 		virtual void ExtractAllFiles(const std::string& destDirectory);
-		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName) = 0;
+		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFileName) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;
 
 	protected:

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -292,7 +292,7 @@ namespace Archives
 		for (std::size_t i = 0; i < internalNames.size(); ++i)
 		{
 			// Copy the filename into the entry
-			std::memcpy(indexEntries[i].fileName.data(), internalNames[i].data(), sizeof(IndexEntry::fileName));
+			std::strncpy(indexEntries[i].fileName.data(), internalNames[i].data(), sizeof(IndexEntry::fileName));
 
 			// Set the offset of the file
 			indexEntries[i].dataOffset = offset;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -2,6 +2,7 @@
 #include "../XFile.h"
 #include <stdexcept>
 #include <algorithm>
+#include <cstring>
 
 namespace Archives
 {
@@ -291,7 +292,7 @@ namespace Archives
 		for (std::size_t i = 0; i < internalNames.size(); ++i)
 		{
 			// Copy the filename into the entry
-			strncpy((char*)&indexEntries[i].fileName, internalNames[i].c_str(), 8);
+			std::memcpy(indexEntries[i].fileName.data(), internalNames[i].data(), sizeof(IndexEntry::fileName));
 
 			// Set the offset of the file
 			indexEntries[i].dataOffset = offset;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -5,7 +5,7 @@
 
 namespace Archives
 {
-	ClmFile::ClmFile(const char *fileName) : ArchiveFile(fileName), clmFileReader(fileName)
+	ClmFile::ClmFile(const std::string& fileName) : ArchiveFile(fileName), clmFileReader(fileName)
 	{
 		m_ArchiveFileSize = clmFileReader.Length();
 		ReadHeader();
@@ -106,7 +106,7 @@ namespace Archives
 		headerOut.dataChunk.length = indexEntries[fileIndex].dataLength;
 	}
 
-	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(const char* internalFileName)
+	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(const std::string& internalFileName)
 	{
 		int fileIndex = GetInternalFileIndex(internalFileName);
 

--- a/Archives/ClmFile.h
+++ b/Archives/ClmFile.h
@@ -15,13 +15,13 @@ namespace Archives
 	class ClmFile : public ArchiveFile
 	{
 	public:
-		ClmFile(const char *fileName);
+		ClmFile(const std::string& fileName);
 		virtual ~ClmFile();
 
 		std::string GetInternalFileName(int index);
 		int GetInternalFileIndex(const std::string& internalFileName);
 		void ExtractFile(int fileIndex, const std::string& pathOut);
-		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
+		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
 		uint32_t GetInternalFileSize(int index);

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -15,7 +15,7 @@ namespace Archives
 	const std::array<char, 4> TagVBLK{ 'V', 'B', 'L', 'K' }; // Packed file tag
 
 
-	VolFile::VolFile(const char *fileName) : ArchiveFile(fileName), archiveFileReader(fileName)
+	VolFile::VolFile(const std::string& fileName) : ArchiveFile(fileName), archiveFileReader(fileName)
 	{
 		m_ArchiveFileSize = archiveFileReader.Length();
 
@@ -72,7 +72,7 @@ namespace Archives
 		return m_IndexEntries[index].fileNameOffset;
 	}
 
-	std::unique_ptr<SeekableStreamReader> VolFile::OpenSeekableStreamReader(const char* internalFileName)
+	std::unique_ptr<SeekableStreamReader> VolFile::OpenSeekableStreamReader(const std::string& internalFileName)
 	{
 		int fileIndex = GetInternalFileIndex(internalFileName);
 

--- a/Archives/VolFile.h
+++ b/Archives/VolFile.h
@@ -18,7 +18,7 @@ namespace Archives
 	class VolFile : public ArchiveFile
 	{
 	public:
-		VolFile(const char *filename);
+		VolFile(const std::string& fileName);
 		~VolFile();
 
 		// Internal file status
@@ -29,7 +29,7 @@ namespace Archives
 
 		// Extraction
 		void ExtractFile(int fileIndex, const std::string& pathOut);
-		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const char *internalFileName);
+		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFileName);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
 		// Volume Creation

--- a/ResourceManager.cpp
+++ b/ResourceManager.cpp
@@ -11,13 +11,13 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory)
 	auto volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
 
 	for (const auto& volFilename : volFilenames) {
-		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename.c_str()));
+		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename));
 	}
 
 	auto clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
 
 	for (const auto& clmFilename : clmFilenames) {
-		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename.c_str()));
+		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename));
 	}
 }
 
@@ -36,7 +36,7 @@ std::unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const s
 	for (const auto& archiveFile : ArchiveFiles)
 	{
 		std::string internalArchiveFilename = XFile::GetFilename(filename);
-		int internalArchiveIndex = archiveFile->GetInternalFileIndex(internalArchiveFilename.c_str());
+		int internalArchiveIndex = archiveFile->GetInternalFileIndex(internalArchiveFilename);
 
 		if (internalArchiveIndex > -1) {
 			return archiveFile->OpenSeekableStreamReader(internalArchiveIndex);
@@ -116,7 +116,7 @@ bool ResourceManager::ExtractSpecificFile(const std::string& filename, bool over
 	int internalArchiveIndex;
 	if (ExistsInArchives(filename, fileIndex, internalArchiveIndex))
 	{
-		ArchiveFiles[fileIndex]->ExtractFile(internalArchiveIndex, filename.c_str());
+		ArchiveFiles[fileIndex]->ExtractFile(internalArchiveIndex, filename);
 		return true;
 	}
 
@@ -155,7 +155,7 @@ std::string ResourceManager::FindContainingArchiveFile(const std::string& filena
 {
 	for (const auto& archiveFile : ArchiveFiles)
 	{
-		int internalFileIndex = archiveFile->GetInternalFileIndex(filename.c_str());
+		int internalFileIndex = archiveFile->GetInternalFileIndex(filename);
 
 		if (internalFileIndex != -1) {
 			return XFile::GetFilename(archiveFile->GetVolumeFileName());

--- a/Streams/FileStreamWriter.cpp
+++ b/Streams/FileStreamWriter.cpp
@@ -3,7 +3,7 @@
 
 FileStreamWriter::FileStreamWriter(const std::string& filename) : 
 	filename(filename),
-	file(filename.c_str(), std::ios::trunc | std::ios::out | std::ios::binary)
+	file(filename, std::ios::trunc | std::ios::out | std::ios::binary)
 {
 	if (!file.is_open()) {
 		throw std::runtime_error("File could not be opened.");


### PR DESCRIPTION
 - Change function arguments from char* to string where appropriate
 - Remove unnecessary string.c_str calls


Some of the string.c_str calls were leftover from bad refactoring and some removals were allowed by changing out the function arguments.

This should implement string everywhere in the codebase where it would be preferred over char*. That took a long time to reach.