### PR TITLE
Basic map reader tests

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -123,7 +123,6 @@
     <ClInclude Include="src\Archives\WaveFile.h" />
     <ClInclude Include="include\OP2Utility.h" />
     <ClInclude Include="src\Maps\CellType.h" />
-    <ClInclude Include="src\Maps\MapType.h" />
     <ClInclude Include="src\Maps\Rect.h" />
     <ClInclude Include="src\Maps\MapData.h" />
     <ClInclude Include="src\Maps\MapHeader.h" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -123,6 +123,7 @@
     <ClInclude Include="src\Archives\WaveFile.h" />
     <ClInclude Include="include\OP2Utility.h" />
     <ClInclude Include="src\Maps\CellType.h" />
+    <ClInclude Include="src\Maps\MapType.h" />
     <ClInclude Include="src\Maps\Rect.h" />
     <ClInclude Include="src\Maps\MapData.h" />
     <ClInclude Include="src\Maps\MapHeader.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -129,9 +129,6 @@
     <ClInclude Include="src\Archives\AdaptiveHuffmanTree.h">
       <Filter>Archives</Filter>
     </ClInclude>
-    <ClInclude Include="src\Maps\MapType.h">
-      <Filter>Maps</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\XFile.cpp">

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="src\Archives\AdaptiveHuffmanTree.h">
       <Filter>Archives</Filter>
     </ClInclude>
+    <ClInclude Include="src\Maps\MapType.h">
+      <Filter>Maps</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\XFile.cpp">

