### PR TITLE
Read/Write strings with size prefixed

### DIFF
--- a/src/Maps/MapReader.cpp
+++ b/src/Maps/MapReader.cpp
@@ -19,7 +19,6 @@ namespace MapReader {
 		void ReadVersionTag(StreamReader& streamReader);
 		void ReadTileGroups(StreamReader& streamReader, MapData& mapData);
 		TileGroup ReadTileGroup(StreamReader& streamReader);
-		std::string ReadString(StreamReader& streamReader);
 
 		const std::array<char, 10> tilesetHeader{ "TILE SET\x1a" };
 	}
@@ -87,7 +86,7 @@ namespace MapReader {
 
 			for (auto& tilesetSource : mapData.tilesetSources)
 			{
-				tilesetSource.tilesetFilename = ReadString(streamReader);
+				streamReader.Read<uint32_t>(tilesetSource.tilesetFilename);
 
 				if (tilesetSource.tilesetFilename.size() > 8) {
 					throw std::runtime_error("Tileset name may not be greater than 8 characters in length.");
@@ -147,22 +146,9 @@ namespace MapReader {
 			tileGroup.mappingIndices.resize(tileGroup.tileWidth * tileGroup.tileHeight);
 			streamReader.Read(tileGroup.mappingIndices);
 
-			tileGroup.name = ReadString(streamReader);
+			streamReader.Read<uint32_t>(tileGroup.name);
 
 			return tileGroup;
-		}
-
-		// String must be stored in file as string length followed by char[].
-		std::string ReadString(StreamReader& streamReader)
-		{
-			uint32_t stringLength;
-			streamReader.Read(stringLength);
-
-			std::string s;
-			s.resize(stringLength);
-			streamReader.Read(&s[0], stringLength);
-
-			return s;
 		}
 	}
 }

--- a/src/Maps/MapWriter.cpp
+++ b/src/Maps/MapWriter.cpp
@@ -14,7 +14,6 @@ namespace MapWriter {
 		void WriteTerrainType(StreamWriter& streamWriter, const std::vector<TerrainType>& terrainTypes);
 		void WriteTileGroups(StreamWriter& streamWriter, const std::vector<TileGroup>& tileGroups);
 		void WriteContainerSize(StreamWriter& streamWriter, uint32_t size);
-		void WriteString(StreamWriter& streamWriter, const std::string& s);
 	}
 
 
@@ -61,7 +60,7 @@ namespace MapWriter {
 		{
 			for (const auto& tilesetSource : tileSetSources)
 			{
-				WriteString(streamWriter, tilesetSource.tilesetFilename);
+				streamWriter.Write<uint32_t>(tilesetSource.tilesetFilename);
 
 				// Only include the number of tiles if the tileset contains a filename.
 				if (tilesetSource.tilesetFilename.size() > 0)
@@ -99,7 +98,7 @@ namespace MapWriter {
 
 				streamWriter.Write(tileGroup.mappingIndices);
 
-				WriteString(streamWriter, tileGroup.name);
+				streamWriter.Write<uint32_t>(tileGroup.name);
 			}
 		}
 
@@ -107,16 +106,6 @@ namespace MapWriter {
 		void WriteContainerSize(StreamWriter& streamWriter, uint32_t size)
 		{
 			streamWriter.Write(size);
-		}
-
-		// String must be stored in file as string length followed by char[].
-		void WriteString(StreamWriter& streamWriter, const std::string& s)
-		{
-			WriteContainerSize(streamWriter, s.size());
-
-			if (s.size() > 0) {
-				streamWriter.Write(s.c_str(), s.size());
-			}
 		}
 	}
 }

--- a/src/Streams/StreamReader.h
+++ b/src/Streams/StreamReader.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <type_traits>
 #include <vector>
+#include <string>
 
 class StreamReader {
 protected:
@@ -38,5 +39,19 @@ public:
 	template<typename T, typename A>
 	inline void Read(std::vector<T, A>& vector) {
 		ReadImplementation(vector.data(), vector.size() * sizeof(T));
+	}
+
+	// std::string prefixed by the string's size. The type of integer representing the size must be provided. 
+	template<typename SizeType>
+	void Read(std::string& string) {
+		SizeType stringSize;
+		Read(stringSize);
+		if (stringSize < 0) {
+			throw std::runtime_error("String's size may not be a negative number");
+		}
+
+		string.clear();
+		string.resize(stringSize);
+		Read(&string[0], stringSize);
 	}
 };

--- a/src/Streams/StreamWriter.h
+++ b/src/Streams/StreamWriter.h
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <vector>
 #include <array>
+#include <string>
 
 class StreamWriter {
 protected:
@@ -34,6 +35,19 @@ public:
 	template<typename T, typename A>
 	inline void Write(const std::vector<T, A>& vector) {
 		WriteImplementation(vector.data(), vector.size() * sizeof(T));
+	}
+
+	// std::string prefixed by the string's size. The type of integer representing the size must be provided.
+	// Does not null terminate string unless null terminator is specifcally included in passed std::string. 
+	template<typename SizeType>
+	void Write(const std::string& string) {
+		auto stringSize = string.size();
+		if (stringSize > std::numeric_limits<SizeType>::max()) {
+			throw std::runtime_error("String's size is too large to write in provided size field");
+		}
+		auto typedSize = static_cast<SizeType>(stringSize);
+		Write(typedSize);
+		Write(string.data(), string.size());
 	}
 
 	// Copy a StreamReader to a StreamWriter


### PR DESCRIPTION
 - Test using MapReader/Writer

Completed tests with both an x86 and x64 compilation of a modified OP2MapImager that allowed saving a new map. Map used in testing was Ashes.map. Was able to render the map properly, create a new map that was the same size as the original, and load the newly created map using Outpost 2.