### PR TITLE
Enable caching of Nuget packages on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,9 @@ configuration:
 platform:
   - x86
   - x64
+cache:
+  # Cache Nuget packages in "packages" folder. Break cache if "packages.config" is updated.
+  - packages -> **\packages.config
 before_build: nuget restore
 build:
   project: OP2Utility.sln


### PR DESCRIPTION
Enabling caching of the Nuget "packages" folder should result in less network traffic, and hopefully faster builds.
