### PR TITLE
Allow StreamWriter to consume StreamReaders

### DIFF
--- a/Archives/ArchivePacker.cpp
+++ b/Archives/ArchivePacker.cpp
@@ -3,12 +3,9 @@
 #include "../StringHelper.h"
 #include <cstddef>
 #include <stdexcept>
-#include <array>
 
 namespace Archives
 {
-	const uint32_t ARCHIVE_WRITE_SIZE = 0x00020000;
-
 	ArchivePacker::ArchivePacker() { }
 	ArchivePacker::~ArchivePacker() { }
 
@@ -36,28 +33,5 @@ namespace Archives
 	bool ArchivePacker::ComparePathFilenames(const std::string path1, const std::string path2)
 	{
 		return StringHelper::StringCompareCaseInsensitive(XFile::GetFilename(path1), XFile::GetFilename(path2));
-	}
-
-	void ArchivePacker::WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength)
-	{
-		std::size_t numBytesToRead;
-		uint32_t offset = 0;
-		std::array<char, ARCHIVE_WRITE_SIZE> buffer;
-
-		do
-		{
-			numBytesToRead = ARCHIVE_WRITE_SIZE;
-
-			// Check if less than ARCHIVE_WRITE_SIZE of data remains for writing to disk.
-			if (offset + numBytesToRead > writeLength) {
-				numBytesToRead = static_cast<std::size_t>(writeLength - offset);
-			}
-
-			// Read the input file
-			streamReader.Read(buffer.data(), numBytesToRead);
-			offset += numBytesToRead;
-
-			streamWriter.Write(buffer.data(), numBytesToRead);
-		} while (numBytesToRead); // End loop when numBytesRead/Written is equal to 0
 	}
 }

--- a/Archives/ArchivePacker.h
+++ b/Archives/ArchivePacker.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "../Streams/StreamReader.h"
-#include "../Streams/StreamWriter.h"
 #include <string>
 #include <vector>
 
@@ -28,7 +26,5 @@ namespace Archives
 		// Compares 2 filenames case insensitive to determine which comes first alphabetically.
 		// Does not compare the entire path, but only the filename.
 		static bool ComparePathFilenames(const std::string path1, const std::string path2);
-
-		static void WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, const uint64_t writeLength);
 	};
 }

--- a/Archives/ArchiveUnpacker.cpp
+++ b/Archives/ArchiveUnpacker.cpp
@@ -1,14 +1,9 @@
 #include "ArchiveUnpacker.h"
 #include "../XFile.h"
-#include "../Streams/SeekableStreamReader.h"
-#include "../Streams/FileStreamWriter.h"
-#include <array>
 #include <cstddef>
 
 namespace Archives
 {
-	const std::size_t ARCHIVE_WRITE_SIZE = 0x00020000;
-
 	ArchiveUnpacker::ArchiveUnpacker(const std::string& fileName) :
 		m_ArchiveFileName(fileName), m_NumberOfPackedFiles(0), m_ArchiveFileSize(0) { }
 
@@ -39,34 +34,5 @@ namespace Archives
 		if (fileIndex < 0 || fileIndex >= m_NumberOfPackedFiles) {
 			throw std::runtime_error("fileIndex is outside the bounds of packed files.");
 		}
-	}
-
-	void ArchiveUnpacker::WriteFromStream(const std::string& filenameOut, StreamReader& streamReader, uint64_t writeLength)
-	{
-		FileStreamWriter fileStreamWriter(filenameOut);
-		WriteFromStream(fileStreamWriter, streamReader, writeLength);
-	}
-
-	void ArchiveUnpacker::WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, uint64_t writeLength)
-	{
-		std::size_t numBytesToRead = 0;
-		uint64_t offset = 0;
-		std::array<char, ARCHIVE_WRITE_SIZE> buffer;
-
-		do
-		{
-			numBytesToRead = ARCHIVE_WRITE_SIZE;
-
-			// Check if less than CLM_WRITE_SIZE of data remains for writing to disk.
-			if (offset + numBytesToRead > writeLength) {
-				numBytesToRead = static_cast<std::size_t>(writeLength - offset);
-			}
-
-			streamReader.Read(buffer.data(), numBytesToRead);
-
-			offset += numBytesToRead;
-
-			streamWriter.Write(buffer.data(), numBytesToRead);
-		} while (numBytesToRead); // End loop when numBytesRead/Written is equal to 0
 	}
 }

