### PR TITLE
Move "build/" folder to ".build/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 x64
 Debug
 Release
-build/
+.build/
 /*.user
 .vs

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ ifeq ($(origin CXX),default)
 endif
 
 SRCDIR := .
-BUILDDIR := build
+BUILDDIR := .build
 BINDIR := $(BUILDDIR)/bin
 OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps


### PR DESCRIPTION
Some source packages use a "build/" folder for build scripts. It may be
confusing to put build output there. Instead, place compiler outputs in
a ".build/" folder. Note: On Linux, files prefixed with a "." are hidden
files.