--- a/src/Maps/MapReader.cpp
+++ b/src/Maps/MapReader.cpp
@@ -26,17 +26,17 @@ namespace MapReader {
 	// ==== Public methohds ====
 
 
-	MapData Read(std::string filename, bool savedGame)
+	MapData Read(std::string filename, MapType type)
 	{
 		Stream::FileReader mapReader(filename);
-		return Read(mapReader, savedGame);
+		return Read(mapReader, type);
 	}
 
-	MapData Read(Stream::SeekableReader& streamReader, bool savedGame)
+	MapData Read(Stream::SeekableReader& streamReader, MapType type)
 	{
 		MapData mapData;
 
-		if (savedGame) {
+		if (type == MapType::Save) {
 			SkipSaveGameHeader(streamReader);
 		}
 

--- a/src/Maps/MapReader.cpp
+++ b/src/Maps/MapReader.cpp
@@ -25,20 +25,15 @@ namespace MapReader {
 
 	// ==== Public methohds ====
 
-
-	MapData Read(std::string filename, MapType type)
+	MapData ReadMap(std::string filename)
 	{
 		Stream::FileReader mapReader(filename);
-		return Read(mapReader, type);
+		return ReadMap(mapReader);
 	}
 
-	MapData Read(Stream::SeekableReader& streamReader, MapType type)
+	MapData ReadMap(Stream::SeekableReader& streamReader)
 	{
 		MapData mapData;
-
-		if (type == MapType::Save) {
-			SkipSaveGameHeader(streamReader);
-		}
 
 		streamReader.Read(mapData.header);
 		ReadTiles(streamReader, mapData);
@@ -52,6 +47,18 @@ namespace MapReader {
 		ReadTileGroups(streamReader, mapData);
 
 		return mapData;
+	}
+
+	MapData ReadSavedGame(std::string filename)
+	{
+		Stream::FileReader mapReader(filename);
+		return ReadSavedGame(mapReader);
+	}
+
+	MapData ReadSavedGame(Stream::SeekableReader& streamReader)
+	{
+		SkipSaveGameHeader(streamReader);
+		return ReadMap(streamReader);
 	}
 
 

--- a/src/Maps/MapReader.h
+++ b/src/Maps/MapReader.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "MapData.h"
-#include "MapType.h"
 #include <string>
 
 namespace Stream {
@@ -9,6 +8,8 @@ namespace Stream {
 }
 
 namespace MapReader {
-	MapData Read(std::string filename, MapType type = MapType::Map);
-	MapData Read(Stream::SeekableReader& mapStream, MapType type = MapType::Map);
+	MapData ReadMap(std::string filename);
+	MapData ReadMap(Stream::SeekableReader& seekableReader);
+	MapData ReadSavedGame(std::string filename);
+	MapData ReadSavedGame(Stream::SeekableReader& seekableReader);
 }

--- a/src/Maps/MapReader.h
+++ b/src/Maps/MapReader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MapData.h"
+#include "MapType.h"
 #include <string>
 
 namespace Stream {
@@ -8,6 +9,6 @@ namespace Stream {
 }
 
 namespace MapReader {
-	MapData Read(std::string filename, bool savedGame = false);
-	MapData Read(Stream::SeekableReader& mapStream, bool savedGame = false);
+	MapData Read(std::string filename, MapType type = MapType::Map);
+	MapData Read(Stream::SeekableReader& mapStream, MapType type = MapType::Map);
 }

--- a/src/Maps/MapType.h
+++ b/src/Maps/MapType.h
@@ -2,5 +2,5 @@
 
 enum class MapType {
 	Map,
-	Save
+	SavedGame
 };

--- a/src/Maps/MapType.h
+++ b/src/Maps/MapType.h
@@ -1,0 +1,6 @@
+#pragma once
+
+enum class MapType {
+	Map,
+	Save
+};

--- a/src/Maps/MapType.h
+++ b/src/Maps/MapType.h
@@ -1,6 +1,0 @@
-#pragma once
-
-enum class MapType {
-	Map,
-	SavedGame
-};

--- a/src/Streams/FileReader.cpp
+++ b/src/Streams/FileReader.cpp
@@ -33,6 +33,10 @@ namespace Stream
 
 	void FileReader::ReadImplementation(void* buffer, std::size_t size) {
 		file.read(static_cast<char*>(buffer), size);
+		// Check stream flags for errors
+		if (!file) {
+			throw std::runtime_error("Error reading from file");
+		}
 	}
 
 	std::size_t FileReader::ReadPartial(void* buffer, std::size_t size) noexcept {

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -5,14 +5,14 @@
 
 TEST(MapReader, MissingFile) {
 	EXPECT_THROW(MapReader::Read("MissingFile.map", MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read("MissingFile.op2", MapType::Save), std::runtime_error);
+	EXPECT_THROW(MapReader::Read("MissingFile.op2", MapType::SavedGame), std::runtime_error);
 
 	// Check if filename is an empty string
 	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Save), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(""), MapType::SavedGame), std::runtime_error);
 }
 
 TEST(MapReader, EmptyFile) {
 	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::Save), std::runtime_error);
+	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::SavedGame), std::runtime_error);
 }

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -4,8 +4,8 @@
 #include <string>
 
 TEST(MapReader, EmptyFilename) {
-	EXPECT_THROW(MapReader::Read(std::string(), MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read(std::string(), MapType::Save), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Map), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Save), std::runtime_error);
 }
 
 TEST(MapReader, MissingFile) {

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -17,8 +17,3 @@ TEST(MapReader, EmptyFile) {
 	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", MapType::Map), std::runtime_error);
 	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::Save), std::runtime_error);
 }
-
-//TEST(MapReader, WrongExtension) {
-//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", MapType::Map), std::runtime_error);
-//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", MapType::Save), std::runtime_error);
-//}

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -1,23 +1,24 @@
 #include "Maps/MapReader.h"
