### PR TITLE
Add `Read`/`Write` template guard

### DIFF
--- a/Streams/StreamReader.h
+++ b/Streams/StreamReader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 class StreamReader {
 public:
@@ -11,7 +12,8 @@ public:
 	}
 
 	// Inline templated convenience methods, to easily read arbitrary data types
-	template<typename T> inline void Read(T& object) {
+	template<typename T>
+	inline std::enable_if_t<std::is_trivially_copyable<T>::value> Read(T& object) {
 		ReadImplementation(&object, sizeof(object));
 	}
 

--- a/Streams/StreamWriter.h
+++ b/Streams/StreamWriter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 class StreamWriter {
 public:
@@ -11,7 +12,8 @@ public:
 	}
 
 	// Inline templated convenience methods, to easily write arbitrary data types
-	template<typename T> inline void Write(const T& object) {
+	template<typename T>
+	inline std::enable_if_t<std::is_trivially_copyable<T>::value> Write(const T& object) {
 		WriteImplementation(&object, sizeof(object));
 	}
 


### PR DESCRIPTION
This should prevent inappropriate expansions of the `Read`/`Write` template methods.

This is related to Issue #68. Still left to do is to provide helpers for common complex types, such as `std::vector`.
