### PR TITLE
Refactor typedef nodeindex

### DIFF
--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -172,10 +172,6 @@ namespace Archives
 	// **NOTE**: I may change the bit ordering! (Make that I WILL change the bit ordering)
 	int AdaptiveHuffmanTree::GetEncodedBitString(int code, int &bitString)
 	{
-		int curNodeIndex;
-		int bitCount;
-		bool bBit;
-
 		// Make sure the code is in range
 		if (code >= m_TerminalNodeCount)
 		{
@@ -183,15 +179,16 @@ namespace Archives
 		}
 
 		// Get the node containing the given code
-		curNodeIndex = m_Parent[code];
+		NodeIndex curNodeIndex = m_Parent[code];
 
 		// Record the path to the root
 		bitString = 0;
+		int bitCount = 0;
 		while (curNodeIndex != m_RootNodeIndex)
 		{
-			bBit = curNodeIndex & 0x01;	// Get the direction from parent to current node
+			bool bBit = curNodeIndex & 0x01;	// Get the direction from parent to current node
 			bitCount++;
-			bitString = (bitString << 1) + bBit;// Pack the bit into the returned string
+			bitString = (bitString << 1) | bBit;// Pack the bit into the returned string
 		}
 
 		return bitCount;					// Return number of bits in path from root to node

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -4,33 +4,33 @@
 
 namespace Archives
 {
-	// Creates an (adaptive) Huffman tree with numTerminalNodes at the bottom.
-	AdaptiveHuffmanTree::AdaptiveHuffmanTree(NodeType numTerminalNodes) :
+	// Creates an (adaptive) Huffman tree with terminalNodeCount at the bottom.
+	AdaptiveHuffmanTree::AdaptiveHuffmanTree(NodeType terminalNodeCount) :
 		// Initialize tree properties
-		m_NumTerminalNodes(numTerminalNodes),
-		m_NumNodes(m_NumTerminalNodes * 2 - 1),
-		m_RootNodeIndex(m_NumNodes - 1),
+		m_TerminalNodeCount(terminalNodeCount),
+		m_NodeCount(m_TerminalNodeCount * 2 - 1),
+		m_RootNodeIndex(m_NodeCount - 1),
 		// Allocate space for tree
-		m_Data(m_NumNodes),
-		m_Count(m_NumNodes),
-		m_Parent(m_NumNodes + m_NumTerminalNodes)
+		m_Data(m_NodeCount),
+		m_Count(m_NodeCount),
+		m_Parent(m_NodeCount + m_TerminalNodeCount)
 	{
 		// Initialize the tree
 		// Initialize terminal nodes
-		for (NodeIndex i = 0; i < m_NumTerminalNodes; ++i)
+		for (NodeIndex i = 0; i < m_TerminalNodeCount; ++i)
 		{
-			m_Data[i] = i + m_NumNodes;						// Initilize data values
+			m_Data[i] = i + m_NodeCount;						// Initilize data values
 			m_Count[i] = 1;
-			m_Parent[i] = (i >> 1) + m_NumTerminalNodes;
-			m_Parent[i + m_NumNodes] = i;						// "Parent of code" (node index)
+			m_Parent[i] = (i >> 1) + m_TerminalNodeCount;
+			m_Parent[i + m_NodeCount] = i;						// "Parent of code" (node index)
 		}
 		// Initialize non terminal nodes
 		NodeIndex left = 0;
-		for (NodeIndex i = m_NumTerminalNodes; i < m_NumNodes; ++i)
+		for (NodeIndex i = m_TerminalNodeCount; i < m_NodeCount; ++i)
 		{
 			m_Data[i] = left;								// Initialize link values
 			m_Count[i] = m_Count[left] + m_Count[left + 1];	// Count is sum of two subtrees
-			m_Parent[i] = (i >> 1) + m_NumTerminalNodes;
+			m_Parent[i] = (i >> 1) + m_TerminalNodeCount;
 			left += 2;										// Calc index of left child (next loop)
 		}
 	}
@@ -61,7 +61,7 @@ namespace Archives
 		VerifyValidNodeIndex(nodeIndex);
 
 		// Return whether or not this is a terminal node
-		return m_Data[nodeIndex] >= m_NumNodes;
+		return m_Data[nodeIndex] >= m_NodeCount;
 	}
 
 	// Returns the data stored in a terminal node
@@ -71,7 +71,7 @@ namespace Archives
 
 		// Return data stored in node translated back to normal form
 		// Note: This assumes the node is a terminal node
-		return m_Data[nodeIndex] - m_NumNodes;
+		return m_Data[nodeIndex] - m_NodeCount;
 	}
 
 
@@ -86,13 +86,13 @@ namespace Archives
 		int blockLeaderIndex;
 
 		// Make sure the code is in range
