### PR TITLE
Add travisci osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ matrix:
             - clang-6.0
             - libstdc++-6-dev
     - os: osx
+      osx_image: xcode9.4
       env: CXX=g++ CC=gcc
     - os: osx
+      osx_image: xcode9.4
       env: CXX=clang++ CC=clang
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
           packages:
             - clang-6.0
             - libstdc++-6-dev
+    - os: osx
+      env: CXX=g++ CC=gcc
+    - os: osx
+      env: CXX=clang++ CC=clang
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors


### PR DESCRIPTION
I'm creating this PR to document a failed experiment to get OSX builds working on TravisCI. The sticking point is the use of `#include <experimental/filesystem>`. After doing some googling, It seems even the most recent versions of the built in developer tools on OSX don't support this header file yet. Posts as recent as about 3 months ago confirm this.

Error is:
```
src/XFile.cpp:5:10: fatal error: 'experimental/filesystem' file not found
#include <experimental/filesystem>
         ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Additions to the build matrix in `.travis.yml` were:
```
   - os: osx
     osx_image: xcode9.4
     env: CXX=g++ CC=gcc
   - os: osx
     osx_image: xcode9.4
     env: CXX=clang++ CC=clang
```
