### PR TITLE
Set CMake standard required setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 project("OP2Utility")
 
-set (CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # https://cmake.org/cmake/help/v3.12/command/file.html
 # CMake documentation recommends not collecting all source files using a GLOB


### PR DESCRIPTION
Without the standard required setting, CMake can try to fall back to previous versions of C++. We explicitly use C++14 features though, so the code would fail to compile under earlier standards.

The reason for this setting seems to be the default standard on Linux is an older one, with new features and updates needing to be explicitly enabled. Hence code does not compile using the latest updates unless it is explicitly requested. This does not always mean code needs the latest features to compile.

Also modified the spacing on `set` to match other instances.