### PR TITLE
Remove stray header include

### DIFF
--- a/src/Streams/FileReader.cpp
+++ b/src/Streams/FileReader.cpp
@@ -1,7 +1,6 @@
 #include "FileReader.h"
 #include "FileSliceReader.h"
 #include <stdexcept>
-#include <limits.h>
 
 namespace Stream
 {


### PR DESCRIPTION
This header was added along with the bit twiddling hack, which was later
removed. It was added for the `CHAR_BIT` constant.

Side note: The newer C++ header `<climits>` would correspond with the
older C header `<limits.h>`.