### PR TITLE
Disable AppVeyor Debug build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 image: Visual Studio 2017
 configuration:
-  - Debug 
   - Release
 platform:
   - x86


### PR DESCRIPTION
Double the configurations means double the test runs. Due to limited
parallelism on the free open source plan, this is doubling the test
time.

Currently we have no code that behaves obviously different in Debug
versus Release mode. In particular there are no `#define` or
`#ifdef`/`#ifndef` blocks that depend on Debug or Release settings.

Contrast that with 32-bit versus 64-bit setting, which affect the
`sizeof` operators litered throughout the code base.