### PR TITLE
Improve archive unpacker extraction functions

### DIFF
--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -46,6 +46,17 @@ namespace Archives
 		ExtractFile(index, pathOut);
 	}
 
+	std::unique_ptr<SeekableStreamReader> ArchiveUnpacker::OpenSeekableStreamReader(const std::string& internalFilename)
+	{
+		int fileIndex = GetInternalFileIndex(internalFilename);
+
+		if (fileIndex == -1) {
+			throw std::runtime_error("Archive " + m_ArchiveFilename + " does not contain a file named " + internalFilename);
+		}
+
+		return OpenSeekableStreamReader(fileIndex);
+	}
+
 	void ArchiveUnpacker::CheckPackedFileIndexBounds(int fileIndex)
 	{
 		if (fileIndex < 0 || fileIndex >= m_NumberOfPackedFiles) {

--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -23,6 +23,18 @@ namespace Archives
 		}
 	}
 
+	int ArchiveUnpacker::GetInternalFileIndex(const std::string& internalFilename)
+	{
+		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
+		{
+			if (XFile::PathsAreEqual(GetInternalFilename(i), internalFilename)) {
+				return i;
+			}
+		}
+
+		return -1;
+	}
+
 	bool ArchiveUnpacker::ContainsFile(const std::string& filename)
 	{
 		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)

--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -46,7 +46,7 @@ namespace Archives
 		ExtractFile(index, pathOut);
 	}
 
-	std::unique_ptr<SeekableStreamReader> ArchiveUnpacker::OpenSeekableStreamReader(const std::string& internalFilename)
+	std::unique_ptr<SeekableStreamReader> ArchiveUnpacker::OpenStream(const std::string& internalFilename)
 	{
 		int fileIndex = GetInternalFileIndex(internalFilename);
 
@@ -54,7 +54,7 @@ namespace Archives
 			throw std::runtime_error("Archive " + m_ArchiveFilename + " does not contain a file named " + internalFilename);
 		}
 
-		return OpenSeekableStreamReader(fileIndex);
+		return OpenStream(fileIndex);
 	}
 
 	void ArchiveUnpacker::CheckPackedFileIndexBounds(int fileIndex)

--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -4,6 +4,7 @@
 #include "../Streams/FileStreamWriter.h"
 #include <array>
 #include <cstddef>
+#include <stdexcept>
 
 namespace Archives
 {
@@ -32,6 +33,17 @@ namespace Archives
 		}
 
 		return false;
+	}
+
+	void ArchiveUnpacker::ExtractFile(const std::string& internalFilename, const std::string& pathOut)
+	{
+		int index = GetInternalFileIndex(internalFilename);
+
+		if (index == -1) {
+			throw std::runtime_error("Archive " + m_ArchiveFilename + " does not contain a file named " + internalFilename);
+		}
+
+		ExtractFile(index, pathOut);
 	}
 
 	void ArchiveUnpacker::CheckPackedFileIndexBounds(int fileIndex)

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -23,7 +23,7 @@ namespace Archives
 
 		virtual std::string GetInternalFilename(int index) = 0;
 		// Returns -1 if internalFilename is not present in archive.
-		virtual int GetInternalFileIndex(const std::string& internalFilename) = 0;
+		int GetInternalFileIndex(const std::string& internalFilename);
 		virtual uint32_t GetInternalFileSize(int index) = 0;
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
 		void ExtractFile(const std::string& internalFilename, const std::string& pathOut);

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -26,6 +26,7 @@ namespace Archives
 		virtual int GetInternalFileIndex(const std::string& internalFilename) = 0;
 		virtual uint32_t GetInternalFileSize(int index) = 0;
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
+		void ExtractFile(const std::string& internalFilename, const std::string& pathOut);
 		virtual void ExtractAllFiles(const std::string& destDirectory);
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFilename) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -28,8 +28,8 @@ namespace Archives
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
 		void ExtractFile(const std::string& internalFilename, const std::string& pathOut);
 		virtual void ExtractAllFiles(const std::string& destDirectory);