--- a/Archives/ArchiveUnpacker.h
+++ b/Archives/ArchiveUnpacker.h
@@ -5,8 +5,6 @@
 #include <cstdint>
 
 class SeekableStreamReader;
-class StreamReader;
-class StreamWriter;
 
 namespace Archives
 {
@@ -32,8 +30,6 @@ namespace Archives
 
 	protected:
 		void CheckPackedFileIndexBounds(int fileIndex);
-		void WriteFromStream(const std::string& filenameOut, StreamReader& streamReader, uint64_t writeLength);
-		void WriteFromStream(StreamWriter& streamWriter, StreamReader& streamReader, uint64_t writeLength);
 
 		const std::string m_ArchiveFileName;
 		int m_NumberOfPackedFiles;

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -81,11 +81,7 @@ namespace Archives
 
 			waveFileWriter.Write(header);
 
-			FileSliceReader reader = clmFileReader.Slice(
-				indexEntries[fileIndex].dataOffset, 
-				indexEntries[fileIndex].dataLength);
-
-			ArchiveUnpacker::WriteFromStream(waveFileWriter, reader, reader.Length());
+			waveFileWriter.Write(clmFileReader.Slice(indexEntries[fileIndex].dataOffset, indexEntries[fileIndex].dataLength));
 		}
 		catch (const std::exception& e)
 		{
@@ -283,7 +279,8 @@ namespace Archives
 
 		// Copy files into the archive
 		for (std::size_t i = 0; i < header.packedFilesCount; ++i) {
-			ArchivePacker::WriteFromStream(clmFileWriter, *filesToPackReaders[i], indexEntries[i].dataLength);
+			clmFileWriter.Write(*filesToPackReaders[i]);
+			//ArchivePacker::WriteFromStream(clmFileWriter, *filesToPackReaders[i], indexEntries[i].dataLength);
 		}
 	}
 

--- a/Archives/ClmFile.cpp
+++ b/Archives/ClmFile.cpp
@@ -81,7 +81,7 @@ namespace Archives
 
 			waveFileWriter.Write(header);
 