-		if (code >= m_NumTerminalNodes)
+		if (code >= m_TerminalNodeCount)
 		{
 			throw std::runtime_error("Code value out of range");
 		}
 
 		// Get the index of the node containing this code
-		curNodeIndex = m_Parent[code + m_NumNodes];
+		curNodeIndex = m_Parent[code + m_NodeCount];
 		m_Count[curNodeIndex]++; // Update the node count
 
 		// Propagate the count increase up to the root of the tree
@@ -126,7 +126,7 @@ namespace Archives
 	void AdaptiveHuffmanTree::VerifyValidNodeIndex(NodeIndex nodeIndex)
 	{
 		// Check that the nodeIndex is in range
-		if (nodeIndex >= m_NumNodes)
+		if (nodeIndex >= m_NodeCount)
 		{
 			throw std::runtime_error("Index out of range");
 		}
@@ -148,12 +148,12 @@ namespace Archives
 
 		auto temp = m_Data[nodeIndex1];
 		m_Parent[temp] = nodeIndex2;			// Update left child
-		if (temp < m_NumNodes)			// Check for non-data node (has right child)
+		if (temp < m_NodeCount)			// Check for non-data node (has right child)
 			m_Parent[temp + 1] = nodeIndex2;	// Update right child
 
 		temp = m_Data[nodeIndex2];
 		m_Parent[temp] = nodeIndex1;			// Update left child
-		if (temp < m_NumNodes)			// Check for non-data node (has right child)
+		if (temp < m_NodeCount)			// Check for non-data node (has right child)
 			m_Parent[temp + 1] = nodeIndex1;	// Update right child
 
 		// Swap Data values (link to children or code value)
@@ -173,11 +173,11 @@ namespace Archives
 	int AdaptiveHuffmanTree::GetEncodedBitString(int code, int &bitString)
 	{
 		int curNodeIndex;
-		int numBits;
+		int bitCount;
 		bool bBit;
 
 		// Make sure the code is in range
-		if (code >= m_NumTerminalNodes)
+		if (code >= m_TerminalNodeCount)
 		{
 			throw std::runtime_error("Code value is out of range");
 		}
@@ -190,11 +190,11 @@ namespace Archives
 		while (curNodeIndex != m_RootNodeIndex)
 		{
 			bBit = curNodeIndex & 0x01;	// Get the direction from parent to current node
-			numBits++;
+			bitCount++;
 			bitString = (bitString << 1) + bBit;// Pack the bit into the returned string
 		}
 
-		return numBits;					// Return number of bits in path from root to node
+		return bitCount;					// Return number of bits in path from root to node
 	}
 	*/
 }

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -1,4 +1,5 @@
 #include "AdaptiveHuffmanTree.h"
+#include <utility>
 #include <stdexcept>
 
 namespace Archives
