### PR TITLE
Use `vector::at`

### DIFF
--- a/src/Sprites/ArtFile.cpp
+++ b/src/Sprites/ArtFile.cpp
@@ -12,13 +12,6 @@ BitCount ArtFile::GetBitCount(std::size_t imageIndex)
 	return imageMetas[imageIndex].type.bShadow ? BitCount::One : BitCount::Eight;
 }
 
-void ArtFile::CheckImageIndex(std::size_t index)
-{
-	if (index > imageMetas.size()) {
-		throw std::runtime_error("An index of " + std::to_string(index) + " exceeds range of images");
-	}
-}
-
 void ArtFile::ValidateImageMetadata() const
 {
 	for (const auto& imageMeta : imageMetas) {

--- a/src/Sprites/ArtFile.cpp
+++ b/src/Sprites/ArtFile.cpp
@@ -5,11 +5,7 @@ const std::array<char, 4> ArtFile::TagPalette{ 'C', 'P', 'A', 'L' };
 
 BitCount ArtFile::GetBitCount(std::size_t imageIndex) 
 {
-	if (imageIndex > imageMetas.size()) {
-		throw std::runtime_error("Index exceeds image count");
-	}
-
-	return imageMetas[imageIndex].type.bShadow ? BitCount::One : BitCount::Eight;
+	return imageMetas.at(imageIndex).type.bShadow ? BitCount::One : BitCount::Eight;
 }
 
 void ArtFile::ValidateImageMetadata() const

--- a/src/Sprites/ArtFile.cpp
+++ b/src/Sprites/ArtFile.cpp
@@ -3,11 +3,6 @@
 
 const std::array<char, 4> ArtFile::TagPalette{ 'C', 'P', 'A', 'L' };
 
-BitCount ArtFile::GetBitCount(std::size_t imageIndex) 
-{
-	return imageMetas.at(imageIndex).type.bShadow ? BitCount::One : BitCount::Eight;
-}
-
 void ArtFile::ValidateImageMetadata() const
 {
 	for (const auto& imageMeta : imageMetas) {

--- a/src/Sprites/ArtFile.h
+++ b/src/Sprites/ArtFile.h
@@ -28,7 +28,6 @@ public:
 	static void Write(Stream::SeekableWriter&, const ArtFile& artFile);
 
 	BitCount GetBitCount(std::size_t imageIndex);
-	void CheckImageIndex(std::size_t index);
 
 private:
 	// Read Functions

--- a/src/Sprites/ArtFile.h
+++ b/src/Sprites/ArtFile.h
@@ -3,7 +3,6 @@
 #include "ImageMeta.h"
 #include "Animation.h"
 #include "Color.h"
-#include "BitCount.h"
 #include <vector>
 #include <array>
 #include <string>
@@ -26,8 +25,6 @@ public:
 	static ArtFile Read(Stream::SeekableReader& seekableReader);
 	static void Write(std::string filename, const ArtFile& artFile);
 	static void Write(Stream::SeekableWriter&, const ArtFile& artFile);
-
-	BitCount GetBitCount(std::size_t imageIndex);
 
 private:
 	// Read Functions

--- a/src/Sprites/ImageMeta.h
+++ b/src/Sprites/ImageMeta.h
@@ -1,10 +1,15 @@
 #pragma once
 
+#include "BitCount.h"
 #include <cstdint>
 
 #pragma pack(push, 1) // Make sure structures are byte aligned
 
 struct ImageMeta {
+	BitCount GetBitCount() const {
+		return type.bShadow ? BitCount::One : BitCount::Eight;
+	}
+
 	struct ImageType {
 		uint16_t bGameGraphic : 1;  // 0 = MenuGraphic, 1 = GameGraphic
 		uint16_t unknown1 : 1; // 2

--- a/src/Sprites/ImageMeta.h
+++ b/src/Sprites/ImageMeta.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "BitCount.h"
 #include <cstdint>
 
 #pragma pack(push, 1) // Make sure structures are byte aligned
 
 struct ImageMeta {
-	BitCount GetBitCount() const {
-		return type.bShadow ? BitCount::One : BitCount::Eight;
+	unsigned int GetBitCount() const {
+		return type.bShadow ? 1 : 8;
 	}
 
 	struct ImageType {

--- a/src/Sprites/OP2BmpLoader.cpp
+++ b/src/Sprites/OP2BmpLoader.cpp
@@ -6,9 +6,7 @@ OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::string artFilename) :
 
 void OP2BmpLoader::ExtractImage(std::size_t index) 
 {
-	artFile.CheckImageIndex(index);
-
-	ImageMeta& imageMeta = artFile.imageMetas[index];
+	ImageMeta& imageMeta = artFile.imageMetas.at(index);
 	auto pixels = GetPixels(imageMeta.pixelDataOffset, imageMeta.scanLineByteWidth * 8 * imageMeta.height);
 
 	// TODO: Save pixels to a BMP file.


### PR DESCRIPTION
Side note: It seems a bit weird to require users of the Sprite API to manually bounds check things. This may be a sign we should make the API a little more class like, with better encapsulation.

For now, perhaps we should consider using [`std::vector::at(size_type index)`](https://en.cppreference.com/w/cpp/container/vector/at) which does implicit bounds checking, rather than [`std::vector::operator[](size_type index)`](https://en.cppreference.com/w/cpp/container/vector/operator_at), which does not. This is still a burden on the caller, though it means less explicit code to write and maintain on our part.