-			waveFileWriter.Write(clmFileReader.Slice(indexEntries[fileIndex].dataOffset, indexEntries[fileIndex].dataLength));
+			waveFileWriter.Write(static_cast<SeekableStreamReader&>(clmFileReader.Slice(indexEntries[fileIndex].dataOffset, indexEntries[fileIndex].dataLength)));
 		}
 		catch (const std::exception& e)
 		{

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -135,7 +135,7 @@ namespace Archives
 			// Calling GetSectionHeader moves the streamReader's position to just past the SectionHeader
 			SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 
-			archiveWriter.Write(archiveFileReader.Slice(sectionHeader.length));
+			archiveWriter.Write(static_cast<SeekableStreamReader&>(archiveFileReader.Slice(sectionHeader.length)));
 		}
 		catch (const std::exception& e)
 		{

--- a/Archives/VolFile.cpp
+++ b/Archives/VolFile.cpp
@@ -130,12 +130,12 @@ namespace Archives
 	{
 		try
 		{
+			FileStreamWriter archiveWriter(pathOut);
+
 			// Calling GetSectionHeader moves the streamReader's position to just past the SectionHeader
 			SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 
-			FileSliceReader slice = archiveFileReader.Slice(sectionHeader.length);
-
-			ArchiveUnpacker::WriteFromStream(pathOut, slice, slice.Length());
+			archiveWriter.Write(archiveFileReader.Slice(sectionHeader.length));
 		}
 		catch (const std::exception& e)
 		{
@@ -226,7 +226,8 @@ namespace Archives
 			volWriter.Write(SectionHeader(TagVBLK, volInfo.indexEntries[i].fileSize));
 
 			try {
-				ArchivePacker::WriteFromStream(volWriter, *volInfo.fileStreamReaders[i], volInfo.indexEntries[i].fileSize);
+				volWriter.Write(*volInfo.fileStreamReaders[i]);
+				//ArchivePacker::WriteFromStream(volWriter, *volInfo.fileStreamReaders[i], volInfo.indexEntries[i].fileSize);
 				int padding = 0;
 
 				// Add padding after the file, ensuring it ends on a 4 byte boundary

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -165,6 +165,7 @@
     <ClInclude Include="Streams\StreamWriter.h" />
     <ClInclude Include="StringHelper.h" />
     <ClInclude Include="XFile.h" />
+    <ClCompile Include="Streams\StreamWriter.cpp" />
     <ClCompile Include="StringHelper.cpp" />
     <ClCompile Include="XFile.cpp" />
   </ItemGroup>

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -182,5 +182,8 @@
     <ClCompile Include="Streams\FileSliceReader.cpp">
       <Filter>Streams</Filter>
     </ClCompile>
+    <ClCompile Include="Streams\StreamWriter.cpp">
+      <Filter>Streams</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Streams/StreamWriter.cpp
+++ b/Streams/StreamWriter.cpp
@@ -1,0 +1,41 @@
+#include "StreamWriter.h"
+#include "SeekableStreamReader.h"
+#include <vector>
+#include <stdexcept>
+
+void StreamWriter::Write(SeekableStreamReader& seekableStreamReader) {
+	Write(seekableStreamReader, seekableStreamReader.Length() - seekableStreamReader.Position());
+}
+
+void StreamWriter::Write(StreamReader& streamReader, uint64_t writeLength)
+{
+	std::size_t bytesToRead = 0;
+	uint64_t offset = 0;
+	std::vector<char> buffer;
+	buffer.resize(streamPassLength);
+
+	do
+	{
+		bytesToRead = buffer.size();
+
+		// Check if less than a streamPassLength of data remains for writing
+		if (offset + bytesToRead > writeLength) {
+			bytesToRead = static_cast<std::size_t>(writeLength - offset);
+		}
+
+		streamReader.Read(buffer.data(), bytesToRead);
+
+		offset += bytesToRead;
+
+		Write(buffer.data(), bytesToRead);
+	} while (bytesToRead); // End loop when BytesToRead/Write is equal to 0
+}
+
+void StreamWriter::SetStreamPassLength(std::size_t streamPassLength) 
+{
+	if (streamPassLength == 0) {
+		throw std::runtime_error("Stream pass length must be set to a value greater than 0.");
+	}
+
+	this->streamPassLength = streamPassLength;
+}

--- a/Streams/StreamWriter.h
+++ b/Streams/StreamWriter.h
@@ -1,22 +1,42 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
+
+class StreamReader;
+class SeekableStreamReader;
 
 class StreamWriter {
 public:
+	StreamWriter() : streamPassLength(0x00020000) { };
 	virtual ~StreamWriter() = default;
 
 	inline void Write(const void* buffer, std::size_t size) {
 		WriteImplementation(buffer, size);
 	}
 
+	// Writes a length of data from the provided stream starting at the provided stream's current position
+	void Write(StreamReader& streamReader, uint64_t length);
+
+	// Writes the remaining length of provided stream from the provided stream's current position
+	void Write(SeekableStreamReader& seekableStreamReader);
+
 	// Inline templated convenience methods, to easily write arbitrary data types
 	template<typename T> inline void Write(const T& object) {
 		WriteImplementation(&object, sizeof(object));
 	}
 
+	// StreamPassLength is the buffer size used when copying data from a stream reader into the writer.
+	// Changing the pass size may affect performance of copying in streams for writing.
+	void SetStreamPassLength(std::size_t streamPassLength);
+
+	inline std::size_t GetStreamPassLength() const { return streamPassLength; }
+
 protected:
 	// WriteImplementation is named differently from Write to prevent name hiding of the 
 	// Write template helpers in derived classes.
 	virtual void WriteImplementation(const void* buffer, std::size_t size) = 0;
+
+private:
+	std::size_t streamPassLength;
 };


### PR DESCRIPTION
**PLEASE READ BEFORE REVIEWING COMMITS** NOTE: This code will compile on MSVC, but will produce unexpected results. Currently the template function StreamWriter::Write will consume calls to StreamWriter::Write(SeekableStreamReader seekableStreamReader). There must be a way to prevent the template from taking priority here.

 - Move code for for consuming streams out of ArchivePacker & ArchiveUnpacker into StreamWriter.
 - Add a property to StreamWriter that allows getting/setting the pass size used when writing from a stream.

Assuming this code looks like a good idea (once the hidden function is resolved that is).

I could probably work a temp fix where within the template function StreamWriter::Write, we use dynamic_cast to check if the item could be cast as a SeekableStreamReader, and then call a private function to consume the SeekableStreamReader. I would see this as a temp fix until we can figure a better solution if nothing comes to mind.

Thanks,
Brett