### PR TITLE
HuffLZ cleanup prep for code to data

### DIFF
--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -211,7 +211,11 @@ namespace Archives
 		return m_AdaptiveHuffmanTree.GetNodeData(nodeIndex);
 	}
 
-	// Determines the offset to the start of a repeated block. (This one is a little weird)
+	// Determines the offset to the start of a repeated block
+	//
+	// Reads a variable length code from the bit stream (9-14 bits)
+	// Smaller offsets have a shorter bit code
+	// Returns a 12-bit offset (0..4095)
 	unsigned int HuffLZ::GetRepeatOffset()
 	{
 		// Get the next 8 bits
@@ -223,12 +227,13 @@ namespace Archives
 		for (; numExtraBits; numExtraBits--) {
 			offset = (offset << 1) + m_BitStreamReader.ReadNextBit();
 		}
-		offset &= 0x3F;			// Mask upper bits (keep lower 6)
+		// Keep lower 6 bits (mask off upper bits)
+		offset &= 0x3F; // 0011 1111
 
-		// Apply the modifier
-		offset |= (mod << 6);	// Set upper 6 bits (12 bit number -> buffer size is 4096)
+		// Set upper 6 bits (12 bit number -> buffer size is 4096)
+		offset |= (mod << 6);
 
-		return offset;			// Return the offset to the start of the repeated block
+		return offset;
 	}
 
 	void HuffLZ::WriteCharToBuffer(char c)

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -231,6 +231,12 @@ namespace Archives
 		return offset;			// Return the offset to the start of the repeated block
 	}
 
+	void HuffLZ::WriteCharToBuffer(char c)
+	{
+		m_DecompressBuffer[m_BuffWriteIndex] = c;			// Write the char to the buffer
+		m_BuffWriteIndex = (m_BuffWriteIndex + 1) & 0x0FFF;	// Wrap around 4096
+	}
+
 
 
 	// Determine how many more bits to read in
@@ -275,11 +281,5 @@ namespace Archives
 		}
 
 		return offset - 0xC0;
-	}
-
-	void HuffLZ::WriteCharToBuffer(char c)
-	{
-		m_DecompressBuffer[m_BuffWriteIndex] = c;			// Write the char to the buffer
-		m_BuffWriteIndex = (m_BuffWriteIndex + 1) & 0x0FFF;	// Wrap around 4096
 	}
 }

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -243,52 +243,22 @@ namespace Archives
 
 
 	HuffLZ::OffsetModifiers HuffLZ::GetOffsetModifiers(unsigned int offset) {
-		auto extraBitCount = GetNumExtraBits(offset);
-		auto offsetUpperBits = GetOffsetBitMod(offset);
-		return OffsetModifiers { extraBitCount, offsetUpperBits };
-	}
-
-	// Determine how many more bits to read in
-	unsigned int HuffLZ::GetNumExtraBits(unsigned int offset)
-	{
 		if (offset < 0x20) {
-			return 1;
+			return { 1, 0 };
 		}
 		if (offset < 0x50) {
-			return 2;
+			return { 2, ((offset - 0x20) >> 4) + 1 };
 		}
 		if (offset < 0x90) {
-			return 3;
+			return { 3, ((offset - 0x50) >> 3) + 4 };
 		}
 		if (offset < 0xC0) {
-			return 4;
+			return { 4, ((offset - 0x90) >> 2) + 0x0C };
 		}
 		if (offset < 0xF0) {
-			return 5;
+			return { 5, ((offset - 0xC0) >> 1) + 0x18 };
 		}
 
-		return 6;
-	}
-
-	// Determine how to modify bits to get real offset
-	unsigned int HuffLZ::GetOffsetBitMod(unsigned int offset)
-	{
-		if (offset < 0x20) {
-			return 0;
-		}
-		if (offset < 0x50) {
-			return ((offset - 0x20) >> 4) + 1;
-		}
-		if (offset < 0x90) {
-			return ((offset - 0x50) >> 3) + 4;
-		}
-		if (offset < 0xC0) {
-			return ((offset - 0x90) >> 2) + 0x0C;
-		}
-		if (offset < 0xF0) {
-			return ((offset - 0xC0) >> 1) + 0x18;
-		}
-
-		return offset - 0xC0;
+		return { 6, offset - 0xC0 };
 	}
 }

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -240,7 +240,7 @@ namespace Archives
 
 
 	// Determine how many more bits to read in
