### PR TITLE
Remove base type on `VolPadding` enum

### DIFF
--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -54,7 +54,7 @@ namespace Archives
 		};
 
 		// Specify boundary padding for a volume file section
-		enum class VolPadding : uint32_t
+		enum class VolPadding
 		{
 			TwoByte = 0,
 			FourByte = 1


### PR DESCRIPTION
This enum is a two valued bit flag. It probably doesn't make sense to explicitly declare the base type as a 32-bit quantity.