-		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFilename) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;
+		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFilename);
 
 	protected:
 		void CheckPackedFileIndexBounds(int fileIndex);

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -20,13 +20,13 @@ namespace Archives
 		uint64_t GetVolumeFileSize() { return m_ArchiveFileSize; };
 		int GetNumberOfPackedFiles() { return m_NumberOfPackedFiles; };
 		bool ContainsFile(const std::string& filename);
-
-		virtual std::string GetInternalFilename(int index) = 0;
 		// Returns -1 if internalFilename is not present in archive.
 		int GetInternalFileIndex(const std::string& internalFilename);
+		void ExtractFile(const std::string& internalFilename, const std::string& pathOut);
+
+		virtual std::string GetInternalFilename(int index) = 0;
 		virtual uint32_t GetInternalFileSize(int index) = 0;
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
-		void ExtractFile(const std::string& internalFilename, const std::string& pathOut);
 		virtual void ExtractAllFiles(const std::string& destDirectory);
 		virtual std::unique_ptr<SeekableStreamReader> OpenStream(int fileIndex) = 0;
 		virtual std::unique_ptr<SeekableStreamReader> OpenStream(const std::string& internalFilename);

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -28,8 +28,8 @@ namespace Archives
 		virtual void ExtractFile(int fileIndex, const std::string& pathOut) = 0;
 		void ExtractFile(const std::string& internalFilename, const std::string& pathOut);
 		virtual void ExtractAllFiles(const std::string& destDirectory);
-		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex) = 0;
-		virtual std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFilename);
+		virtual std::unique_ptr<SeekableStreamReader> OpenStream(int fileIndex) = 0;
+		virtual std::unique_ptr<SeekableStreamReader> OpenStream(const std::string& internalFilename);
 
 	protected:
 		void CheckPackedFileIndexBounds(int fileIndex);

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -108,17 +108,6 @@ namespace Archives
 		headerOut.dataChunk.length = indexEntries[fileIndex].dataLength;
 	}
 
-	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(const std::string& internalFilename)
-	{
-		int fileIndex = GetInternalFileIndex(internalFilename);
-
-		if (fileIndex < 0) {
-			throw std::runtime_error("File does not exist in Archive.");
-		}
-
-		return OpenSeekableStreamReader(fileIndex);
-	}
-
 	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(int fileIndex)
 	{
 		CheckPackedFileIndexBounds(fileIndex);

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -108,11 +108,11 @@ namespace Archives
 		headerOut.dataChunk.length = indexEntries[fileIndex].dataLength;
 	}
 
-	std::unique_ptr<SeekableStreamReader> ClmFile::OpenSeekableStreamReader(int fileIndex)
+	std::unique_ptr<SeekableStreamReader> ClmFile::OpenStream(int fileIndex)
 	{
 		CheckPackedFileIndexBounds(fileIndex);
 
-		throw std::logic_error("OpenSeekableStreamReader not yet implemented for Clm files.");
+		throw std::logic_error("OpenStream not yet implemented for Clm files.");
 	}
 
 	// Repacks the volume using the same files as are specified by the internal file names

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -112,7 +112,11 @@ namespace Archives
 	{
 		CheckPackedFileIndexBounds(fileIndex);
 
-		throw std::logic_error("OpenStream not yet implemented for Clm files.");
+		FileSliceReader reader = clmFileReader.Slice(
+			indexEntries[fileIndex].dataOffset,
+			indexEntries[fileIndex].dataLength);
+
+		return std::make_unique<FileSliceReader>(reader);
 	}
 
 	// Repacks the volume using the same files as are specified by the internal file names

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -46,18 +46,6 @@ namespace Archives
 		return indexEntries[index].GetFilename();
 	}
 
-	int ClmFile::GetInternalFileIndex(const std::string& internalFilename)
-	{
-		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
-		{
-			if (XFile::PathsAreEqual(GetInternalFilename(i), internalFilename)) {
-				return i;
-			}
-		}
-
-		return -1;
-	}
-
 	// Returns the size of the internal file corresponding to index
 	uint32_t ClmFile::GetInternalFileSize(int index)
 	{

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -21,7 +21,6 @@ namespace Archives
 		std::string GetInternalFilename(int index);
 		int GetInternalFileIndex(const std::string& internalFilename);
 		void ExtractFile(int fileIndex, const std::string& pathOut);
-		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFilename);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
 		uint32_t GetInternalFileSize(int index);

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -21,6 +21,8 @@ namespace Archives
 		std::string GetInternalFilename(int index);
 		int GetInternalFileIndex(const std::string& internalFilename);
 		void ExtractFile(int fileIndex, const std::string& pathOut);