@@ -151,7 +152,7 @@ namespace Archives
 	void AdaptiveHuffmanTree::SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2)
 	{
 		// Swap Count values
-		auto temp = m_Count[nodeIndex1]; m_Count[nodeIndex1] = m_Count[nodeIndex2]; m_Count[nodeIndex2] = temp;
+		std::swap(m_Count[nodeIndex1], m_Count[nodeIndex2]);
 
 		// Update the Parent of the children
 		// Note: If the current node is a terminal node (data node) then the left
@@ -160,7 +161,7 @@ namespace Archives
 		//  a terminal node (not a data node) then both left and right child nodes
 		//  need to have their parent link updated
 
-		temp = m_Data[nodeIndex1];
+		auto temp = m_Data[nodeIndex1];
 		m_Parent[temp] = nodeIndex2;			// Update left child
 		if (temp < m_NumNodes)			// Check for non-data node (has right child)
 			m_Parent[temp + 1] = nodeIndex2;	// Update right child
@@ -169,8 +170,9 @@ namespace Archives
 		m_Parent[temp] = nodeIndex1;			// Update left child
 		if (temp < m_NumNodes)			// Check for non-data node (has right child)
 			m_Parent[temp + 1] = nodeIndex1;	// Update right child
+
 		// Swap Data values (link to children or code value)
-		temp = m_Data[nodeIndex1]; m_Data[nodeIndex1] = m_Data[nodeIndex2]; m_Data[nodeIndex2] = temp;
+		std::swap(m_Data[nodeIndex1], m_Data[nodeIndex2]);
 	}
 
 

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -5,18 +5,16 @@
 namespace Archives
 {
 	// Creates an (adaptive) Huffman tree with numTerminalNodes at the bottom.
-	AdaptiveHuffmanTree::AdaptiveHuffmanTree(NodeType numTerminalNodes)
-	{
+	AdaptiveHuffmanTree::AdaptiveHuffmanTree(NodeType numTerminalNodes) :
 		// Initialize tree properties
-		m_NumTerminalNodes = numTerminalNodes;
-		m_NumNodes = m_NumTerminalNodes * 2 - 1;
-		m_RootNodeIndex = m_NumNodes - 1;
-
-		// Allocate space for the tree
-		m_Data = new NodeType[m_NumNodes];
-		m_Count = new NodeType[m_NumNodes];
-		m_Parent = new NodeType[m_NumNodes + m_NumTerminalNodes];
-
+		m_NumTerminalNodes(numTerminalNodes),
+		m_NumNodes(m_NumTerminalNodes * 2 - 1),
+		m_RootNodeIndex(m_NumNodes - 1),
+		// Allocate space for tree
+		m_Data(m_NumNodes),
+		m_Count(m_NumNodes),
+		m_Parent(m_NumNodes + m_NumTerminalNodes)
+	{
 		// Initialize the tree
 		// Initialize terminal nodes
 		for (NodeIndex i = 0; i < m_NumTerminalNodes; ++i)
@@ -35,14 +33,6 @@ namespace Archives
 			m_Parent[i] = (i >> 1) + m_NumTerminalNodes;
 			left += 2;										// Calc index of left child (next loop)
 		}
-	}
-
-	AdaptiveHuffmanTree::~AdaptiveHuffmanTree()
-	{
-		// Delete the tree
-		delete m_Data;
-		delete m_Count;
-		delete m_Parent;
 	}
 
 

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -1,5 +1,6 @@
 #include "AdaptiveHuffmanTree.h"
 #include <utility>
+#include <string>
 #include <stdexcept>
 
 namespace Archives

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -88,7 +88,7 @@ namespace Archives
 		// Make sure the code is in range
 		if (code >= m_TerminalNodeCount)
 		{
-			throw std::runtime_error("Code value out of range");
+			throw std::runtime_error("AdaptiveHuffmanTree DataValue out of range");
 		}
 
 		// Get the index of the node containing this code
@@ -128,7 +128,7 @@ namespace Archives
 		// Check that the nodeIndex is in range
 		if (nodeIndex >= m_NodeCount)
 		{
-			throw std::runtime_error("Index out of range");
+			throw std::runtime_error("AdaptiveHuffmanTree NodeIndex out of range");
 		}
 	}
 

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -58,11 +58,7 @@ namespace Archives
 	// This is used to traverse the tree to a terminal node.
 	AdaptiveHuffmanTree::NodeIndex AdaptiveHuffmanTree::GetChildNode(NodeIndex nodeIndex, bool bRight)
 	{
-		// Check that the nodeIndex is in range
-		if (nodeIndex >= m_NumNodes)
-		{
-			throw std::runtime_error("Index out of range");
-		}
+		VerifyValidNodeIndex(nodeIndex);
 
 		// Return the child node index
 		return m_Data[nodeIndex] + bRight;
@@ -72,11 +68,7 @@ namespace Archives
 	// This is used to know when a tree search has completed.
 	bool AdaptiveHuffmanTree::IsLeaf(NodeIndex nodeIndex)
 	{
-		// Check that the nodeIndex is in range
-		if (nodeIndex >= m_NumNodes)
-		{
-			throw std::runtime_error("Index out of range");
-		}
+		VerifyValidNodeIndex(nodeIndex);
 
 		// Return whether or not this is a terminal node
 		return m_Data[nodeIndex] >= m_NumNodes;
@@ -85,11 +77,7 @@ namespace Archives
 	// Returns the data stored in a terminal node
 	AdaptiveHuffmanTree::DataValue AdaptiveHuffmanTree::GetNodeData(NodeIndex nodeIndex)
 	{
-		// Check that the nodeIndex is in range
-		if (nodeIndex >= m_NumNodes)
-		{
-			throw std::runtime_error("Index out of range");
-		}
+		VerifyValidNodeIndex(nodeIndex);
 
 		// Return data stored in node translated back to normal form
 		// Note: This assumes the node is a terminal node
@@ -143,6 +131,16 @@ namespace Archives
 	}
 
 
+
+	// Raise exception if nodeIndex is out of range
+	void AdaptiveHuffmanTree::VerifyValidNodeIndex(NodeIndex nodeIndex)
+	{
+		// Check that the nodeIndex is in range
+		if (nodeIndex >= m_NumNodes)
+		{
+			throw std::runtime_error("Index out of range");
+		}
+	}
 
 	// Private function to swap two nodes in the Huffman tree.
 	// This is used during tree restructing by UpdateCodeCount.

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -4,10 +4,10 @@
 namespace Archives
 {
 	// Creates an (adaptive) Huffman tree with numTerminalNodes at the bottom.
-	AdaptiveHuffmanTree::AdaptiveHuffmanTree(unsigned short numTerminalNodes)
+	AdaptiveHuffmanTree::AdaptiveHuffmanTree(NodeType numTerminalNodes)
 	{
-		unsigned short i;
-		unsigned short left;
+		NodeIndex i;
+		NodeIndex left;
 
 		// Initialize tree properties
 		m_NumTerminalNodes = numTerminalNodes;
@@ -15,9 +15,9 @@ namespace Archives
 		m_RootNodeIndex = m_NumNodes - 1;
 
 		// Allocate space for the tree
-		m_Data = new USHORT[m_NumNodes];
-		m_Count = new USHORT[m_NumNodes];
-		m_Parent = new USHORT[m_NumNodes + m_NumTerminalNodes];
+		m_Data = new NodeType[m_NumNodes];
+		m_Count = new NodeType[m_NumNodes];
+		m_Parent = new NodeType[m_NumNodes + m_NumTerminalNodes];
 
 		// Initialize the tree
 		// Initialize terminal nodes
@@ -51,14 +51,14 @@ namespace Archives
 
 	// Returns the index of the root node.
 	// All tree searches start at the root node.
-	unsigned short AdaptiveHuffmanTree::GetRootNodeIndex()
+	AdaptiveHuffmanTree::NodeIndex AdaptiveHuffmanTree::GetRootNodeIndex()
 	{
 		return m_RootNodeIndex;
 	}
 
 	// Return a child node of the given node.
 	// This is used to traverse the tree to a terminal node.
-	unsigned short AdaptiveHuffmanTree::GetChildNode(unsigned short nodeIndex, bool bRight)
+	AdaptiveHuffmanTree::NodeIndex AdaptiveHuffmanTree::GetChildNode(NodeIndex nodeIndex, bool bRight)
 	{
 		// Check that the nodeIndex is in range
 		if (nodeIndex >= m_NumNodes)
@@ -72,7 +72,7 @@ namespace Archives
 
 	// Returns true if the node is a terminal node.
 	// This is used to know when a tree search has completed.
-	bool AdaptiveHuffmanTree::IsLeaf(unsigned short nodeIndex)
+	bool AdaptiveHuffmanTree::IsLeaf(NodeIndex nodeIndex)
 	{
 		// Check that the nodeIndex is in range
 		if (nodeIndex >= m_NumNodes)
@@ -85,7 +85,7 @@ namespace Archives
 	}
 
 	// Returns the data stored in a terminal node
-	unsigned short AdaptiveHuffmanTree::GetNodeData(unsigned short nodeIndex)
+	AdaptiveHuffmanTree::DataValue AdaptiveHuffmanTree::GetNodeData(NodeIndex nodeIndex)
 	{
 		// Check that the nodeIndex is in range
 		if (nodeIndex >= m_NumNodes)
@@ -104,7 +104,7 @@ namespace Archives
 	// This updates the count for the given code and restructures the tree if needed.
 	// This is used after a tree search to update the tree (gives more frequently used
 	// codes a shorter bit encoding).
-	void AdaptiveHuffmanTree::UpdateCodeCount(unsigned short code)
+	void AdaptiveHuffmanTree::UpdateCodeCount(DataValue code)
 	{
 		int curNodeIndex;
 		int blockLeaderIndex;
@@ -148,12 +148,10 @@ namespace Archives
 
 	// Private function to swap two nodes in the Huffman tree.
 	// This is used during tree restructing by UpdateCodeCount.
-	void AdaptiveHuffmanTree::SwapNodes(unsigned short node1, unsigned short node2)
+	void AdaptiveHuffmanTree::SwapNodes(NodeIndex node1, NodeIndex node2)
 	{
-		unsigned short temp;
-
 		// Swap Count values
-		temp = m_Count[node1]; m_Count[node1] = m_Count[node2]; m_Count[node2] = temp;
+		auto temp = m_Count[node1]; m_Count[node1] = m_Count[node2]; m_Count[node2] = temp;
 
 		// Update the Parent of the children
 		// Note: If the current node is a terminal node (data node) then the left

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -7,9 +7,6 @@ namespace Archives
 	// Creates an (adaptive) Huffman tree with numTerminalNodes at the bottom.
 	AdaptiveHuffmanTree::AdaptiveHuffmanTree(NodeType numTerminalNodes)
 	{
-		NodeIndex i;
-		NodeIndex left;
-
 		// Initialize tree properties
 		m_NumTerminalNodes = numTerminalNodes;
 		m_NumNodes = m_NumTerminalNodes * 2 - 1;
@@ -22,7 +19,7 @@ namespace Archives
 
 		// Initialize the tree
 		// Initialize terminal nodes
-		for (i = 0; i < m_NumTerminalNodes; ++i)
+		for (NodeIndex i = 0; i < m_NumTerminalNodes; ++i)
 		{
 			m_Data[i] = i + m_NumNodes;						// Initilize data values
 			m_Count[i] = 1;
@@ -30,8 +27,8 @@ namespace Archives
 			m_Parent[i + m_NumNodes] = i;						// "Parent of code" (node index)
 		}
 		// Initialize non terminal nodes
-		left = 0;
-		for (i = m_NumTerminalNodes; i < m_NumNodes; ++i)
+		NodeIndex left = 0;
+		for (NodeIndex i = m_NumTerminalNodes; i < m_NumNodes; ++i)
 		{
 			m_Data[i] = left;								// Initialize link values
 			m_Count[i] = m_Count[left] + m_Count[left + 1];	// Count is sum of two subtrees

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -148,10 +148,10 @@ namespace Archives
 
 	// Private function to swap two nodes in the Huffman tree.
 	// This is used during tree restructing by UpdateCodeCount.
-	void AdaptiveHuffmanTree::SwapNodes(NodeIndex node1, NodeIndex node2)
+	void AdaptiveHuffmanTree::SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2)
 	{
 		// Swap Count values
-		auto temp = m_Count[node1]; m_Count[node1] = m_Count[node2]; m_Count[node2] = temp;
+		auto temp = m_Count[nodeIndex1]; m_Count[nodeIndex1] = m_Count[nodeIndex2]; m_Count[nodeIndex2] = temp;
 
 		// Update the Parent of the children
 		// Note: If the current node is a terminal node (data node) then the left
@@ -160,17 +160,17 @@ namespace Archives
 		//  a terminal node (not a data node) then both left and right child nodes
 		//  need to have their parent link updated
 
-		temp = m_Data[node1];
-		m_Parent[temp] = node2;			// Update left child
+		temp = m_Data[nodeIndex1];
+		m_Parent[temp] = nodeIndex2;			// Update left child
 		if (temp < m_NumNodes)			// Check for non-data node (has right child)
-			m_Parent[temp + 1] = node2;	// Update right child
+			m_Parent[temp + 1] = nodeIndex2;	// Update right child
 
-		temp = m_Data[node2];
-		m_Parent[temp] = node1;			// Update left child
+		temp = m_Data[nodeIndex2];
+		m_Parent[temp] = nodeIndex1;			// Update left child
 		if (temp < m_NumNodes)			// Check for non-data node (has right child)
-			m_Parent[temp + 1] = node1;	// Update right child
+			m_Parent[temp + 1] = nodeIndex1;	// Update right child
 		// Swap Data values (link to children or code value)
-		temp = m_Data[node1]; m_Data[node1] = m_Data[node2]; m_Data[node2] = temp;
+		temp = m_Data[nodeIndex1]; m_Data[nodeIndex1] = m_Data[nodeIndex2]; m_Data[nodeIndex2] = temp;
 	}
 
 

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -88,7 +88,8 @@ namespace Archives
 		// Make sure the code is in range
 		if (code >= m_TerminalNodeCount)
 		{
-			throw std::runtime_error("AdaptiveHuffmanTree DataValue out of range");
+			throw std::runtime_error("AdaptiveHuffmanTree DataValue of " + std::to_string(code)
+				+ " is out of range " + std::to_string(m_TerminalNodeCount));
 		}
 
 		// Get the index of the node containing this code
@@ -128,7 +129,8 @@ namespace Archives
 		// Check that the nodeIndex is in range
 		if (nodeIndex >= m_NodeCount)
 		{
-			throw std::runtime_error("AdaptiveHuffmanTree NodeIndex out of range");
+			throw std::runtime_error("AdaptiveHuffmanTree NodeIndex of " + std::to_string(nodeIndex)
+				+ " is out of range " + std::to_string(m_NodeCount));
 		}
 	}
 

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -31,7 +31,7 @@ namespace Archives
 		// code and places the path in bitString
 
 	private:
-		void SwapNodes(NodeIndex node1, NodeIndex node2);
+		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Next three arrays comprise the adaptive huffman tree
 		// Note: m_Data is used for both tree links and node data.

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -3,7 +3,7 @@
 namespace Archives
 {
 	// The Huffman Tree stores codes in the terminal nodes of the (binary) tree.
-	// The tree is initially balanced with codes 0 to numTerminalNodes-1 in the
+	// The tree is initially balanced with codes 0 to terminalNodeCount-1 in the
 	// terminal nodes at the bottom of the tree. The tree branches are traversed
 	// using binary values: "0" traverse Left branch, "1" traverse Right branch.
 	class AdaptiveHuffmanTree
@@ -13,7 +13,7 @@ namespace Archives
 		using NodeIndex = NodeType;
 		using DataValue = NodeType;
 
-		AdaptiveHuffmanTree(NodeType numTerminalNodes);
+		AdaptiveHuffmanTree(NodeType terminalNodeCount);
 
 		// Decompression routines
 		NodeIndex GetRootNodeIndex();				// Get root of tree to start search at
@@ -36,14 +36,14 @@ namespace Archives
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Tree properties
-		NodeType m_NumTerminalNodes;
-		NodeType m_NumNodes;
+		NodeType m_TerminalNodeCount;
+		NodeType m_NodeCount;
 		NodeIndex m_RootNodeIndex;
 		// Next three arrays comprise the adaptive huffman tree
 		// Note: m_Data is used for both tree links and node data.
-		//   Values above or equal m_NumNodes represent data
-		//   Values below m_NumNodes represent links
-		std::vector<NodeType> m_Data;   // index of left child (link) or code+m_NumNodes (data)
+		//   Values above or equal m_NodeCount represent data
+		//   Values below m_NodeCount represent links
+		std::vector<NodeType> m_Data;   // index of left child (link) or code+m_NodeCount (data)
 		std::vector<NodeType> m_Count;  // number of occurances of code or codes in subtrees
 		std::vector<NodeType> m_Parent; // index of the parent node to (current node or data)
 							//  Note: This is also used to translate: code -> node_index
@@ -56,11 +56,11 @@ namespace Archives
 	// --------------------
 
 	// Note: the m_Data array contains both link data and code data. If the value is
-	//  less than m_NumNodes then the value represents the index of the node which is
+	//  less than m_NodeCount then the value represents the index of the node which is
 	//  the left child of the current node and value+1 represents the index of the
 	//  node which is the right child of the current node.
-	//  If the value is greater or equal to m_NumNodes then the current node is a
-	//  terminal node and the code stored in this node is value-m_NumNodes.
+	//  If the value is greater or equal to m_NodeCount then the current node is a
+	//  terminal node and the code stored in this node is value-m_NodeCount.
 
 	// Note: Block Leader referse to the "rightmost" node whose count is equal to
 	//  the count of the current node (before the count of the current node is
@@ -75,8 +75,8 @@ namespace Archives
 	//  does not need to be performed when swapping the current node with the block leader.
 
 	// Note: The m_Parent array contains more entries than the other two. Entries below
-	//  m_NumNodes are used to find the parent of a given node. Entries above m_NumNodes
-	//  (up to m_NumNodes + m_NumTerminalNodes) are used to find the node which contains
+	//  m_NodeCount are used to find the parent of a given node. Entries above m_NodeCount
+	//  (up to m_NodeCount + m_TerminalNodeCount) are used to find the node which contains
 	//  a given code. i.e. the "parent" of the code.
 
 	// Note: Parents are always to the "right" of their children. Also every node except

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -31,6 +31,7 @@ namespace Archives
 		// code and places the path in bitString
 
 	private:
+		void VerifyValidNodeIndex(NodeIndex nodeIndex);
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Next three arrays comprise the adaptive huffman tree

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -1,3 +1,5 @@
+#include <vector>
+
 namespace Archives
 {
 	// The Huffman Tree stores codes in the terminal nodes of the (binary) tree.
@@ -12,7 +14,6 @@ namespace Archives
 		using DataValue = NodeType;
 
 		AdaptiveHuffmanTree(NodeType numTerminalNodes);
-		~AdaptiveHuffmanTree();
 
 		// Decompression routines
 		NodeIndex GetRootNodeIndex();				// Get root of tree to start search at
@@ -34,18 +35,18 @@ namespace Archives
 		void VerifyValidNodeIndex(NodeIndex nodeIndex);
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
+		// Tree properties
+		NodeType m_NumTerminalNodes;
+		NodeType m_NumNodes;
+		NodeIndex m_RootNodeIndex;
 		// Next three arrays comprise the adaptive huffman tree
 		// Note: m_Data is used for both tree links and node data.
 		//   Values above or equal m_NumNodes represent data
 		//   Values below m_NumNodes represent links
-		NodeType *m_Data;		// index of left child (link) or code+m_NumNodes (data)
-		NodeType *m_Count;	// number of occurances of code or codes in subtrees
-		NodeType *m_Parent;	// index of the parent node to (current node or data)
+		std::vector<NodeType> m_Data;   // index of left child (link) or code+m_NumNodes (data)
+		std::vector<NodeType> m_Count;  // number of occurances of code or codes in subtrees
+		std::vector<NodeType> m_Parent; // index of the parent node to (current node or data)
 							//  Note: This is also used to translate: code -> node_index
-		// Tree properties
-		NodeIndex m_RootNodeIndex;
-		NodeType m_NumTerminalNodes;
-		NodeType m_NumNodes;
 	};
 
 

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -7,20 +7,22 @@ namespace Archives
 	class AdaptiveHuffmanTree
 	{
 	public:
-		typedef unsigned short USHORT;
+		using NodeType = unsigned short;
+		using NodeIndex = NodeType;
+		using DataValue = NodeType;
 
-		AdaptiveHuffmanTree(USHORT numTerminalNodes);
+		AdaptiveHuffmanTree(NodeType numTerminalNodes);
 		~AdaptiveHuffmanTree();
 
 		// Decompression routines
-		USHORT GetRootNodeIndex();				// Get root of tree to start search at
-		USHORT GetChildNode(USHORT nodeIndex, bool bRight);
+		NodeIndex GetRootNodeIndex();				// Get root of tree to start search at
+		NodeIndex GetChildNode(NodeIndex nodeIndex, bool bRight);
 		// bRight = 1 --> follow right branch
-		bool IsLeaf(USHORT nodeIndex);			// Determines if node is terminal node
-		USHORT GetNodeData(USHORT nodeIndex);	// Returns the data in a terminal node
+		bool IsLeaf(NodeIndex nodeIndex);			// Determines if node is terminal node
+		DataValue GetNodeData(NodeIndex nodeIndex);	// Returns the data in a terminal node
 
 		// Tree restructuring routines
-		void UpdateCodeCount(USHORT code);		// Perform tree update/restructure
+		void UpdateCodeCount(DataValue code);		// Perform tree update/restructure
 
 		// Compression routines
 		int GetEncodedBitString(int code, int &bitString);
@@ -29,20 +31,20 @@ namespace Archives
 		// code and places the path in bitString
 
 	private:
-		void SwapNodes(USHORT node1, USHORT node2);
+		void SwapNodes(NodeIndex node1, NodeIndex node2);
 
 		// Next three arrays comprise the adaptive huffman tree
 		// Note: m_Data is used for both tree links and node data.
 		//   Values above or equal m_NumNodes represent data
 		//   Values below m_NumNodes represent links
-		USHORT *m_Data;		// index of left child (link) or code+m_NumNodes (data)
-		USHORT *m_Count;	// number of occurances of code or codes in subtrees
-		USHORT *m_Parent;	// index of the parent node to (current node or data)
+		NodeType *m_Data;		// index of left child (link) or code+m_NumNodes (data)
+		NodeType *m_Count;	// number of occurances of code or codes in subtrees
+		NodeType *m_Parent;	// index of the parent node to (current node or data)
 							//  Note: This is also used to translate: code -> node_index
 		// Tree properties
-		USHORT m_RootNodeIndex;
-		USHORT m_NumTerminalNodes;
-		USHORT m_NumNodes;
+		NodeIndex m_RootNodeIndex;
+		NodeType m_NumTerminalNodes;
+		NodeType m_NumNodes;
 	};
 
 

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -36,16 +36,16 @@ namespace Archives
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Tree properties
-		NodeType m_TerminalNodeCount;
-		NodeType m_NodeCount;
-		NodeIndex m_RootNodeIndex;
+		NodeType terminalNodeCount;
+		NodeType nodeCount;
+		NodeIndex rootNodeIndex;
 		// Next three arrays comprise the adaptive huffman tree
-		// Note: m_Data is used for both tree links and node data.
-		//   Values above or equal m_NodeCount represent data
-		//   Values below m_NodeCount represent links
-		std::vector<NodeType> m_Data;   // index of left child (link) or code+m_NodeCount (data)
-		std::vector<NodeType> m_Count;  // number of occurances of code or codes in subtrees
-		std::vector<NodeType> m_Parent; // index of the parent node to (current node or data)
+		// Note:  is used for both tree links and node data.
+		//   Values above or equal nodeCount represent data
+		//   Values below nodeCount represent links
+		std::vector<NodeType> linkOrData;   // index of left child (link) or code+nodeCount (data)
+		std::vector<NodeType> subtreeCount; // number of occurances of code or codes in subtrees
+		std::vector<NodeType> parentIndex; // index of the parent node to (current node or data)
 							//  Note: This is also used to translate: code -> node_index
 	};
 
@@ -55,12 +55,12 @@ namespace Archives
 	// Implementation Notes
 	// --------------------
 
-	// Note: the m_Data array contains both link data and code data. If the value is
-	//  less than m_NodeCount then the value represents the index of the node which is
+	// Note: the linkOrData array contains both link data and code data. If the value is
+	//  less than nodeCount then the value represents the index of the node which is
 	//  the left child of the current node and value+1 represents the index of the
 	//  node which is the right child of the current node.
-	//  If the value is greater or equal to m_NodeCount then the current node is a
-	//  terminal node and the code stored in this node is value-m_NodeCount.
+	//  If the value is greater or equal to nodeCount then the current node is a
+	//  terminal node and the code stored in this node is value-nodeCount.
 
 	// Note: Block Leader referse to the "rightmost" node whose count is equal to
 	//  the count of the current node (before the count of the current node is
@@ -74,9 +74,9 @@ namespace Archives
 	//  1 greater than either of it's two subtress, which both exist). Thus such a check
 	//  does not need to be performed when swapping the current node with the block leader.
 
-	// Note: The m_Parent array contains more entries than the other two. Entries below
-	//  m_NodeCount are used to find the parent of a given node. Entries above m_NodeCount
-	//  (up to m_NodeCount + m_TerminalNodeCount) are used to find the node which contains
+	// Note: The parentIndex array contains more entries than the other two. Entries below
+	//  nodeCount are used to find the parent of a given node. Entries above nodeCount
+	//  (up to nodeCount + terminalNodeCount) are used to find the node which contains
 	//  a given code. i.e. the "parent" of the code.
 
 	// Note: Parents are always to the "right" of their children. Also every node except

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -1,0 +1,22 @@
+#include "Archives/AdaptiveHuffmanTree.h"
+#include <gtest/gtest.h>
+
+
+TEST(AdaptiveHuffmanTreeTests, SimpleTree2) {
+  // Construct minimum non-degenerate binary tree with 2 data nodes
+  Archives::AdaptiveHuffmanTree tree(2);
+
+  // With 2 data nodes, the root can not be a data node
+  auto rootIndex = tree.GetRootNodeIndex();
+  ASSERT_FALSE(tree.IsLeaf(rootIndex));
+
+  // With 2 data nodes, the children of the root must be data nodes
+  auto leftChild = tree.GetChildNode(rootIndex, false);
+  auto rightChild = tree.GetChildNode(rootIndex, true);
+  ASSERT_TRUE(tree.IsLeaf(leftChild));
+  ASSERT_TRUE(tree.IsLeaf(rightChild));
+
+  // No tree updates, so initial data should still be in order
+  ASSERT_EQ(0, tree.GetNodeData(leftChild));
+  ASSERT_EQ(1, tree.GetNodeData(rightChild));
+}

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -3,20 +3,20 @@
 
 
 TEST(AdaptiveHuffmanTreeTests, SimpleTree2) {
-  // Construct minimum non-degenerate binary tree with 2 data nodes
-  Archives::AdaptiveHuffmanTree tree(2);
+	// Construct minimum non-degenerate binary tree with 2 data nodes
+	Archives::AdaptiveHuffmanTree tree(2);
 
-  // With 2 data nodes, the root can not be a data node
-  auto rootIndex = tree.GetRootNodeIndex();
-  ASSERT_FALSE(tree.IsLeaf(rootIndex));
+	// With 2 data nodes, the root can not be a data node
+	auto rootIndex = tree.GetRootNodeIndex();
+	ASSERT_FALSE(tree.IsLeaf(rootIndex));
 
-  // With 2 data nodes, the children of the root must be data nodes
-  auto leftChild = tree.GetChildNode(rootIndex, false);
-  auto rightChild = tree.GetChildNode(rootIndex, true);
-  ASSERT_TRUE(tree.IsLeaf(leftChild));
-  ASSERT_TRUE(tree.IsLeaf(rightChild));
+	// With 2 data nodes, the children of the root must be data nodes
+	auto leftChild = tree.GetChildNode(rootIndex, false);
+	auto rightChild = tree.GetChildNode(rootIndex, true);
+	ASSERT_TRUE(tree.IsLeaf(leftChild));
+	ASSERT_TRUE(tree.IsLeaf(rightChild));
 
-  // No tree updates, so initial data should still be in order
-  ASSERT_EQ(0, tree.GetNodeData(leftChild));
-  ASSERT_EQ(1, tree.GetNodeData(rightChild));
+	// No tree updates, so initial data should still be in order
+	ASSERT_EQ(0, tree.GetNodeData(leftChild));
+	ASSERT_EQ(1, tree.GetNodeData(rightChild));
 }


### PR DESCRIPTION
This closes #149, by consistently using the type alias throughout the code. I opted to use the newer C++ style `using` alias, instead of the older `typedef` alias.

Contains a number of other refactorings to clean up the code. In particular, replacing manual memory management with `std::vector`.

Edit: My quick and dirty unit test shows these changes do not impact decompression output.