### PR TITLE
Add basic map writer tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTLDFLAGS := -L./
-TESTLIBS := -lgtest -lgtest_main -lpthread -lOP2Utility
+TESTLIBS := -lgtest -lgtest_main -lpthread -lOP2Utility -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td

--- a/src/Maps/MapHeader.h
+++ b/src/Maps/MapHeader.h
@@ -23,7 +23,7 @@ struct MapHeader
 	uint32_t mapTileHeight;
 
 	// Number of tile sets on map.
-	uint32_t numTilesets;
+	uint32_t tilesetCount;
 
 	// Map Width in Tiles.
 	uint32_t MapTileWidth() const

--- a/src/Maps/MapReader.cpp
+++ b/src/Maps/MapReader.cpp
@@ -89,7 +89,7 @@ namespace MapReader {
 
 		void ReadTilesetSources(Stream::Reader& streamReader, MapData& mapData)
 		{
-			mapData.tilesetSources.resize(static_cast<std::size_t>(mapData.header.numTilesets));
+			mapData.tilesetSources.resize(static_cast<std::size_t>(mapData.header.tilesetCount));
 
 			for (auto& tilesetSource : mapData.tilesetSources)
 			{

--- a/src/Maps/MapWriter.cpp
+++ b/src/Maps/MapWriter.cpp
@@ -99,7 +99,7 @@ namespace MapWriter {
 		void WriteContainerSize(Stream::Writer& streamWriter, std::size_t size)
 		{
 			if (size > UINT32_MAX) {
-				throw std::runtime_error("Container size is too large for writing into an Outpost 2 maps.");
+				throw std::runtime_error("Container size is too large for writing into an Outpost 2 map");
 			}
 
 			streamWriter.Write(static_cast<uint32_t>(size));

--- a/src/Maps/MapWriter.cpp
+++ b/src/Maps/MapWriter.cpp
@@ -9,7 +9,7 @@
 namespace MapWriter {
 	// Anonymous namespace to hold private methods
 	namespace {
-		void WriteHeader(Stream::Writer& streamWriter, const MapHeader& header);
+		void ValidateMap(const MapData& mapData);
 		void WriteTilesetSources(Stream::Writer& streamWriter, const std::vector<TilesetSource>& tilesetSources);
 		void WriteTileGroups(Stream::Writer& streamWriter, const std::vector<TileGroup>& tileGroups);
 		void WriteContainerSize(Stream::Writer& streamWriter, std::size_t size);
@@ -27,7 +27,9 @@ namespace MapWriter {
 
 	void Write(Stream::Writer& streamWriter, const MapData& mapData)
 	{
-		WriteHeader(streamWriter, mapData.header);
+		ValidateMap(mapData);
+
+		streamWriter.Write(mapData.header);
 		streamWriter.Write(mapData.tiles);
 		streamWriter.Write(mapData.clipRect);
 		WriteTilesetSources(streamWriter, mapData.tilesetSources);
@@ -46,13 +48,18 @@ namespace MapWriter {
 
 
 	namespace {
-		void WriteHeader(Stream::Writer& streamWriter, const MapHeader& header)
-		{
-			if (!header.VersionTagValid()) {
-				throw std::runtime_error("All instances of version tag in .map and .op2 files must be greater than 0x1010.");
+		void ValidateMap(const MapData& mapData) {
+			if (!mapData.header.VersionTagValid()) {
+				throw std::runtime_error("All instances of version tag in .map and .op2 files must be greater than 0x1010");
 			}
 
-			streamWriter.Write(header);
+			if (mapData.header.TileCount() != mapData.tiles.size()) {
+				throw std::runtime_error("Header reported tile width * tile height does not match actual tile count");
+			}
+
+			if (mapData.header.numTilesets != mapData.tilesetSources.size()) {
+				throw std::runtime_error("Header reported tileset count does not match actual tileset sources");
+			}
 		}
 
 		void WriteTilesetSources(Stream::Writer& streamWriter, const std::vector<TilesetSource>& tilesetSources)

--- a/src/Maps/MapWriter.cpp
+++ b/src/Maps/MapWriter.cpp
@@ -57,7 +57,7 @@ namespace MapWriter {
 				throw std::runtime_error("Header reported tile width * tile height does not match actual tile count");
 			}
 
-			if (mapData.header.numTilesets != mapData.tilesetSources.size()) {
+			if (mapData.header.tilesetCount != mapData.tilesetSources.size()) {
 				throw std::runtime_error("Header reported tileset count does not match actual tileset sources");
 			}
 		}

--- a/test/Maps/MapWriter.test.cpp
+++ b/test/Maps/MapWriter.test.cpp
@@ -8,7 +8,7 @@
 TEST(MapWriter, EmptyMapData)
 {
 	// Write to File
-	const std::string testFilename("maps/data/test.map");
+	const std::string testFilename("Maps/data/test.map");
 	EXPECT_THROW(MapWriter::Write(testFilename, MapData()), std::runtime_error);
 	XFile::DeletePath(testFilename);
 
@@ -24,7 +24,7 @@ TEST(MapWriter, BlankFilename)
 }
 
 TEST(MapWriter, VersionTag) {
-	const std::string testFilename("maps/data/test.map");
+	const std::string testFilename("Maps/data/test.map");
 	MapData mapData;
 	const int minVersionTag = 0x1010;
 	

--- a/test/Maps/MapWriter.test.cpp
+++ b/test/Maps/MapWriter.test.cpp
@@ -33,11 +33,12 @@ TEST(MapWriter, VersionTag) {
 	MapData mapData;
 	const int minVersionTag = 0x1010;
 	
-	mapData.header.versionTag = minVersionTag;
-	EXPECT_NO_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+	// The following 2 tests will require a legitimately constructed Map before running.
+	//mapData.header.versionTag = minVersionTag;
+	//EXPECT_NO_THROW(MapWriter::Write(testFilename, mapData));
 
-	mapData.header.versionTag = minVersionTag + 1;
-	EXPECT_NO_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+	//mapData.header.versionTag = minVersionTag + 1;
+	//EXPECT_NO_THROW(MapWriter::Write(testFilename, mapData));
 
 	mapData.header.versionTag = minVersionTag - 1;
 	EXPECT_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);

--- a/test/Maps/MapWriter.test.cpp
+++ b/test/Maps/MapWriter.test.cpp
@@ -27,3 +27,20 @@ TEST(MapWriter, BlankFilename)
 
 	EXPECT_THROW(MapWriter::Write("", mapData), std::runtime_error);
 }
+
+TEST(MapWriter, VersionTag) {
+	const std::string testFilename("maps/data/test.map");
+	MapData mapData;
+	const int minVersionTag = 0x1010;
+	
+	mapData.header.versionTag = minVersionTag;
+	EXPECT_NO_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+
+	mapData.header.versionTag = minVersionTag + 1;
+	EXPECT_NO_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+
+	mapData.header.versionTag = minVersionTag - 1;
+	EXPECT_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+
+	XFile::DeletePath(testFilename);
+}

--- a/test/Maps/MapWriter.test.cpp
+++ b/test/Maps/MapWriter.test.cpp
@@ -7,24 +7,20 @@
 
 TEST(MapWriter, EmptyMapData)
 {
-	MapData mapData;
-	
 	// Write to File
 	const std::string testFilename("maps/data/test.map");
-	EXPECT_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+	EXPECT_THROW(MapWriter::Write(testFilename, MapData()), std::runtime_error);
 	XFile::DeletePath(testFilename);
 
 	// Write to Memory
 	std::vector<char> buffer(1024);
 	Stream::MemoryWriter memoryWriter(buffer.data(), buffer.size() * sizeof(decltype(buffer)::value_type));
-	EXPECT_THROW(MapWriter::Write(memoryWriter, mapData), std::runtime_error);
+	EXPECT_THROW(MapWriter::Write(memoryWriter, MapData()), std::runtime_error);
 }
 
 TEST(MapWriter, BlankFilename)
 {
-	MapData mapData;
-
-	EXPECT_THROW(MapWriter::Write("", mapData), std::runtime_error);
+	EXPECT_THROW(MapWriter::Write("", MapData()), std::runtime_error);
 }
 
 TEST(MapWriter, VersionTag) {

--- a/test/Maps/MapWriter.test.cpp
+++ b/test/Maps/MapWriter.test.cpp
@@ -1,0 +1,29 @@
+#include "Maps/MapWriter.h"
+#include "Streams/MemoryWriter.h"
+#include "XFile.h"
+#include <gtest/gtest.h>
+#include <vector>
+#include <stdexcept>
+
+TEST(MapWriter, EmptyMapData)
+{
+	MapData mapData;
+	
+	// Write to File
+	const std::string testFilename("maps/data/test.map");
+	EXPECT_THROW(MapWriter::Write(testFilename, mapData), std::runtime_error);
+	XFile::DeletePath(testFilename);
+
+	// Write to Memory
+	std::vector<char> buffer;
+	buffer.resize(1000);
+	Stream::MemoryWriter memoryWriter(buffer.data(), buffer.size() * sizeof(decltype(buffer)::value_type));
+	EXPECT_THROW(MapWriter::Write(memoryWriter, mapData), std::runtime_error);
+}
+
+TEST(MapWriter, BlankFilename)
+{
+	MapData mapData;
+
+	EXPECT_THROW(MapWriter::Write("", mapData), std::runtime_error);
+}

--- a/test/Maps/MapWriter.test.cpp
+++ b/test/Maps/MapWriter.test.cpp
@@ -15,8 +15,7 @@ TEST(MapWriter, EmptyMapData)
 	XFile::DeletePath(testFilename);
 
 	// Write to Memory
-	std::vector<char> buffer;
-	buffer.resize(1000);
+	std::vector<char> buffer(1024);
 	Stream::MemoryWriter memoryWriter(buffer.data(), buffer.size() * sizeof(decltype(buffer)::value_type));
 	EXPECT_THROW(MapWriter::Write(memoryWriter, mapData), std::runtime_error);
 }

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -42,6 +42,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="Maps\MapReader.test.cpp" />
+    <ClCompile Include="Maps\MapWriter.test.cpp" />
     <ClCompile Include="Streams\FileReader.test.cpp" />
     <ClCompile Include="Streams\FileSliceReader.test.cpp" />
     <ClCompile Include="Streams\MemoryStreamReader.test.cpp" />

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -13,6 +13,9 @@
     <ClCompile Include="Maps\MapReader.test.cpp">
       <Filter>Maps</Filter>
     </ClCompile>
+    <ClCompile Include="Maps\MapWriter.test.cpp">
+      <Filter>Maps</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This is my first time using the syntax:

```sizeof(decltype(buffer)::value_type));```

Which is a feature of C++11 as pointed out in the issue #158. I had to append decltype to make it work.

To test the memory writer overload, I created a buffer of 1000 char. This was a bit arbitrary. It just needs to big enough that it fails before running out of space in the buffer. It is failing after reading the header and checking the version tag. 

Give me a minute to refactor here.