### PR TITLE
Rename "Check" to "Verify"

### DIFF
--- a/src/Archives/ArchivePacker.cpp
+++ b/src/Archives/ArchivePacker.cpp
@@ -21,7 +21,7 @@ namespace Archives
 		return filenames;
 	}
 
-	void ArchivePacker::CheckSortedContainerForDuplicateNames(const std::vector<std::string>& names)
+	void ArchivePacker::VerifySortedContainerHasNoDuplicateNames(const std::vector<std::string>& names)
 	{
 		for (std::size_t i = 1; i < names.size(); ++i)
 		{

--- a/src/Archives/ArchivePacker.h
+++ b/src/Archives/ArchivePacker.h
@@ -23,7 +23,7 @@ namespace Archives
 
 		// Throws an error if 2 names are identical, case insensitve.
 		// names must be presorted.
-		static void CheckSortedContainerForDuplicateNames(const std::vector<std::string>& names);
+		static void VerifySortedContainerHasNoDuplicateNames(const std::vector<std::string>& names);
 
 		// Compares 2 filenames case insensitive to determine which comes first alphabetically.
 		// Does not compare the entire path, but only the filename.

--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -55,7 +55,7 @@ namespace Archives
 		return OpenStream(GetIndex(name));
 	}
 
-	void ArchiveUnpacker::CheckIndexBounds(std::size_t index)
+	void ArchiveUnpacker::VerifyIndexInBounds(std::size_t index)
 	{
 		if (index >= m_Count) {
 			throw std::runtime_error("Index " + std::to_string(index) + " is out of bounds in archive " + m_ArchiveFilename + ".");

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -34,7 +34,7 @@ namespace Archives
 		virtual std::unique_ptr<Stream::SeekableReader> OpenStream(const std::string& name);
 
 	protected:
-		void CheckIndexBounds(std::size_t index);
+		void VerifyIndexInBounds(std::size_t index);
 
 		const std::string m_ArchiveFilename;
 		std::size_t m_Count;

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -41,7 +41,7 @@ namespace Archives
 	// Throws an error if packed file index is not valid.
 	std::string ClmFile::GetName(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return indexEntries[index].GetFilename();
 	}
@@ -49,7 +49,7 @@ namespace Archives
 	// Returns the size of the internal file corresponding to index
 	uint32_t ClmFile::GetSize(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return indexEntries[index].dataLength;
 	}
@@ -58,7 +58,7 @@ namespace Archives
 	// Extracts the internal file corresponding to index
 	void ClmFile::ExtractFile(std::size_t index, const std::string& pathOut)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		WaveHeader header;
 		InitializeWaveHeader(header, index);
@@ -98,7 +98,7 @@ namespace Archives
 
 	std::unique_ptr<Stream::SeekableReader> ClmFile::OpenStream(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		auto slice = clmFileReader.Slice(
 			indexEntries[index].dataOffset,

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -164,7 +164,7 @@ namespace Archives
 		}
 
 		// Allowing duplicate names when packing may cause unintended results during search and file extraction.
-		CheckSortedContainerForDuplicateNames(names);
+		VerifySortedContainerHasNoDuplicateNames(names);
 
 		// Write the archive header and copy files into the archive
 		WriteArchive(archiveFilename, filesToPackReaders, indexEntries, names, PrepareWaveFormat(waveFormats));

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -29,21 +29,21 @@ namespace Archives
 
 	std::string VolFile::GetName(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return m_StringTable[index];
 	}
 
 	CompressionType VolFile::GetCompressionCode(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return m_IndexEntries[index].compressionType;
 	}
 
 	uint32_t VolFile::GetSize(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return m_IndexEntries[index].fileSize;
 	}
@@ -69,7 +69,7 @@ namespace Archives
 
 	VolFile::SectionHeader VolFile::GetSectionHeader(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		archiveFileReader.Seek(m_IndexEntries[index].dataBlockOffset);
 
@@ -88,7 +88,7 @@ namespace Archives
 	// Extracts the internal file at the given index to the filename.
 	void VolFile::ExtractFile(std::size_t index, const std::string& pathOut)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		if (m_IndexEntries[index].compressionType == CompressionType::Uncompressed)
 		{

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -178,7 +178,7 @@ namespace Archives
 		volInfo.names = GetNamesFromPaths(filesToPack);
 
 		// Allowing duplicate names when packing may cause unintended results during binary search and file extraction.
-		CheckSortedContainerForDuplicateNames(volInfo.names);
+		VerifySortedContainerHasNoDuplicateNames(volInfo.names);
 
 		// Open input files and prepare header and indexing info
 		PrepareHeader(volInfo, volumeFilename);

--- a/src/Sprites/ArtFile.cpp
+++ b/src/Sprites/ArtFile.cpp
@@ -12,7 +12,7 @@ BitCount ArtFile::GetBitCount(std::size_t imageIndex)
 	return imageMetas[imageIndex].type.bShadow ? BitCount::One : BitCount::Eight;
 }
 
-void ArtFile::CheckImageIndex(std::size_t index)
+void ArtFile::VerifyImageIndexInBounds(std::size_t index)
 {
 	if (index > imageMetas.size()) {
 		throw std::runtime_error("An index of " + std::to_string(index) + " exceeds range of images");

--- a/src/Sprites/ArtFile.h
+++ b/src/Sprites/ArtFile.h
@@ -28,7 +28,7 @@ public:
 	static void Write(Stream::SeekableWriter&, const ArtFile& artFile);
 
 	BitCount GetBitCount(std::size_t imageIndex);
-	void CheckImageIndex(std::size_t index);
+	void VerifyImageIndexInBounds(std::size_t index);
 
 private:
 	// Read Functions

--- a/src/Sprites/OP2BmpLoader.cpp
+++ b/src/Sprites/OP2BmpLoader.cpp
@@ -6,7 +6,7 @@ OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::string artFilename) :
 
 void OP2BmpLoader::ExtractImage(std::size_t index) 
 {
-	artFile.CheckImageIndex(index);
+	artFile.VerifyImageIndexInBounds(index);
 
 	ImageMeta& imageMeta = artFile.imageMetas[index];
 	auto pixels = GetPixels(imageMeta.pixelDataOffset, imageMeta.scanLineByteWidth * 8 * imageMeta.height);


### PR DESCRIPTION
This should be more consistent with our evolving naming standard.