### PR TITLE
Allow Calling Slice on SeekableStreamReaders

### DIFF
--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -1,4 +1,5 @@
 #include "ClmFile.h"
+#include "../Streams/FileSliceReader.h"
 #include "../XFile.h"
 #include <stdexcept>
 #include <algorithm>
@@ -80,11 +81,11 @@ namespace Archives
 
 			waveFileWriter.Write(header);
 
-			std::unique_ptr<SeekableStreamReader> reader = clmFileReader.Slice(
+			FileSliceReader reader = clmFileReader.Slice(
 				indexEntries[fileIndex].dataOffset, 
 				indexEntries[fileIndex].dataLength);
 
-			ArchiveUnpacker::WriteFromStream(waveFileWriter, *reader, reader->Length());
+			ArchiveUnpacker::WriteFromStream(waveFileWriter, reader, reader.Length());
 		}
 		catch (const std::exception& e)
 		{

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -80,10 +80,11 @@ namespace Archives
 
 			waveFileWriter.Write(header);
 
-			// Seek to the beginning of the file data (in the .clm file)
-			clmFileReader.Seek(indexEntries[fileIndex].dataOffset);
+			std::unique_ptr<SeekableStreamReader> reader = clmFileReader.Slice(
+				indexEntries[fileIndex].dataOffset, 
+				indexEntries[fileIndex].dataLength);
 
-			ArchiveUnpacker::WriteFromStream(waveFileWriter, clmFileReader, indexEntries[fileIndex].dataLength);
+			ArchiveUnpacker::WriteFromStream(waveFileWriter, *reader, reader->Length());
 		}
 		catch (const std::exception& e)
 		{

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -1,4 +1,5 @@
 #include "VolFile.h"
+#include "../Streams/FileSliceReader.h"
 #include "../XFile.h"
 #include <stdexcept>
 #include <algorithm>
@@ -86,7 +87,7 @@ namespace Archives
 	{
 		SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 
-		return archiveFileReader.Slice(archiveFileReader.Position(), static_cast<uint64_t>(sectionHeader.length));
+		return std::make_unique<FileSliceReader>(archiveFileReader.Slice(archiveFileReader.Position(), static_cast<uint64_t>(sectionHeader.length)));
 	}
 
 	VolFile::SectionHeader VolFile::GetSectionHeader(int index)
@@ -132,9 +133,9 @@ namespace Archives
 			// Calling GetSectionHeader moves the streamReader's position to just past the SectionHeader
 			SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 
-			std::unique_ptr<SeekableStreamReader> slice = archiveFileReader.Slice(sectionHeader.length);
+			FileSliceReader slice = archiveFileReader.Slice(sectionHeader.length);
 
-			ArchiveUnpacker::WriteFromStream(pathOut, *slice, slice->Length());
+			ArchiveUnpacker::WriteFromStream(pathOut, slice, slice.Length());
 		}
 		catch (const std::exception& e)
 		{

--- a/Streams/FileSliceReader.cpp
+++ b/Streams/FileSliceReader.cpp
@@ -69,9 +69,9 @@ std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceLengt
 	return slice;
 }
 
