### PR TITLE
Fix AppVeyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,4 +9,6 @@ before_build: nuget restore
 build:
   project: OP2Utility.sln
 test_script:
+  - cd %APPVEYOR_BUILD_FOLDER%\test
   - '%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\OP2UtilityTest.exe'
+  - cd %APPVEYOR_BUILD_FOLDER%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,8 @@ before_build: nuget restore
 build:
   project: OP2Utility.sln
 test_script:
+  - echo Current working directory = '%CD%'
+  - echo Test exe path = '%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\OP2UtilityTest.exe'
   - cd %APPVEYOR_BUILD_FOLDER%\test
   - '%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\OP2UtilityTest.exe'
   - cd %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
For some reason, the current working directory used when runnings tests appears to have changed. This PR adds an explicit command to set the current working directory before running tests.

The original problem may be related to the branch that added the `.appveyor.yml` configuration file, or perhaps due to recent project file changes, I'm not really sure. I didn't see any documentation that addressed the default working directory, nor how MSBuild might have affect the current working directory. It would be nice to know what changed to cause this behaviour. Meanwhile though, explicitly setting the current working directory seems to fix it.