+#include "Maps/MapType.h"
 #include "gtest/gtest.h"
 #include <string>
 
 TEST(MapReader, EmptyFilename) {
-	EXPECT_THROW(MapReader::Read(std::string(), false), std::runtime_error);
-	EXPECT_THROW(MapReader::Read(std::string(), true), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(), MapType::Map), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(), MapType::Save), std::runtime_error);
 }
 
 TEST(MapReader, MissingFile) {
-	EXPECT_THROW(MapReader::Read("MissingFile.map", false), std::runtime_error);
-	EXPECT_THROW(MapReader::Read("MissingFile.op2", true), std::runtime_error);
+	EXPECT_THROW(MapReader::Read("MissingFile.map", MapType::Map), std::runtime_error);
+	EXPECT_THROW(MapReader::Read("MissingFile.op2", MapType::Save), std::runtime_error);
 }
 
 //TEST(MapReader, EmptyFile) {
-//	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", false), std::runtime_error);
-//	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", true), std::runtime_error);
+//	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", MapType::Map), std::runtime_error);
+//	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::Save), std::runtime_error);
 //}
 
 //TEST(MapReader, WrongExtension) {
-//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", false), std::runtime_error);
-//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", true), std::runtime_error);
+//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", MapType::Map), std::runtime_error);
+//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", MapType::Save), std::runtime_error);
 //}

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -1,18 +1,17 @@
 #include "Maps/MapReader.h"
-#include "Maps/MapType.h"
 #include <gtest/gtest.h>
 #include <string>
 
 TEST(MapReader, MissingFile) {
-	EXPECT_THROW(MapReader::Read("MissingFile.map", MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read("MissingFile.op2", MapType::SavedGame), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadMap("MissingFile.map"), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadSavedGame("MissingFile.op2"), std::runtime_error);
 
 	// Check if filename is an empty string
-	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read(std::string(""), MapType::SavedGame), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadMap(std::string("")), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadSavedGame(std::string("")), std::runtime_error);
 }
 
 TEST(MapReader, EmptyFile) {
-	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::SavedGame), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadMap("Maps/data/EmptyMap.map"), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadSavedGame("Maps/data/EmptySave.OP2"), std::runtime_error);
 }

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -1,0 +1,23 @@
+#include "Maps/MapReader.h"
+#include "gtest/gtest.h"
+#include <string>
+
+TEST(MapReader, EmptyFilename) {
+	EXPECT_THROW(MapReader::Read(std::string(), false), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(), true), std::runtime_error);
+}
+
+TEST(MapReader, MissingFile) {
+	EXPECT_THROW(MapReader::Read("MissingFile.map", false), std::runtime_error);
+	EXPECT_THROW(MapReader::Read("MissingFile.op2", true), std::runtime_error);
+}
+
+//TEST(MapReader, EmptyFile) {
+//	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", false), std::runtime_error);
+//	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", true), std::runtime_error);
+//}
+
+//TEST(MapReader, WrongExtension) {
+//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", false), std::runtime_error);
+//	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", true), std::runtime_error);
+//}

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -3,14 +3,13 @@
 #include <gtest/gtest.h>
 #include <string>
 
