### PR TITLE
Implement length prefix vector read

### DIFF
--- a/src/Streams/StreamReader.h
+++ b/src/Streams/StreamReader.h
@@ -42,6 +42,19 @@ public:
 		ReadImplementation(vector.data(), vector.size() * sizeof(T));
 	}
 
+	// Size prefixed vector data types
+	template<typename SizeType, typename T, typename A>
+	void Read(std::vector<T, A>& vector) {
+		SizeType vectorSize;
+		Read(vectorSize);
+		if (vectorSize < 0) {
+			throw std::runtime_error("Vector's size may not be a negative number");
+		}
+		vector.clear();
+		vector.resize(vectorSize);
+		Read(vector);
+	}
+
 	// std::string prefixed by the string's size. The type of integer representing the size must be provided. 
 	template<typename SizeType>
 	void Read(std::string& string) {


### PR DESCRIPTION
Curiously, the implementation is exactly the same as the templated
length prefixed string read. Perhaps there is a way to make the template
parameter more generic and provide both with one source method.

One complication with combining length prefixed vector and string
methods is they both contain an implicit assumption of contiguous
memory. This assumption comes from the `Read` on the last line of both
methods. Although this assumption is guaranteed by the standard for both
`vector` (since C++03), and `string` (since C++11), it is not true for
other more generic STL containers. Hence combining code to one method
would need to restrict the method to those two data types to prevent bad
code generation for other STL containers.

For now though, this works, and closes #133.