### PR TITLE
Prevent name truncation when creating clm files

### DIFF
--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -163,7 +163,7 @@ namespace Archives
 			}
 		}
 
-		// Allowing duplicate names when packing may cause unintended results during binary search and file extraction.
+		// Allowing duplicate names when packing may cause unintended results during search and file extraction.
 		CheckSortedContainerForDuplicateNames(names);
 
 		// Write the archive header and copy files into the archive

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -156,6 +156,13 @@ namespace Archives
 
 		std::vector<std::string> names = GetNamesFromPaths(filesToPack);
 		names = StripFilenameExtensions(names);
+
+		for (const auto& name : names) {
+			if (name.size() > 8) {
+				throw std::runtime_error("Filename " + name + " for packing into archive " + archiveFilename + " must be at most 8 characters in length excluding the extension");
+			}
+		}
+
 		// Allowing duplicate names when packing may cause unintended results during binary search and file extraction.
 		CheckSortedContainerForDuplicateNames(names);
 


### PR DESCRIPTION
Also fixes erroneous comment about binary search in a CLM file.