-TEST(MapReader, EmptyFilename) {
-	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Map), std::runtime_error);
-	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Save), std::runtime_error);
-}
-
 TEST(MapReader, MissingFile) {
 	EXPECT_THROW(MapReader::Read("MissingFile.map", MapType::Map), std::runtime_error);
 	EXPECT_THROW(MapReader::Read("MissingFile.op2", MapType::Save), std::runtime_error);
+
+	// Check if filename is an empty string
+	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Map), std::runtime_error);
+	EXPECT_THROW(MapReader::Read(std::string(""), MapType::Save), std::runtime_error);
 }
 
 TEST(MapReader, EmptyFile) {

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -7,8 +7,8 @@ TEST(MapReader, MissingFile) {
 	EXPECT_THROW(MapReader::ReadSavedGame("MissingFile.op2"), std::runtime_error);
 
 	// Check if filename is an empty string
-	EXPECT_THROW(MapReader::ReadMap(std::string("")), std::runtime_error);
-	EXPECT_THROW(MapReader::ReadSavedGame(std::string("")), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadMap(""), std::runtime_error);
+	EXPECT_THROW(MapReader::ReadSavedGame(""), std::runtime_error);
 }
 
 TEST(MapReader, EmptyFile) {

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -1,6 +1,6 @@
 #include "Maps/MapReader.h"
 #include "Maps/MapType.h"
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <string>
 
 TEST(MapReader, EmptyFilename) {

--- a/test/Maps/MapReader.test.cpp
+++ b/test/Maps/MapReader.test.cpp
@@ -13,10 +13,10 @@ TEST(MapReader, MissingFile) {
 	EXPECT_THROW(MapReader::Read("MissingFile.op2", MapType::Save), std::runtime_error);
 }
 
-//TEST(MapReader, EmptyFile) {
-//	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", MapType::Map), std::runtime_error);
-//	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::Save), std::runtime_error);
-//}
+TEST(MapReader, EmptyFile) {
+	EXPECT_THROW(MapReader::Read("Maps/data/EmptyMap.map", MapType::Map), std::runtime_error);
+	EXPECT_THROW(MapReader::Read("Maps/data/EmptySave.OP2", MapType::Save), std::runtime_error);
+}
 
 //TEST(MapReader, WrongExtension) {
 //	EXPECT_THROW(MapReader::Read("Maps/data/WrongExtension.txt", MapType::Map), std::runtime_error);

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -41,6 +41,7 @@
     <OutDir>$(SolutionDir)x86\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="Maps\MapReader.test.cpp" />
     <ClCompile Include="Streams\FileReader.test.cpp" />
     <ClCompile Include="Streams\FileSliceReader.test.cpp" />
     <ClCompile Include="Streams\MemoryStreamReader.test.cpp" />

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -10,6 +10,9 @@
     <ClCompile Include="Streams\FileSliceReader.test.cpp">
       <Filter>Streams</Filter>
     </ClCompile>
+    <ClCompile Include="Maps\MapReader.test.cpp">
+      <Filter>Maps</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -17,6 +20,9 @@
   <ItemGroup>
     <Filter Include="Streams">
       <UniqueIdentifier>{f07f4252-ca5e-4f5b-94cb-8df3794157fe}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Maps">
+      <UniqueIdentifier>{25da91a1-3f8e-4c48-899f-860901568964}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I started writing basic tests for MapReader. Several topics worth discussing immediately emerged, so I wanted to stop where I was at and discuss.

 - We need to determine a strategy for testing exception handling. Currently, hitting any runtime_exception will pass when using ASSERT_THROW. However, almost all of our exceptions are runtime_exceptions, so there is no guarantee you are hitting the correct one. 

    - We could check the exception message to ensure it matches. This would require doubling the text of the exception message up in both places unless we somehow give the test fixture access to the message from the class throwing somehow. Maybe a protected variable containing the message, but I don't like this idea.

 - MapReader will fail when attempting to read an empty file because it will eventually try to read something improperly and throw an exception. This will fail due to a non-runtime_exception from the std::library (I think) and not our code. I was thinking it would be better to test if the size of the stream is greater than zero or not and fail then instead of letting the reader continue reading garbage to eventually fail. However, that would imply we would want to test the remaining size of the stream before every read. This seems to get too cumbersome by bloating the source code and possible performance implications from constantly reading the and checking the length. Maybe the performance hit is small enough not to worry about? Open for suggestions here.

 - I opened a separate issue to discuss if we want to force an exception if the file extension if unexpected. We should probably discuss this there.

 - I would like to test passing an incorrect Stream::MemoryReader and Stream::FileReader into MapReader. We will have basic MemoryReader and FileReader test fixtures created in the Stream code for testing the stream code. Would it make sense to try and use these fixtures in the MapReader code as well? If so, I need to do some reading to figure out how to incorporate these test fixtures sense they are instantiated with constructors called from the templates to allow proper testing of the interface itself (If this doesn't make sense it is because I'm not sure what I'm talking about yet.)

Thanks,
Brett