### PR TITLE
Add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+
+language: cpp
+sudo: false
+os:
+  - linux
+  - osx
+compiler:
+  - gcc
+  - clang
+script:
+  # Use -k to continue after errors, ensuring full build log with all errors
+  - make -k
+notifications:
+  email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,27 @@
 
-language: cpp
+language: generic
 sudo: false
-os:
-  - linux
-  - osx
-compiler:
-  - gcc
-  - clang
+matrix:
+  include:
+    - os: linux
+      env: CXX=g++-6 CC=gcc-6
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+    - os: linux
+      env: CXX=clang++-6.0 CC=clang-6.0
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-6.0
+          packages:
+            - clang-6.0
+            - libstdc++-6-dev
+
 script:
   # Use -k to continue after errors, ensuring full build log with all errors
   - make -k


### PR DESCRIPTION
Adds a TravisCI config file.

The initial commit did builds for both MacOS and Linux, but with outdated packages. The results didn't seem too usable. I've since updated the config file to install newer versions of Linux compilers. I'm leaving the MacOS builds out of scope for now. They were having issues with `#include <experimental/filesystem>`, likely due to outdated packages.