-std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) 
+std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const
 {
-	if (sliceStartPosition + sliceLength > Length() ||
+	if (sliceStartPosition + sliceLength > this->sliceLength ||
 		sliceStartPosition + sliceLength < sliceStartPosition) // Check if length wraps past max size of uint64_t
 	{
 		throw std::runtime_error("Unable to create a slice of an existing file stream slice. Requested slice is outside bounds of underlying stream slice.");

--- a/Streams/FileSliceReader.cpp
+++ b/Streams/FileSliceReader.cpp
@@ -2,15 +2,30 @@
 #include <stdexcept>
 
 FileSliceReader::FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength) : 
-	fileStreamReader(filename), startingOffset(startingOffset), sliceLength(sliceLength)
+	fileStreamReader(filename), 
+	startingOffset(startingOffset), 
+	sliceLength(sliceLength)
+{
+	Initialize();
+}
+
+FileSliceReader::FileSliceReader(const FileSliceReader& fileSliceReader) :  
+	fileStreamReader(fileSliceReader.GetFilename()), 
+	startingOffset(fileSliceReader.startingOffset), 
+	sliceLength(fileSliceReader.sliceLength)
+{
+	Initialize();
+}
+
+void FileSliceReader::Initialize() 
 {
 	if (startingOffset + sliceLength < startingOffset) {
-		throw std::runtime_error("The supplied starting offset & length cause the ending offset to wrap past the largest allowed value in the FileSliceReader created on file " + 
+		throw std::runtime_error("The supplied starting offset & length cause the ending offset to wrap past the largest allowed value in the FileSliceReader created on file " +
 			fileStreamReader.GetFilename());
 	}
 
 	if (startingOffset + sliceLength > fileStreamReader.Length()) {
-		throw std::runtime_error("The ending offset of the FileSliceReader created on " + 
+		throw std::runtime_error("The ending offset of the FileSliceReader created on " +
 			fileStreamReader.GetFilename() + "is greater than the file's length");
 	}
 
@@ -59,9 +74,9 @@ void FileSliceReader::SeekRelative(int64_t offset)
 	fileStreamReader.SeekRelative(offset);
 }
 
-std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceLength) 
+FileSliceReader FileSliceReader::Slice(uint64_t sliceLength) 
 {
-	auto slice = Slice(startingOffset + Position(), sliceLength);
+	FileSliceReader slice = Slice(startingOffset + Position(), sliceLength);
 
 	// Wait until slice is successfully created before seeking forward.
 	SeekRelative(sliceLength);
@@ -69,7 +84,7 @@ std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceLengt
 	return slice;
 }
 
-std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const
+FileSliceReader FileSliceReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const
 {
 	if (sliceStartPosition + sliceLength > this->sliceLength ||
 		sliceStartPosition + sliceLength < sliceStartPosition) // Check if length wraps past max size of uint64_t
@@ -77,5 +92,5 @@ std::unique_ptr<SeekableStreamReader> FileSliceReader::Slice(uint64_t sliceStart
 		throw std::runtime_error("Unable to create a slice of an existing file stream slice. Requested slice is outside bounds of underlying stream slice.");
 	}
 
-	return std::make_unique<FileSliceReader>(GetFilename(), sliceStartPosition, sliceLength);
+	return FileSliceReader(GetFilename(), sliceStartPosition, sliceLength);
 }

--- a/Streams/FileSliceReader.h
+++ b/Streams/FileSliceReader.h
@@ -17,8 +17,8 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) override;
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) override;
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength);
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
 
 	inline const std::string& GetFilename() const {
 		return fileStreamReader.GetFilename();

--- a/Streams/FileSliceReader.h
+++ b/Streams/FileSliceReader.h
@@ -17,6 +17,9 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) override;
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) override;
+
 	inline const std::string& GetFilename() const {
 		return fileStreamReader.GetFilename();
 	}