+
+		// Opens a stream containing packed audio PCM data
 		std::unique_ptr<SeekableStreamReader> OpenStream(int fileIndex);
 
 		uint32_t GetInternalFileSize(int index);

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -21,7 +21,7 @@ namespace Archives
 		std::string GetInternalFilename(int index);
 		int GetInternalFileIndex(const std::string& internalFilename);
 		void ExtractFile(int fileIndex, const std::string& pathOut);
-		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
+		std::unique_ptr<SeekableStreamReader> OpenStream(int fileIndex);
 
 		uint32_t GetInternalFileSize(int index);
 

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -72,17 +72,6 @@ namespace Archives
 		return m_IndexEntries[index].filenameOffset;
 	}
 
-	std::unique_ptr<SeekableStreamReader> VolFile::OpenSeekableStreamReader(const std::string& internalFilename)
-	{
-		int fileIndex = GetInternalFileIndex(internalFilename);
-
-		if (fileIndex < 0) {
-			throw std::runtime_error("File does not exist in Archive.");
-		}
-
-		return OpenSeekableStreamReader(fileIndex);
-	}
-
 	std::unique_ptr<SeekableStreamReader> VolFile::OpenSeekableStreamReader(int fileIndex)
 	{
 		SectionHeader sectionHeader = GetSectionHeader(fileIndex);

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -72,7 +72,7 @@ namespace Archives
 		return m_IndexEntries[index].filenameOffset;
 	}
 
-	std::unique_ptr<SeekableStreamReader> VolFile::OpenSeekableStreamReader(int fileIndex)
+	std::unique_ptr<SeekableStreamReader> VolFile::OpenStream(int fileIndex)
 	{
 		SectionHeader sectionHeader = GetSectionHeader(fileIndex);
 

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -33,19 +33,6 @@ namespace Archives
 		return m_StringTable[index];
 	}
 
-	int VolFile::GetInternalFileIndex(const std::string& internalFilename)
-	{
-		for (int i = 0; i < GetNumberOfPackedFiles(); ++i)
-		{
-			std::string actualInternalFilename = GetInternalFilename(i);
-			if (XFile::PathsAreEqual(actualInternalFilename, internalFilename)) {
-				return i;
-			}
-		}
-
-		return -1;
-	}
-
 	CompressionType VolFile::GetInternalCompressionCode(int index)
 	{
 		CheckPackedFileIndexBounds(index);

--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -29,7 +29,6 @@ namespace Archives
 
 		// Extraction
 		void ExtractFile(int fileIndex, const std::string& pathOut);
-		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(const std::string& internalFilename);
 		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
 
 		// Volume Creation

--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -29,6 +29,8 @@ namespace Archives
 
 		// Extraction
 		void ExtractFile(int fileIndex, const std::string& pathOut);
+
+		// Opens a stream containing a packed file
 		std::unique_ptr<SeekableStreamReader> OpenStream(int fileIndex);
 
 		// Volume Creation

--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -29,7 +29,7 @@ namespace Archives
 
 		// Extraction
 		void ExtractFile(int fileIndex, const std::string& pathOut);
-		std::unique_ptr<SeekableStreamReader> OpenSeekableStreamReader(int fileIndex);
+		std::unique_ptr<SeekableStreamReader> OpenStream(int fileIndex);
 
 		// Volume Creation
 		void Repack();

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<SeekableStreamReader> ResourceManager::GetResourceStream(const s
 		int internalArchiveIndex = archiveFile->GetInternalFileIndex(internalArchiveFilename);
 
 		if (internalArchiveIndex > -1) {
-			return archiveFile->OpenSeekableStreamReader(internalArchiveIndex);
+			return archiveFile->OpenStream(internalArchiveIndex);
 		}
 	}
 


### PR DESCRIPTION
Closes issue #109 
Closes issue #102 

Will need to followup with OP2Archive to reduce code using new ArchiveUnpacker::ExtractFile function overload.
