### PR TITLE
Use `vector::at` in archive code

### DIFF
--- a/src/Archives/ArchivePacker.cpp
+++ b/src/Archives/ArchivePacker.cpp
@@ -21,7 +21,7 @@ namespace Archives
 		return filenames;
 	}
 
-	void ArchivePacker::CheckSortedContainerForDuplicateNames(const std::vector<std::string>& names)
+	void ArchivePacker::VerifySortedContainerHasNoDuplicateNames(const std::vector<std::string>& names)
 	{
 		for (std::size_t i = 1; i < names.size(); ++i)
 		{

--- a/src/Archives/ArchivePacker.h
+++ b/src/Archives/ArchivePacker.h
@@ -23,7 +23,7 @@ namespace Archives
 
 		// Throws an error if 2 names are identical, case insensitve.
 		// names must be presorted.
-		static void CheckSortedContainerForDuplicateNames(const std::vector<std::string>& names);
+		static void VerifySortedContainerHasNoDuplicateNames(const std::vector<std::string>& names);
 
 		// Compares 2 filenames case insensitive to determine which comes first alphabetically.
 		// Does not compare the entire path, but only the filename.

--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -55,7 +55,7 @@ namespace Archives
 		return OpenStream(GetIndex(name));
 	}
 
-	void ArchiveUnpacker::CheckIndexBounds(std::size_t index)
+	void ArchiveUnpacker::VerifyIndexInBounds(std::size_t index)
 	{
 		if (index >= m_Count) {
 			throw std::runtime_error("Index " + std::to_string(index) + " is out of bounds in archive " + m_ArchiveFilename + ".");

--- a/src/Archives/ArchiveUnpacker.cpp
+++ b/src/Archives/ArchiveUnpacker.cpp
@@ -54,11 +54,4 @@ namespace Archives
 	{
 		return OpenStream(GetIndex(name));
 	}
-
-	void ArchiveUnpacker::VerifyIndexInBounds(std::size_t index)
-	{
-		if (index >= m_Count) {
-			throw std::runtime_error("Index " + std::to_string(index) + " is out of bounds in archive " + m_ArchiveFilename + ".");
-		}
-	}
 }

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -34,7 +34,7 @@ namespace Archives
 		virtual std::unique_ptr<Stream::SeekableReader> OpenStream(const std::string& name);
 
 	protected:
-		void CheckIndexBounds(std::size_t index);
+		void VerifyIndexInBounds(std::size_t index);
 
 		const std::string m_ArchiveFilename;
 		std::size_t m_Count;

--- a/src/Archives/ArchiveUnpacker.h
+++ b/src/Archives/ArchiveUnpacker.h
@@ -34,8 +34,6 @@ namespace Archives
 		virtual std::unique_ptr<Stream::SeekableReader> OpenStream(const std::string& name);
 
 	protected:
-		void VerifyIndexInBounds(std::size_t index);
-
 		const std::string m_ArchiveFilename;
 		std::size_t m_Count;
 		uint64_t m_ArchiveFileSize;

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -60,8 +60,7 @@ namespace Archives
 	{
 		VerifyIndexInBounds(index);
 
-		WaveHeader header;
-		InitializeWaveHeader(header, index);
+		auto header = InitializeWaveHeader(clmHeader.waveFormat, indexEntries[index].dataLength);
 
 		try
 		{
@@ -81,19 +80,23 @@ namespace Archives
 		}
 	}
 
-	void ClmFile::InitializeWaveHeader(WaveHeader& headerOut, std::size_t index)
+	WaveHeader ClmFile::InitializeWaveHeader(const WaveFormatEx& waveFormat, uint32_t dataLength)
 	{
+		WaveHeader headerOut;
+
 		headerOut.riffHeader.riffTag = tagRIFF;
 		headerOut.riffHeader.waveTag = tagWAVE;
-		headerOut.riffHeader.chunkSize = sizeof(headerOut.riffHeader.waveTag) + sizeof(FormatChunk) + sizeof(ChunkHeader) + indexEntries[index].dataLength;
+		headerOut.riffHeader.chunkSize = sizeof(headerOut.riffHeader.waveTag) + sizeof(FormatChunk) + sizeof(ChunkHeader) + dataLength;
 
 		headerOut.formatChunk.fmtTag = tagFMT_;
 		headerOut.formatChunk.formatSize = sizeof(headerOut.formatChunk.waveFormat);
-		headerOut.formatChunk.waveFormat = clmHeader.waveFormat;
+		headerOut.formatChunk.waveFormat = waveFormat;
 		headerOut.formatChunk.waveFormat.cbSize = 0;
 
 		headerOut.dataChunk.formatTag = tagDATA;
-		headerOut.dataChunk.length = indexEntries[index].dataLength;
+		headerOut.dataChunk.length = dataLength;
+
+		return headerOut;
 	}
 
 	std::unique_ptr<Stream::SeekableReader> ClmFile::OpenStream(std::size_t index)

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -41,7 +41,7 @@ namespace Archives
 	// Throws an error if packed file index is not valid.
 	std::string ClmFile::GetName(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return indexEntries[index].GetFilename();
 	}
@@ -49,7 +49,7 @@ namespace Archives
 	// Returns the size of the internal file corresponding to index
 	uint32_t ClmFile::GetSize(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return indexEntries[index].dataLength;
 	}
@@ -58,7 +58,7 @@ namespace Archives
 	// Extracts the internal file corresponding to index
 	void ClmFile::ExtractFile(std::size_t index, const std::string& pathOut)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		WaveHeader header;
 		InitializeWaveHeader(header, index);
@@ -98,7 +98,7 @@ namespace Archives
 
 	std::unique_ptr<Stream::SeekableReader> ClmFile::OpenStream(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		auto slice = clmFileReader.Slice(
 			indexEntries[index].dataOffset,
@@ -164,7 +164,7 @@ namespace Archives
 		}
 
 		// Allowing duplicate names when packing may cause unintended results during search and file extraction.
-		CheckSortedContainerForDuplicateNames(names);
+		VerifySortedContainerHasNoDuplicateNames(names);
 
 		// Write the archive header and copy files into the archive
 		WriteArchive(archiveFilename, filesToPackReaders, indexEntries, names, PrepareWaveFormat(waveFormats));

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -97,11 +97,10 @@ namespace Archives
 
 	std::unique_ptr<Stream::SeekableReader> ClmFile::OpenStream(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
+		const auto& indexEntry = indexEntries.at(index);
 		auto slice = clmFileReader.Slice(
-			indexEntries[index].dataOffset,
-			indexEntries[index].dataLength);
+			indexEntry.dataOffset,
+			indexEntry.dataLength);
 
 		return std::make_unique<Stream::FileSliceReader>(slice);
 	}

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -54,9 +54,9 @@ namespace Archives
 	// Extracts the internal file corresponding to index
 	void ClmFile::ExtractFile(std::size_t index, const std::string& pathOut)
 	{
-		VerifyIndexInBounds(index);
+		const auto& indexEntry = indexEntries.at(index);
 
-		auto header = InitializeWaveHeader(clmHeader.waveFormat, indexEntries[index].dataLength);
+		auto header = InitializeWaveHeader(clmHeader.waveFormat, indexEntry.dataLength);
 
 		try
 		{
@@ -65,8 +65,8 @@ namespace Archives
 			waveFileWriter.Write(header);
 
 			auto slice = clmFileReader.Slice(
-				indexEntries[index].dataOffset,
-				indexEntries[index].dataLength);
+				indexEntry.dataOffset,
+				indexEntry.dataLength);
 
 			waveFileWriter.Write(slice);
 		}

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -41,17 +41,13 @@ namespace Archives
 	// Throws an error if packed file index is not valid.
 	std::string ClmFile::GetName(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
-		return indexEntries[index].GetFilename();
+		return indexEntries.at(index).GetFilename();
 	}
 
 	// Returns the size of the internal file corresponding to index
 	uint32_t ClmFile::GetSize(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
-		return indexEntries[index].dataLength;
+		return indexEntries.at(index).dataLength;
 	}
 
 

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -62,7 +62,7 @@ namespace Archives
 		// Private functions for reading archive
 		void ReadHeader();
 
-		void InitializeWaveHeader(WaveHeader& headerOut, std::size_t index);
+		static WaveHeader InitializeWaveHeader(const WaveFormatEx& waveFormat, uint32_t dataLength);
 
 		// Private functions for packing files
 		static void ReadAllWaveHeaders(std::vector<std::unique_ptr<Stream::FileReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -29,21 +29,21 @@ namespace Archives
 
 	std::string VolFile::GetName(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return m_StringTable[index];
 	}
 
 	CompressionType VolFile::GetCompressionCode(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return m_IndexEntries[index].compressionType;
 	}
 
 	uint32_t VolFile::GetSize(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		return m_IndexEntries[index].fileSize;
 	}
@@ -69,7 +69,7 @@ namespace Archives
 
 	VolFile::SectionHeader VolFile::GetSectionHeader(std::size_t index)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		archiveFileReader.Seek(m_IndexEntries[index].dataBlockOffset);
 
@@ -88,7 +88,7 @@ namespace Archives
 	// Extracts the internal file at the given index to the filename.
 	void VolFile::ExtractFile(std::size_t index, const std::string& pathOut)
 	{
-		CheckIndexBounds(index);
+		VerifyIndexInBounds(index);
 
 		if (m_IndexEntries[index].compressionType == CompressionType::Uncompressed)
 		{
@@ -178,7 +178,7 @@ namespace Archives
 		volInfo.names = GetNamesFromPaths(filesToPack);
 
 		// Allowing duplicate names when packing may cause unintended results during binary search and file extraction.
-		CheckSortedContainerForDuplicateNames(volInfo.names);
+		VerifySortedContainerHasNoDuplicateNames(volInfo.names);
 
 		// Open input files and prepare header and indexing info
 		PrepareHeader(volInfo, volumeFilename);

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -29,9 +29,7 @@ namespace Archives
 
 	std::string VolFile::GetName(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
-		return m_StringTable[index];
+		return m_StringTable.at(index);
 	}
 
 	CompressionType VolFile::GetCompressionCode(std::size_t index)

--- a/src/Archives/VolFile.cpp
+++ b/src/Archives/VolFile.cpp
@@ -36,16 +36,12 @@ namespace Archives
 
 	CompressionType VolFile::GetCompressionCode(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
-		return m_IndexEntries[index].compressionType;
+		return m_IndexEntries.at(index).compressionType;
 	}
 
 	uint32_t VolFile::GetSize(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
-		return m_IndexEntries[index].fileSize;
+		return m_IndexEntries.at(index).fileSize;
 	}
 
 
@@ -69,9 +65,7 @@ namespace Archives
 
 	VolFile::SectionHeader VolFile::GetSectionHeader(std::size_t index)
 	{
-		VerifyIndexInBounds(index);
-
-		archiveFileReader.Seek(m_IndexEntries[index].dataBlockOffset);
+		archiveFileReader.Seek(m_IndexEntries.at(index).dataBlockOffset);
 
 		SectionHeader sectionHeader;
 		archiveFileReader.Read(sectionHeader);
@@ -88,13 +82,13 @@ namespace Archives
 	// Extracts the internal file at the given index to the filename.
 	void VolFile::ExtractFile(std::size_t index, const std::string& pathOut)
 	{
-		VerifyIndexInBounds(index);
+		const auto& indexEntry = m_IndexEntries.at(index);
 
-		if (m_IndexEntries[index].compressionType == CompressionType::Uncompressed)
+		if (indexEntry.compressionType == CompressionType::Uncompressed)
 		{
 			ExtractFileUncompressed(index, pathOut);
 		}
-		else if (m_IndexEntries[index].compressionType == CompressionType::LZH)
+		else if (indexEntry.compressionType == CompressionType::LZH)
 		{
 			ExtractFileLzh(index, pathOut);
 		}

--- a/src/Sprites/ArtFile.cpp
+++ b/src/Sprites/ArtFile.cpp
@@ -12,7 +12,7 @@ BitCount ArtFile::GetBitCount(std::size_t imageIndex)
 	return imageMetas[imageIndex].type.bShadow ? BitCount::One : BitCount::Eight;
 }
 
-void ArtFile::CheckImageIndex(std::size_t index)
+void ArtFile::VerifyImageIndexInBounds(std::size_t index)
 {
 	if (index > imageMetas.size()) {
 		throw std::runtime_error("An index of " + std::to_string(index) + " exceeds range of images");

--- a/src/Sprites/ArtFile.h
+++ b/src/Sprites/ArtFile.h
@@ -28,7 +28,7 @@ public:
 	static void Write(Stream::SeekableWriter&, const ArtFile& artFile);
 
 	BitCount GetBitCount(std::size_t imageIndex);
-	void CheckImageIndex(std::size_t index);
+	void VerifyImageIndexInBounds(std::size_t index);
 
 private:
 	// Read Functions

--- a/src/Sprites/OP2BmpLoader.cpp
+++ b/src/Sprites/OP2BmpLoader.cpp
@@ -6,7 +6,7 @@ OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::string artFilename) :
 
 void OP2BmpLoader::ExtractImage(std::size_t index) 
 {
-	artFile.CheckImageIndex(index);
+	artFile.VerifyImageIndexInBounds(index);
 
 	ImageMeta& imageMeta = artFile.imageMetas[index];
 	auto pixels = GetPixels(imageMeta.pixelDataOffset, imageMeta.scanLineByteWidth * 8 * imageMeta.height);


### PR DESCRIPTION
There are some slightly controversial changes in this branch. By using `vector::at` for bounds checking rather than a custom method, it simplifies the code, but we also lose explicit control over the exception messages. In particular, we lose explicit reporting of the archive filename in the event a bounds check throws.

This branch is based on changes from other recent branches, which it would otherwise have merge conflicts with. For this reason, I added explicit merge commits to bring in changes from the other branches, so you can verify the changes unique to this branch by viewing commits added after the two merge commits.
