### PR TITLE
Activate Huffman encoder code

### DIFF
--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -38,6 +38,11 @@ namespace Archives
 
 
 
+	AdaptiveHuffmanTree::NodeType AdaptiveHuffmanTree::TerminalNodeCount()
+	{
+		return terminalNodeCount;
+	}
+
 	// Returns the index of the root node.
 	// All tree searches start at the root node.
 	AdaptiveHuffmanTree::NodeIndex AdaptiveHuffmanTree::GetRootNodeIndex()

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -91,12 +91,7 @@ namespace Archives
 		int curNodeIndex;
 		int blockLeaderIndex;
 
-		// Make sure the code is in range
-		if (code >= terminalNodeCount)
-		{
-			throw std::runtime_error("AdaptiveHuffmanTree DataValue of " + std::to_string(code)
-				+ " is out of range " + std::to_string(terminalNodeCount));
-		}
+		VerifyValidDataValue(code);
 
 		// Get the index of the node containing this code
 		curNodeIndex = parentIndex[code + nodeCount];
@@ -140,6 +135,16 @@ namespace Archives
 		}
 	}
 
+	// Raise exception if code is out of range
+	void AdaptiveHuffmanTree::VerifyValidDataValue(DataValue code)
+	{
+		if (code >= terminalNodeCount)
+		{
+			throw std::runtime_error("AdaptiveHuffmanTree DataValue of " + std::to_string(code)
+				+ " is out of range " + std::to_string(terminalNodeCount));
+		}
+	}
+
 	// Private function to swap two nodes in the Huffman tree.
 	// This is used during tree restructing by UpdateCodeCount.
 	void AdaptiveHuffmanTree::SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2)
