### PR TITLE
Add override to archive methods

### DIFF
--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -21,9 +21,9 @@ namespace Archives
 		uint64_t GetVolumeFileSize() { return m_ArchiveFileSize; };
 		std::size_t GetCount() { return m_Count; };
 		bool Contains(const std::string& name);
-		std::size_t GetIndex(const std::string& name);
 		void ExtractFile(const std::string& name, const std::string& pathOut);
 
+		virtual std::size_t GetIndex(const std::string& name);
 		virtual std::string GetName(std::size_t index) = 0;
 		virtual uint32_t GetSize(std::size_t index) = 0;
 		virtual void ExtractFile(std::size_t index, const std::string& pathOut) = 0;

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -18,15 +18,15 @@ namespace Archives
 		ClmFile(const std::string& filename);
 		virtual ~ClmFile();
 
-		std::string GetName(std::size_t index);
-		void ExtractFile(std::size_t index, const std::string& pathOut);
+		std::string GetName(std::size_t index) override;
+		void ExtractFile(std::size_t index, const std::string& pathOut) override;
 
 		// Opens a stream containing packed audio PCM data
-		std::unique_ptr<SeekableStreamReader> OpenStream(std::size_t index);
+		std::unique_ptr<SeekableStreamReader> OpenStream(std::size_t index) override;
 
-		uint32_t GetSize(std::size_t index);
+		uint32_t GetSize(std::size_t index) override;
 
-		void Repack();
+		void Repack() override;
 
 		// Create a new archive with the files specified in filesToPack
 		static void CreateArchive(const std::string& archiveFilename, std::vector<std::string> filesToPack);

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -19,12 +19,11 @@ namespace Archives
 		virtual ~ClmFile();
 
 		std::string GetName(std::size_t index) override;
+		uint32_t GetSize(std::size_t index) override;
 		void ExtractFile(std::size_t index, const std::string& pathOut) override;
 
 		// Opens a stream containing packed audio PCM data
 		std::unique_ptr<SeekableStreamReader> OpenStream(std::size_t index) override;
-
-		uint32_t GetSize(std::size_t index) override;
 
 		void Repack() override;
 

--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -20,18 +20,19 @@ namespace Archives
 		~VolFile();
 
 		// Internal file status
-		std::string GetName(std::size_t index);
+		virtual std::size_t GetIndex(const std::string& name);
+		std::string GetName(std::size_t index) override;
 		CompressionType GetCompressionCode(std::size_t index);
-		uint32_t GetSize(std::size_t index);
+		uint32_t GetSize(std::size_t index) override;
 
 		// Extraction
-		void ExtractFile(std::size_t index, const std::string& pathOut);
+		void ExtractFile(std::size_t index, const std::string& pathOut) override;
 
 		// Opens a stream containing a packed file
-		std::unique_ptr<SeekableStreamReader> OpenStream(std::size_t index);
+		std::unique_ptr<SeekableStreamReader> OpenStream(std::size_t index) override;
 
 		// Volume Creation
-		void Repack();
+		void Repack() override;
 
 		// Create a new archive with the files specified in filesToPack
 		static void CreateArchive(const std::string& volumeFilename, std::vector<std::string> filesToPack);

--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -20,7 +20,7 @@ namespace Archives
 		~VolFile();
 
 		// Internal file status
-		virtual std::size_t GetIndex(const std::string& name);
+		//std::size_t GetIndex(const std::string& name) override;
 		std::string GetName(std::size_t index) override;
 		CompressionType GetCompressionCode(std::size_t index);
 		uint32_t GetSize(std::size_t index) override;


### PR DESCRIPTION
This contains a few updates for compiler checks. I noticed this while preparing to tackle Issue #132.

In particular, the `std::size_t GetIndex(const std::string& name)` method was not virtual. For the VOL file and CLM file to have different implementations, this will need to be virtual.

The `VolFile` class had declared a corresponding `virtual` method, but never implemented it. This did not cause an error because the base class didn't declare the method virtual, and calling code used a base class pointer, hence the compiler never saw any calls to the unimplemented method.

As a new implementation does not yet exist, the line to override this method is commented out. Hence VOL file is still using the base class linear search algorithm at this point.