-	int HuffLZ::GetNumExtraBits(int offset)
+	unsigned int HuffLZ::GetNumExtraBits(unsigned int offset)
 	{
 		if (offset < 0x20) {
 			return 1;
@@ -262,7 +262,7 @@ namespace Archives
 	}
 
 	// Determine how to modify bits to get real offset
-	int HuffLZ::GetOffsetBitMod(int offset)
+	unsigned int HuffLZ::GetOffsetBitMod(unsigned int offset)
 	{
 		if (offset < 0x20) {
 			return 0;

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -227,11 +227,10 @@ namespace Archives
 		for (; numExtraBits; numExtraBits--) {
 			offset = (offset << 1) + m_BitStreamReader.ReadNextBit();
 		}
-		// Keep lower 6 bits (mask off upper bits)
-		offset &= 0x3F; // 0011 1111
 
-		// Set upper 6 bits (12 bit number -> buffer size is 4096)
-		offset |= (mod << 6);
+		// Set upper 6 bits and preserve lower 6 bits (0x3F = 0011 1111)
+		// Result is a 12-bit number with range 0..4095
+		offset = (mod << 6) | (offset & 0x3F);
 
 		return offset;
 	}

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -1,5 +1,5 @@
-#include <string.h>
 #include "HuffLZ.h"
+#include <cstring>
 
 namespace Archives
 {
@@ -16,7 +16,7 @@ namespace Archives
 
 	void HuffLZ::InitializeDecompressBuffer() {
 		// Initialize the decompress buffer to spaces
-		memset(m_DecompressBuffer, ' ', 4096);
+		std::memset(m_DecompressBuffer, ' ', 4096);
 	}
 
 
@@ -127,7 +127,7 @@ namespace Archives
 			}
 
 			// Copy what is already decompressed into the output buffer
-			memcpy(buff, &m_DecompressBuffer[m_BuffReadIndex], numBytesToCopy);
+			std::memcpy(buff, &m_DecompressBuffer[m_BuffReadIndex], numBytesToCopy);
 			numBytesTotal = numBytesToCopy;	// Update number of bytes copied
 			size -= numBytesToCopy;			// Update space left in buffer
 			// Update read index and wrap around 4096
@@ -145,7 +145,7 @@ namespace Archives
 		if (numBytesToCopy > 0)
 		{
 			// Copy what is already decompressed into the output buffer
-			memcpy(&buff[numBytesTotal], &m_DecompressBuffer[m_BuffReadIndex], numBytesToCopy);
+			std::memcpy(&buff[numBytesTotal], &m_DecompressBuffer[m_BuffReadIndex], numBytesToCopy);
 			numBytesTotal += numBytesToCopy;// Update number of bytes copied
 			// Update read index (Note: no need to wrap around 4096 here)
 			m_BuffReadIndex = (m_BuffReadIndex + numBytesToCopy);

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -234,7 +234,7 @@ namespace Archives
 
 
 	// Determine how many more bits to read in
-	int HuffLZ::GetNumExtraBits(int offset) const
+	int HuffLZ::GetNumExtraBits(int offset)
 	{
 		if (offset < 0x20) {
 			return 1;
@@ -256,7 +256,7 @@ namespace Archives
 	}
 
 	// Determine how to modify bits to get real offset
-	int HuffLZ::GetOffsetBitMod(int offset) const
+	int HuffLZ::GetOffsetBitMod(int offset)
 	{
 		if (offset < 0x20) {
 			return 0;

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -160,8 +160,8 @@ namespace Archives
 	bool HuffLZ::DecompressCode()
 	{
 		unsigned short code;
-		int start;
-		int offset;
+		unsigned int start;
+		unsigned int offset;
 
 		// Get the next code
 		code = GetNextCode();
@@ -212,12 +212,12 @@ namespace Archives
 	}
 
 	// Determines the offset to the start of a repeated block. (This one is a little weird)
-	int HuffLZ::GetRepeatOffset()
+	unsigned int HuffLZ::GetRepeatOffset()
 	{
 		// Get the next 8 bits
-		int offset = m_BitStreamReader.ReadNext8Bits();
-		int numExtraBits = GetNumExtraBits(offset);
-		int mod = GetOffsetBitMod(offset);
+		unsigned int offset = m_BitStreamReader.ReadNext8Bits();
+		unsigned int numExtraBits = GetNumExtraBits(offset);
+		unsigned int mod = GetOffsetBitMod(offset);
 
 		// Read in the extra bits
 		for (; numExtraBits; numExtraBits--) {

--- a/src/Archives/HuffLZ.cpp
+++ b/src/Archives/HuffLZ.cpp
@@ -220,17 +220,16 @@ namespace Archives
 	{
 		// Get the next 8 bits
 		unsigned int offset = m_BitStreamReader.ReadNext8Bits();
-		unsigned int numExtraBits = GetNumExtraBits(offset);
-		unsigned int mod = GetOffsetBitMod(offset);
+		auto modifiers = GetOffsetModifiers(offset);
 
 		// Read in the extra bits
-		for (; numExtraBits; numExtraBits--) {
+		for (auto i = modifiers.extraBitCount; i; --i) {
 			offset = (offset << 1) + m_BitStreamReader.ReadNextBit();
 		}
 
 		// Set upper 6 bits and preserve lower 6 bits (0x3F = 0011 1111)
 		// Result is a 12-bit number with range 0..4095
-		offset = (mod << 6) | (offset & 0x3F);
+		offset = (modifiers.offsetUpperBits << 6) | (offset & 0x3F);
 
 		return offset;
 	}
@@ -242,6 +241,12 @@ namespace Archives
 	}
 
 
+
+	HuffLZ::OffsetModifiers HuffLZ::GetOffsetModifiers(unsigned int offset) {
+		auto extraBitCount = GetNumExtraBits(offset);
+		auto offsetUpperBits = GetOffsetBitMod(offset);
+		return OffsetModifiers { extraBitCount, offsetUpperBits };
+	}
 
 	// Determine how many more bits to read in
 	unsigned int HuffLZ::GetNumExtraBits(unsigned int offset)

--- a/src/Archives/HuffLZ.h
+++ b/src/Archives/HuffLZ.h
@@ -23,7 +23,7 @@ namespace Archives
 		std::size_t CopyAvailableData(char *buff, std::size_t size);// Copies already decompressed data
 		bool DecompressCode();	// Decompresses a code and returns false at end of stream
 		int GetNextCode();
-		int GetRepeatOffset();
+		unsigned int GetRepeatOffset();
 		void WriteCharToBuffer(char c);
 
 		static unsigned int GetNumExtraBits(unsigned int offset);

--- a/src/Archives/HuffLZ.h
+++ b/src/Archives/HuffLZ.h
@@ -31,8 +31,6 @@ namespace Archives
 			unsigned int offsetUpperBits;
 		};
 		static OffsetModifiers GetOffsetModifiers(unsigned int offset);
-		static unsigned int GetNumExtraBits(unsigned int offset);
-		static unsigned int GetOffsetBitMod(unsigned int offset);
 
 		// Member variables
 		BitStreamReader m_BitStreamReader;

--- a/src/Archives/HuffLZ.h
+++ b/src/Archives/HuffLZ.h
@@ -26,8 +26,8 @@ namespace Archives
 		int GetRepeatOffset();
 		void WriteCharToBuffer(char c);
 
-		static int GetNumExtraBits(int offset);
-		static int GetOffsetBitMod(int offset);
+		static unsigned int GetNumExtraBits(unsigned int offset);
+		static unsigned int GetOffsetBitMod(unsigned int offset);
 
 		// Member variables
 		BitStreamReader m_BitStreamReader;

--- a/src/Archives/HuffLZ.h
+++ b/src/Archives/HuffLZ.h
@@ -24,9 +24,10 @@ namespace Archives
 		bool DecompressCode();	// Decompresses a code and returns false at end of stream
 		int GetNextCode();
 		int GetRepeatOffset();
+		void WriteCharToBuffer(char c);
+
 		static int GetNumExtraBits(int offset);
 		static int GetOffsetBitMod(int offset);
-		void WriteCharToBuffer(char c);
 
 		// Member variables
 		BitStreamReader m_BitStreamReader;

--- a/src/Archives/HuffLZ.h
+++ b/src/Archives/HuffLZ.h
@@ -24,8 +24,8 @@ namespace Archives
 		bool DecompressCode();	// Decompresses a code and returns false at end of stream
 		int GetNextCode();
 		int GetRepeatOffset();
-		int GetNumExtraBits(int offset) const;
-		int GetOffsetBitMod(int offset) const;
+		static int GetNumExtraBits(int offset);
+		static int GetOffsetBitMod(int offset);
 		void WriteCharToBuffer(char c);
 
 		// Member variables

--- a/src/Archives/HuffLZ.h
+++ b/src/Archives/HuffLZ.h
@@ -26,6 +26,11 @@ namespace Archives
 		unsigned int GetRepeatOffset();
 		void WriteCharToBuffer(char c);
 
+		struct OffsetModifiers {
+			unsigned int extraBitCount;
+			unsigned int offsetUpperBits;
+		};
+		static OffsetModifiers GetOffsetModifiers(unsigned int offset);
 		static unsigned int GetNumExtraBits(unsigned int offset);
 		static unsigned int GetOffsetBitMod(unsigned int offset);
 


### PR DESCRIPTION
This relates to Issue #134. This branch contains cleanup prep work to support switching from data-like code to using an actual data table.

In particular, it updates comments and cleans up code to make what's going on more clear. It also eliminates the double cascaded `if` lookup, and now returns both values from a single lookup.

As this work stands on it's own, and I'm about to take a break, I thought I'd stop here and submit the changes.