@@ -179,10 +184,7 @@ namespace Archives
 	int AdaptiveHuffmanTree::GetEncodedBitString(int code, unsigned int& bitCount)
 	{
 		// Make sure the code is in range
-		if (code >= terminalNodeCount)
-		{
-			throw std::runtime_error("Code value is out of range");
-		}
+		VerifyValidDataValue(code);
 
 		// Record the path to the root
 		bitCount = 0;

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -127,7 +127,6 @@ namespace Archives
 	// Raise exception if nodeIndex is out of range
 	void AdaptiveHuffmanTree::VerifyValidNodeIndex(NodeIndex nodeIndex)
 	{
-		// Check that the nodeIndex is in range
 		if (nodeIndex >= nodeCount)
 		{
 			throw std::runtime_error("AdaptiveHuffmanTree NodeIndex of " + std::to_string(nodeIndex)
@@ -183,7 +182,6 @@ namespace Archives
 	// Subsequent branches are stored in higher bits
 	int AdaptiveHuffmanTree::GetEncodedBitString(int code, unsigned int& bitCount)
 	{
-		// Make sure the code is in range
 		VerifyValidDataValue(code);
 
 		// Record the path to the root

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -71,7 +71,7 @@ namespace Archives
 	}
 
 	// Returns the data stored in a terminal node
-	AdaptiveHuffmanTree::DataValue AdaptiveHuffmanTree::GetNodeData(NodeIndex nodeIndex)
+	AdaptiveHuffmanTree::NodeData AdaptiveHuffmanTree::GetNodeData(NodeIndex nodeIndex)
 	{
 		VerifyNodeIndexInBounds(nodeIndex);
 
@@ -86,9 +86,9 @@ namespace Archives
 	// This updates the count for the given code and restructures the tree if needed.
 	// This is used after a tree search to update the tree (gives more frequently used
 	// codes a shorter bit encoding).
-	void AdaptiveHuffmanTree::UpdateCodeCount(DataValue code)
+	void AdaptiveHuffmanTree::UpdateCodeCount(NodeData code)
 	{
-		VerifyDataValueInBounds(code);
+		VerifyNodeDataInBounds(code);
 
 		// Get the index of the node containing this code
 		NodeIndex curNodeIndex = parentIndex[code + nodeCount];
@@ -132,11 +132,11 @@ namespace Archives
 	}
 
 	// Raise exception if code is out of range
-	void AdaptiveHuffmanTree::VerifyDataValueInBounds(DataValue code)
+	void AdaptiveHuffmanTree::VerifyNodeDataInBounds(NodeData code)
 	{
 		if (code >= terminalNodeCount)
 		{
-			throw std::runtime_error("AdaptiveHuffmanTree DataValue of " + std::to_string(code)
+			throw std::runtime_error("AdaptiveHuffmanTree NodeData of " + std::to_string(code)
 				+ " is out of range " + std::to_string(terminalNodeCount));
 		}
 	}
@@ -177,9 +177,9 @@ namespace Archives
 	// NOTE: Bit order subject to change (and likely will change). Currently:
 	// The branch to take between the root and a child of the root is placed in the LSB
 	// Subsequent branches are stored in higher bits
-	unsigned int AdaptiveHuffmanTree::GetEncodedBitString(DataValue code, unsigned int& bitCount)
+	unsigned int AdaptiveHuffmanTree::GetEncodedBitString(NodeData code, unsigned int& bitCount)
 	{
-		VerifyDataValueInBounds(code);
+		VerifyNodeDataInBounds(code);
 
 		// Record the path to the root
 		bitCount = 0;

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -88,13 +88,10 @@ namespace Archives
 	// codes a shorter bit encoding).
 	void AdaptiveHuffmanTree::UpdateCodeCount(DataValue code)
 	{
-		int curNodeIndex;
-		int blockLeaderIndex;
-
 		VerifyValidDataValue(code);
 
 		// Get the index of the node containing this code
-		curNodeIndex = parentIndex[code + nodeCount];
+		NodeIndex curNodeIndex = parentIndex[code + nodeCount];
 		subtreeCount[curNodeIndex]++; // Update the node count
 
 		// Propagate the count increase up to the root of the tree
@@ -104,7 +101,7 @@ namespace Archives
 			// Note: the block leader is the "rightmost" node with count equal to the
 			//  count of the current node, BEFORE the count of the current node is
 			//  updated. (The current node has already had it's count updated.)
-			blockLeaderIndex = curNodeIndex;
+			NodeIndex blockLeaderIndex = curNodeIndex;
 			while (subtreeCount[curNodeIndex] > subtreeCount[blockLeaderIndex + 1])
 				blockLeaderIndex++;
 

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -177,17 +177,17 @@ namespace Archives
 	// NOTE: Bit order subject to change (and likely will change). Currently:
 	// The branch to take between the root and a child of the root is placed in the LSB
 	// Subsequent branches are stored in higher bits
-	int AdaptiveHuffmanTree::GetEncodedBitString(int code, unsigned int& bitCount)
+	unsigned int AdaptiveHuffmanTree::GetEncodedBitString(DataValue code, unsigned int& bitCount)
 	{
 		VerifyValidDataValue(code);
 
 		// Record the path to the root
 		bitCount = 0;
-		int bitString = 0;
+		unsigned int bitString = 0;
 		NodeIndex curNodeIndex = code;
 		while (curNodeIndex != rootNodeIndex)
 		{
-			bool bBit = curNodeIndex & 0x01;  // Get the direction from parent to current node
+			unsigned int bBit = curNodeIndex & 1;  // Get the direction from parent to current node
 			bitString = (bitString << 1) | bBit;  // Pack the bit into the returned string
 			bitCount++;
 			curNodeIndex = parentIndex[curNodeIndex];

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -54,7 +54,7 @@ namespace Archives
 	// This is used to traverse the tree to a terminal node.
 	AdaptiveHuffmanTree::NodeIndex AdaptiveHuffmanTree::GetChildNode(NodeIndex nodeIndex, bool bRight)
 	{
-		VerifyValidNodeIndex(nodeIndex);
+		VerifyNodeIndexInBounds(nodeIndex);
 
 		// Return the child node index
 		return linkOrData[nodeIndex] + bRight;
@@ -64,7 +64,7 @@ namespace Archives
 	// This is used to know when a tree search has completed.
 	bool AdaptiveHuffmanTree::IsLeaf(NodeIndex nodeIndex)
 	{
-		VerifyValidNodeIndex(nodeIndex);
+		VerifyNodeIndexInBounds(nodeIndex);
 
 		// Return whether or not this is a terminal node
 		return linkOrData[nodeIndex] >= nodeCount;
@@ -73,7 +73,7 @@ namespace Archives
 	// Returns the data stored in a terminal node
 	AdaptiveHuffmanTree::DataValue AdaptiveHuffmanTree::GetNodeData(NodeIndex nodeIndex)
 	{
-		VerifyValidNodeIndex(nodeIndex);
+		VerifyNodeIndexInBounds(nodeIndex);
 
 		// Return data stored in node translated back to normal form
 		// Note: This assumes the node is a terminal node
@@ -88,7 +88,7 @@ namespace Archives
 	// codes a shorter bit encoding).
 	void AdaptiveHuffmanTree::UpdateCodeCount(DataValue code)
 	{
-		VerifyValidDataValue(code);
+		VerifyDataValueInBounds(code);
 
 		// Get the index of the node containing this code
 		NodeIndex curNodeIndex = parentIndex[code + nodeCount];
@@ -122,7 +122,7 @@ namespace Archives
 
 
 	// Raise exception if nodeIndex is out of range
-	void AdaptiveHuffmanTree::VerifyValidNodeIndex(NodeIndex nodeIndex)
+	void AdaptiveHuffmanTree::VerifyNodeIndexInBounds(NodeIndex nodeIndex)
 	{
 		if (nodeIndex >= nodeCount)
 		{
@@ -132,7 +132,7 @@ namespace Archives
 	}
 
 	// Raise exception if code is out of range
-	void AdaptiveHuffmanTree::VerifyValidDataValue(DataValue code)
+	void AdaptiveHuffmanTree::VerifyDataValueInBounds(DataValue code)
 	{
 		if (code >= terminalNodeCount)
 		{
@@ -179,7 +179,7 @@ namespace Archives
 	// Subsequent branches are stored in higher bits
 	unsigned int AdaptiveHuffmanTree::GetEncodedBitString(DataValue code, unsigned int& bitCount)
 	{
-		VerifyValidDataValue(code);
+		VerifyDataValueInBounds(code);
 
 		// Record the path to the root
 		bitCount = 0;

--- a/src/Archives/AdaptiveHuffmanTree.cpp
+++ b/src/Archives/AdaptiveHuffmanTree.cpp
@@ -165,15 +165,13 @@ namespace Archives
 
 
 
-	// **NOTE**: The following procedure is experimental and is not yet in use.
-	//			Nor should it be used yet!
-	/*
 	// Used during compression to get the bitstring to emit for a given code.
-	// The number of bits in the bitstring is returned and the bitstring is placed
-	// in the bitString parameter. The branch to take between the root and a child
-	// of the root is placed in the LSB. Subsequent branches are stored in higher bits
-	// **NOTE**: I may change the bit ordering! (Make that I WILL change the bit ordering)
-	int AdaptiveHuffmanTree::GetEncodedBitString(int code, int &bitString)
+	// Returns the bitstring for a given code
+	// Places the length of the bitstring in the bitCount out parameter
+	// NOTE: Bit order subject to change (and likely will change). Currently:
+	// The branch to take between the root and a child of the root is placed in the LSB
+	// Subsequent branches are stored in higher bits
+	int AdaptiveHuffmanTree::GetEncodedBitString(int code, unsigned int& bitCount)
 	{
 		// Make sure the code is in range
 		if (code >= terminalNodeCount)
@@ -181,20 +179,18 @@ namespace Archives
 			throw std::runtime_error("Code value is out of range");
 		}
 
-		// Get the node containing the given code
-		NodeIndex curNodeIndex = parentIndex[code];
-
 		// Record the path to the root
-		bitString = 0;
-		int bitCount = 0;
+		bitCount = 0;
+		int bitString = 0;
+		NodeIndex curNodeIndex = code;
 		while (curNodeIndex != rootNodeIndex)
 		{
-			bool bBit = curNodeIndex & 0x01;	// Get the direction from parent to current node
+			bool bBit = curNodeIndex & 0x01;  // Get the direction from parent to current node
+			bitString = (bitString << 1) | bBit;  // Pack the bit into the returned string
 			bitCount++;
-			bitString = (bitString << 1) | bBit;// Pack the bit into the returned string
+			curNodeIndex = parentIndex[curNodeIndex];
 		}
 
-		return bitCount;					// Return number of bits in path from root to node
+		return bitString;
 	}
-	*/
 }

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -26,10 +26,10 @@ namespace Archives
 		void UpdateCodeCount(DataValue code);		// Perform tree update/restructure
 
 		// Compression routines
-		int GetEncodedBitString(int code, int &bitString);
-		// Retuns the length of the path from the
-		// root node to the node with the given
-		// code and places the path in bitString
+		// NOTE: experimental, API likely to change
+		// Retuns the path from the root node to the node with the given code
+		// Places the path length in bitCount
+		int GetEncodedBitString(int code, unsigned int &bitCount);
 
 	private:
 		void VerifyValidNodeIndex(NodeIndex nodeIndex);

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -36,6 +36,7 @@ namespace Archives
 
 	private:
 		void VerifyValidNodeIndex(NodeIndex nodeIndex);
+		void VerifyValidDataValue(DataValue code);
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Tree properties

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -32,7 +32,7 @@ namespace Archives
 		// NOTE: experimental, API likely to change
 		// Retuns the path from the root node to the node with the given code
 		// Places the path length in bitCount
-		int GetEncodedBitString(int code, unsigned int &bitCount);
+		unsigned int GetEncodedBitString(DataValue code, unsigned int &bitCount);
 
 	private:
 		void VerifyValidNodeIndex(NodeIndex nodeIndex);

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -15,6 +15,9 @@ namespace Archives
 
 		AdaptiveHuffmanTree(NodeType terminalNodeCount);
 
+		// Tree info
+		NodeType TerminalNodeCount();
+
 		// Decompression routines
 		NodeIndex GetRootNodeIndex();				// Get root of tree to start search at
 		NodeIndex GetChildNode(NodeIndex nodeIndex, bool bRight);

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -35,8 +35,8 @@ namespace Archives
 		unsigned int GetEncodedBitString(DataValue code, unsigned int &bitCount);
 
 	private:
-		void VerifyValidNodeIndex(NodeIndex nodeIndex);
-		void VerifyValidDataValue(DataValue code);
+		void VerifyNodeIndexInBounds(NodeIndex nodeIndex);
+		void VerifyDataValueInBounds(DataValue code);
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Tree properties

--- a/src/Archives/AdaptiveHuffmanTree.h
+++ b/src/Archives/AdaptiveHuffmanTree.h
@@ -11,7 +11,7 @@ namespace Archives
 	public:
 		using NodeType = unsigned short;
 		using NodeIndex = NodeType;
-		using DataValue = NodeType;
+		using NodeData = NodeType;
 
 		AdaptiveHuffmanTree(NodeType terminalNodeCount);
 
@@ -23,20 +23,20 @@ namespace Archives
 		NodeIndex GetChildNode(NodeIndex nodeIndex, bool bRight);
 		// bRight = 1 --> follow right branch
 		bool IsLeaf(NodeIndex nodeIndex);			// Determines if node is terminal node
-		DataValue GetNodeData(NodeIndex nodeIndex);	// Returns the data in a terminal node
+		NodeData GetNodeData(NodeIndex nodeIndex);	// Returns the data in a terminal node
 
 		// Tree restructuring routines
-		void UpdateCodeCount(DataValue code);		// Perform tree update/restructure
+		void UpdateCodeCount(NodeData code);		// Perform tree update/restructure
 
 		// Compression routines
 		// NOTE: experimental, API likely to change
 		// Retuns the path from the root node to the node with the given code
 		// Places the path length in bitCount
-		unsigned int GetEncodedBitString(DataValue code, unsigned int &bitCount);
+		unsigned int GetEncodedBitString(NodeData code, unsigned int &bitCount);
 
 	private:
 		void VerifyNodeIndexInBounds(NodeIndex nodeIndex);
-		void VerifyDataValueInBounds(DataValue code);
+		void VerifyNodeDataInBounds(NodeData code);
 		void SwapNodes(NodeIndex nodeIndex1, NodeIndex nodeIndex2);
 
 		// Tree properties

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -6,7 +6,7 @@ TEST(AdaptiveHuffmanTreeTests, SimpleTree2) {
 	// Construct minimum non-degenerate binary tree with 2 data nodes
 	Archives::AdaptiveHuffmanTree tree(2);
 
-	// With 2 data nodes, the root can not be a data node
+	// With 2 data nodes, the root cannot be a data node
 	auto rootIndex = tree.GetRootNodeIndex();
 	ASSERT_FALSE(tree.IsLeaf(rootIndex));
 

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -29,7 +29,8 @@ protected:
 
 // Test the encoder and decoder against each other
 TEST_F(AdaptiveHuffmanTreeOutpost2, EncodeDecode) {
-	for (unsigned int i = 0; i < 314; ++i) {
+	auto codeCount = tree.TerminalNodeCount();
+	for (unsigned int i = 0; i < codeCount; ++i) {
 		unsigned int codeLength;
 		auto bitstring = tree.GetEncodedBitString(i, codeLength);
 		auto node = tree.GetRootNodeIndex();

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -36,7 +36,7 @@ TEST_F(AdaptiveHuffmanTreeOutpost2, EncodeDecode) {
 		auto node = tree.GetRootNodeIndex();
 		for (; codeLength > 0; --codeLength) {
 			ASSERT_FALSE(tree.IsLeaf(node));
-			node = tree.GetChildNode(node, bitString & 0x01);
+			node = tree.GetChildNode(node, bitString & 1);
 			bitString >>= 1;
 		}
 		ASSERT_TRUE(tree.IsLeaf(node));

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -20,3 +20,25 @@ TEST(AdaptiveHuffmanTreeTests, SimpleTree2) {
 	ASSERT_EQ(0, tree.GetNodeData(leftChild));
 	ASSERT_EQ(1, tree.GetNodeData(rightChild));
 }
+
+
+class AdaptiveHuffmanTreeOutpost2 : public ::testing::Test {
+protected:
+	Archives::AdaptiveHuffmanTree tree{314};
+};
+
+// Test the encoder and decoder against each other
+TEST_F(AdaptiveHuffmanTreeOutpost2, EncodeDecode) {
+	for (unsigned int i = 0; i < 314; ++i) {
+		unsigned int codeLength;
+		auto bitstring = tree.GetEncodedBitString(i, codeLength);
+		auto node = tree.GetRootNodeIndex();
+		for (; codeLength > 0; --codeLength) {
+			ASSERT_FALSE(tree.IsLeaf(node));
+			node = tree.GetChildNode(node, bitstring & 0x01);
+			bitstring >>= 1;
+		}
+		ASSERT_TRUE(tree.IsLeaf(node));
+		ASSERT_EQ(i, tree.GetNodeData(node));
+	}
+}

--- a/test/Archives/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archives/AdaptiveHuffmanTree.test.cpp
@@ -32,12 +32,12 @@ TEST_F(AdaptiveHuffmanTreeOutpost2, EncodeDecode) {
 	auto codeCount = tree.TerminalNodeCount();
 	for (unsigned int i = 0; i < codeCount; ++i) {
 		unsigned int codeLength;
-		auto bitstring = tree.GetEncodedBitString(i, codeLength);
+		auto bitString = tree.GetEncodedBitString(i, codeLength);
 		auto node = tree.GetRootNodeIndex();
 		for (; codeLength > 0; --codeLength) {
 			ASSERT_FALSE(tree.IsLeaf(node));
-			node = tree.GetChildNode(node, bitstring & 0x01);
-			bitstring >>= 1;
+			node = tree.GetChildNode(node, bitString & 0x01);
+			bitString >>= 1;
 		}
 		ASSERT_TRUE(tree.IsLeaf(node));
 		ASSERT_EQ(i, tree.GetNodeData(node));

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -41,6 +41,7 @@
     <OutDir>$(SolutionDir)x86\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
+    <ClCompile Include="Archives\AdaptiveHuffmanTree.test.cpp" />
     <ClCompile Include="Maps\MapReader.test.cpp" />
     <ClCompile Include="Maps\MapWriter.test.cpp" />
     <ClCompile Include="Streams\FileReader.test.cpp" />

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="Maps\MapWriter.test.cpp">
       <Filter>Maps</Filter>
     </ClCompile>
+    <ClCompile Include="Archives\AdaptiveHuffmanTree.test.cpp">
+      <Filter>Archives</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -26,6 +29,9 @@
     </Filter>
     <Filter Include="Maps">
       <UniqueIdentifier>{25da91a1-3f8e-4c48-899f-860901568964}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Archives">
+      <UniqueIdentifier>{beb7ce96-9a50-4c40-900e-50de0f3f995b}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This actives and fixes some previously commented out encoding code.

This allows testing part of the decompressor against the corresponding encoding code. It verifies the encoder can be properly paired with the decoder to round-trip the data.

----

This does not yet verify the particular Huffman encoding scheme necessarily matches what was used in Outpost 2, only that the encoder and decoder are properly paired with each other.

This does not verify the full compression/decompression scheme used in Outpost 2. It only deals with the adapative Huffman codes. It does not deal with the fixed Huffman codes, nor the repeated runs of data.