--- a/Streams/FileSliceReader.h
+++ b/Streams/FileSliceReader.h
@@ -10,6 +10,7 @@ class FileSliceReader : public SeekableStreamReader
 {
 public:
 	FileSliceReader(std::string filename, uint64_t startingOffset, uint64_t sliceLength);
+	FileSliceReader(const FileSliceReader& fileSliceReader);
 
 	// SeekableStreamReader methods
 	uint64_t Length() override;
@@ -17,8 +18,8 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength);
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
+	FileSliceReader Slice(uint64_t sliceLength);
+	FileSliceReader Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
 
 	inline const std::string& GetFilename() const {
 		return fileStreamReader.GetFilename();
@@ -28,6 +29,8 @@ protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
+	void Initialize();
+
 	FileStreamReader fileStreamReader;
 	const uint64_t startingOffset;
 	const uint64_t sliceLength;

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -1,4 +1,5 @@
 #include "FileStreamReader.h"
+#include "FileSliceReader.h"
 #include <stdexcept>
 
 // Defers calls to C++ standard library methods
@@ -37,4 +38,18 @@ void FileStreamReader::Seek(uint64_t position) {
 
 void FileStreamReader::SeekRelative(int64_t offset) {
 	file.seekg(offset, std::ios_base::cur);
+}
+
+std::unique_ptr<SeekableStreamReader> FileStreamReader::Slice(uint64_t sliceLength) 
+{
+	auto slice = Slice(Position(), sliceLength);
+
+	// Wait until slice is successfully created before seeking forward.
+	SeekRelative(sliceLength);
+
+	return slice;
+}
+
+std::unique_ptr<SeekableStreamReader> FileStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) {
+	return std::make_unique<FileSliceReader>(filename, sliceStartPosition, sliceLength);
 }

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -40,16 +40,16 @@ void FileStreamReader::SeekRelative(int64_t offset) {
 	file.seekg(offset, std::ios_base::cur);
 }
 
-std::unique_ptr<SeekableStreamReader> FileStreamReader::Slice(uint64_t sliceLength) 
+FileSliceReader FileStreamReader::Slice(uint64_t sliceLength) 
 {
-	auto slice = Slice(Position(), sliceLength);
+	return Slice(Position(), sliceLength);
 
 	// Wait until slice is successfully created before seeking forward.
 	SeekRelative(sliceLength);
 
-	return slice;
+	//return sliceOut;
 }
 
-std::unique_ptr<SeekableStreamReader> FileStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) {
-	return std::make_unique<FileSliceReader>(filename, sliceStartPosition, sliceLength);
+FileSliceReader FileStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const {
+	return FileSliceReader(filename, sliceStartPosition, sliceLength);
 }

--- a/Streams/FileStreamReader.cpp
+++ b/Streams/FileStreamReader.cpp
@@ -7,6 +7,18 @@ FileStreamReader::FileStreamReader(std::string filename) :
 	filename(filename),
 	file(filename, std::ios::in | std::ios::binary)
 {
+	Initialize();
+}
+
+FileStreamReader::FileStreamReader(const FileStreamReader& fileStreamReader) :
+	filename(fileStreamReader.filename),
+	file(fileStreamReader.filename, std::ios::in | std::ios::binary)
+{
+	Initialize();
+}
+
+void FileStreamReader::Initialize()
+{
 	if (!file.is_open()) {
 		throw std::runtime_error("Could not open file: " + filename);
 	}
@@ -42,12 +54,12 @@ void FileStreamReader::SeekRelative(int64_t offset) {
 
 FileSliceReader FileStreamReader::Slice(uint64_t sliceLength) 
 {
-	return Slice(Position(), sliceLength);
+	FileSliceReader slice = Slice(Position(), sliceLength);
 
 	// Wait until slice is successfully created before seeking forward.
 	SeekRelative(sliceLength);
 
-	//return sliceOut;
+	return slice;
 }
 
 FileSliceReader FileStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const {

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -6,6 +6,8 @@
 #include <cstddef>
 #include <cstdint>
 
+class FileSliceReader;
+
 class FileStreamReader : public SeekableStreamReader {
 public:
 	FileStreamReader(std::string fileName);
@@ -17,8 +19,12 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) override;
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) override;
+	// Create a slice of the stream for independent processing. Starts at current position of stream. 
+	// Seeks parent stream forward the slice's length if creation is successful.
+	FileSliceReader Slice(uint64_t sliceLength);
+
+	// Create a slice of the stream for independent processing.
+	FileSliceReader Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
 
 	inline const std::string& GetFilename() const {
 		return filename;

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -11,6 +11,7 @@ class FileSliceReader;
 class FileStreamReader : public SeekableStreamReader {
 public:
 	FileStreamReader(std::string fileName);
+	FileStreamReader(const FileStreamReader& fileStreamReader);
 	~FileStreamReader() override;
 
 	// SeekableStreamReader methods
@@ -34,6 +35,8 @@ protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
+	void FileStreamReader::Initialize();
+
 	const std::string filename;
 	std::ifstream file;
 };

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -17,6 +17,9 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) override;
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) override;
+
 	inline const std::string& GetFilename() const {
 		return filename;
 	}

--- a/Streams/FileStreamReader.h
+++ b/Streams/FileStreamReader.h
@@ -35,7 +35,7 @@ protected:
 	void ReadImplementation(void* buffer, std::size_t size) override;
 
 private:
-	void FileStreamReader::Initialize();
+	void Initialize();
 
 	const std::string filename;
 	std::ifstream file;

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -3,8 +3,8 @@
 #include <cstring> //memcpy
 #include <stdexcept>
 
-MemoryStreamReader::MemoryStreamReader(void* buffer, std::size_t size) : 
-	streamBuffer(static_cast<char*>(buffer)), streamSize(size), position(0) { }
+MemoryStreamReader::MemoryStreamReader(const void* const buffer, std::size_t size) : 
+	streamBuffer(static_cast<const char* const>(buffer)), streamSize(size), position(0) { }
 
 void MemoryStreamReader::ReadImplementation(void* buffer, std::size_t size)
 {
@@ -71,5 +71,5 @@ MemoryStreamReader MemoryStreamReader::Slice(uint64_t sliceStartPosition, uint64
 		throw std::runtime_error("Unable to create a slice of memory stream. Requested slice is outside bounds of underlying stream.");
 	}
 
-	return MemoryStreamReader((void*)(&streamBuffer[sliceStartPosition]), static_cast<std::size_t>(sliceLength));
+	return MemoryStreamReader(&streamBuffer[sliceStartPosition], static_cast<std::size_t>(sliceLength));
 }

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -49,7 +49,7 @@ void MemoryStreamReader::SeekRelative(int64_t offset)
 	this->position += static_cast<std::size_t>(offset); 
 }
 
-std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceLength) 
+MemoryStreamReader MemoryStreamReader::Slice(uint64_t sliceLength) 
 {
 	auto slice = Slice(Position(), sliceLength);
 
@@ -59,7 +59,7 @@ std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceLe
 	return slice;
 }
 
-std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength)  const
+MemoryStreamReader MemoryStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength)  const
 {
 	if (sliceStartPosition > SIZE_MAX || sliceLength > SIZE_MAX) {
 		throw std::runtime_error("Slice starting position and Slice length for creating a new memory stream slice must be smaller values.");
@@ -71,5 +71,5 @@ std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceSt
 		throw std::runtime_error("Unable to create a slice of memory stream. Requested slice is outside bounds of underlying stream.");
 	}
 
-	return std::make_unique<MemoryStreamReader>((void*)&streamBuffer[sliceStartPosition], static_cast<std::size_t>(sliceLength));
+	return MemoryStreamReader((void*)(&streamBuffer[sliceStartPosition]), static_cast<std::size_t>(sliceLength));
 }

--- a/Streams/MemoryStreamReader.cpp
+++ b/Streams/MemoryStreamReader.cpp
@@ -59,13 +59,13 @@ std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceLe
 	return slice;
 }
 
-std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength) 
+std::unique_ptr<SeekableStreamReader> MemoryStreamReader::Slice(uint64_t sliceStartPosition, uint64_t sliceLength)  const
 {
 	if (sliceStartPosition > SIZE_MAX || sliceLength > SIZE_MAX) {
 		throw std::runtime_error("Slice starting position and Slice length for creating a new memory stream slice must be smaller values.");
 	}
 
-	if (sliceStartPosition + sliceLength > Length() ||
+	if (sliceStartPosition + sliceLength > streamSize ||
 		sliceStartPosition + sliceLength < sliceStartPosition) // Check if length wraps past max size of uint64_t
 	{ 
 		throw std::runtime_error("Unable to create a slice of memory stream. Requested slice is outside bounds of underlying stream.");

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -14,8 +14,8 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) override;
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) override;
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength);
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
 
 protected:
 	// StreamReader methods

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -6,7 +6,7 @@
 
 class MemoryStreamReader : public SeekableStreamReader {
 public:
-	MemoryStreamReader(void* buffer, std::size_t size);
+	MemoryStreamReader(const void* const buffer, std::size_t size);
 
 	// SeekableStreamReader methods
 	uint64_t Length() override;

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -14,8 +14,8 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength);
-	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
+	MemoryStreamReader Slice(uint64_t sliceLength);
+	MemoryStreamReader Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const;
 
 protected:
 	// StreamReader methods

--- a/Streams/MemoryStreamReader.h
+++ b/Streams/MemoryStreamReader.h
@@ -14,6 +14,9 @@ public:
 	void Seek(uint64_t position) override;
 	void SeekRelative(int64_t offset) override;
 
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) override;
+	std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) override;
+
 protected:
 	// StreamReader methods
 	void ReadImplementation(void* buffer, std::size_t size) override;

--- a/Streams/SeekableStreamReader.h
+++ b/Streams/SeekableStreamReader.h
@@ -17,11 +17,4 @@ public:
 
 	// Seek by a relative amount, given as offset from current position
 	virtual void SeekRelative(int64_t offset) = 0;
-
-	// Create a slice of the stream for independent processing. Starts at current position of stream. 
-	// Seeks parent stream forward the slice's length if creation is successful.
-	virtual std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) = 0;
-
-	// Create a slice of the stream for independent processing.
-	virtual std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) = 0;
 };

--- a/Streams/SeekableStreamReader.h
+++ b/Streams/SeekableStreamReader.h
@@ -2,7 +2,6 @@
 
 #include "StreamReader.h"
 #include <cstdint>
-#include <memory>
 
 class SeekableStreamReader : public StreamReader {
 public:

--- a/Streams/SeekableStreamReader.h
+++ b/Streams/SeekableStreamReader.h
@@ -2,6 +2,7 @@
 
 #include "StreamReader.h"
 #include <cstdint>
+#include <memory>
 
 class SeekableStreamReader : public StreamReader {
 public:
@@ -16,4 +17,11 @@ public:
 
 	// Seek by a relative amount, given as offset from current position
 	virtual void SeekRelative(int64_t offset) = 0;
+
+	// Create a slice of the stream for independent processing. Starts at current position of stream. 
+	// Seeks parent stream forward the slice's length if creation is successful.
+	virtual std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceLength) = 0;
+
+	// Create a slice of the stream for independent processing.
+	virtual std::unique_ptr<SeekableStreamReader> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) = 0;
 };


### PR DESCRIPTION
I had to wrap the returned stream slice in a unique_ptr.

I'm a bit split about the addition here. What do others think?

MemoryStreamReader's Slice function is untested, so worth taking a closer look.

Thanks,
Brett
