### PR TITLE
Add static assert for sizeof structs used in serialization

### DIFF
--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -49,6 +49,8 @@ namespace Archives
 			void VerifyUnknown() const; // Exception raised if invalid version
 		};
 
+		static_assert(42 + sizeof(WaveFormatEx) == sizeof(ClmHeader), "ClmHeader is an unexpected size");
+
 		struct IndexEntry
 		{
 			std::array<char, 8> filename;
@@ -57,6 +59,8 @@ namespace Archives
 
 			std::string GetFilename() const;
 		};
+
+		static_assert(16 == sizeof(IndexEntry), "ClmFile::IndexEntry is an unexpected size");
 #pragma pack(pop)
 
 		// Private functions for reading archive

--- a/src/Archives/CompressionType.h
+++ b/src/Archives/CompressionType.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Archives
 {
 	// Represents compression flags used by Outpost 2 .VOL files to compress files
 	// See FileFormat Archive Vol.txt for more details
-	enum class CompressionType : unsigned short
+	enum class CompressionType : uint16_t
 	{
 		Uncompressed = 0x100,
 		RLE = 0x101,  // Run Length Encoded. Currently not supported.

--- a/src/Archives/VolFile.h
+++ b/src/Archives/VolFile.h
@@ -53,6 +53,8 @@ namespace Archives
 			CompressionType compressionType;
 		};
 
+		static_assert(14 == sizeof(IndexEntry), "VolFile::IndexEntry is an unexpected size");
+
 		// Specify boundary padding for a volume file section
 		enum class VolPadding
 		{
@@ -64,13 +66,15 @@ namespace Archives
 		{
 			SectionHeader();
 			SectionHeader(std::array<char, 4> tag, uint32_t length, VolPadding padding = VolPadding::FourByte);
+
 			std::array<char, 4> tag;
 			uint32_t length : 31;
 			VolPadding padding : 1;
 		};
-#pragma pack(pop)
 
-		static_assert(sizeof(SectionHeader) == 8, "SectionHeader not of required size");
+		static_assert(8 == sizeof(SectionHeader), "VolFile::SectionHeader is an unexpected size");
+
+#pragma pack(pop)
 
 		struct CreateVolumeInfo
 		{

--- a/src/Archives/WaveFile.h
+++ b/src/Archives/WaveFile.h
@@ -28,12 +28,16 @@ namespace Archives
 		uint16_t cbSize;             /* the count in bytes of the size of extra information (after cbSize) */
 	};
 
+	static_assert(18 == sizeof(WaveFormatEx), "WaveFormatEx is an unexpected size");
+
 	struct RiffHeader
 	{
 		std::array<char, 4> riffTag;
 		uint32_t chunkSize;
 		std::array<char, 4> waveTag;
 	};
+
+	static_assert(12 == sizeof(RiffHeader), "RiffHeader is an unexpected size");
 
 	struct FormatChunk
 	{
@@ -42,11 +46,15 @@ namespace Archives
 		WaveFormatEx waveFormat;
 	};
 
+	static_assert(8 + sizeof(WaveFormatEx) == sizeof(FormatChunk), "FormatChunk is an unexpected size");
+
 	struct ChunkHeader
 	{
 		std::array<char, 4> formatTag;
 		uint32_t length;
 	};
+
+	static_assert(8 == sizeof(ChunkHeader), "ChunkHeader is an unexpected size");
 
 	// http://soundfile.sapp.org/doc/WaveFormat/
 	struct WaveHeader
@@ -57,6 +65,8 @@ namespace Archives
 		FormatChunk formatChunk;
 		ChunkHeader dataChunk;
 	};
+
+	static_assert(sizeof(RiffHeader) + sizeof(FormatChunk) + sizeof(ChunkHeader) == sizeof(WaveHeader), "WaveHeader is an unexpected size");
 
 #pragma pack(pop)
 }

--- a/src/Maps/MapHeader.h
+++ b/src/Maps/MapHeader.h
@@ -48,4 +48,6 @@ struct MapHeader
 	}
 };
 
+static_assert(20 == sizeof(MapHeader), "MapHeader is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Maps/TerrainType.h
+++ b/src/Maps/TerrainType.h
@@ -35,7 +35,7 @@ struct TerrainType
 
 	// 5 groups of 16 tiles. Each group represents a different wall type.
 	// Lava, Microbe, Full Strength Regular, Damaged Regular, and Heavily Damaged Regular.
-	int16_t wall[5][16];
+	uint16_t wall[5][16];
 
 	// First index for lava tiles in Terrain Type.
 	uint16_t lavaTileIndex;

--- a/src/Maps/TerrainType.h
+++ b/src/Maps/TerrainType.h
@@ -33,7 +33,7 @@ struct TerrainType
 
 	// 5 groups of 16 tiles. Each group represents a different wall type.
 	// Lava, Microbe, Full Strength Regular, Damaged Regular, and Heavily Damaged Regular.
-	short wall[5][16];
+	int16_t wall[5][16];
 
 	// First index for lava tiles in Terrain Type.
 	uint16_t lavaTileIndex;

--- a/src/Maps/TerrainType.h
+++ b/src/Maps/TerrainType.h
@@ -13,6 +13,8 @@ struct TileRange
 	uint16_t end;
 };
 
+static_assert(4 == sizeof(TileRange), "TileRange is an unexpected size");
+
 // The properties associated with a range of tiles.
 struct TerrainType
 {
@@ -59,5 +61,7 @@ struct TerrainType
 	// UNKNOWN
 	int16_t unkown[15];
 };
+
+static_assert(248 + 4 * sizeof(TileRange) == sizeof(TerrainType), "TerrainType is an unexpected size");
 
 #pragma pack(pop)

--- a/src/Maps/TileData.h
+++ b/src/Maps/TileData.h
@@ -33,4 +33,6 @@ struct TileData
 	int bWallOrBuilding : 1;
 };
 
+static_assert(4 == sizeof(TileData), "TileData is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Maps/TileInfo.h
+++ b/src/Maps/TileInfo.h
@@ -21,4 +21,6 @@ struct TileInfo
 	uint16_t animationDelay;
 };
 
+static_assert(8 == sizeof(TileInfo), "TileInfo is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Point.h
+++ b/src/Point.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#pragma pack(push, 1) // Make sure structures are byte aligned
+
 struct Point32
 {
 	int32_t x;
@@ -13,3 +15,5 @@ struct Point16
 	int16_t x;
 	int16_t y;
 };
+
+#pragma pack(pop)

--- a/src/Point.h
+++ b/src/Point.h
@@ -10,10 +10,14 @@ struct Point32
 	int32_t y;
 };
 
+static_assert(8 == sizeof(Point32), "Point32 is an unexpected size");
+
 struct Point16
 {
 	int16_t x;
 	int16_t y;
 };
+
+static_assert(4 == sizeof(Point16), "Point16 is an unexpected size");
 
 #pragma pack(pop)

--- a/src/Rect.h
+++ b/src/Rect.h
@@ -12,4 +12,6 @@ struct Rect
 	int32_t y2;
 };
 
+static_assert(16 == sizeof(Rect), "Rect is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Sprites/Animation.h
+++ b/src/Sprites/Animation.h
@@ -14,10 +14,14 @@ struct Animation {
 			uint8_t bReadOptionalData : 1;
 		};
 
+		static_assert(1 == sizeof(LayerMetadata), "Animation::Frame::LayerMetadata is an unexpected size");
+
 		struct UnknownBitfield {
 			uint8_t unknown : 7;
 			uint8_t bReadOptionalData : 1;
 		};
+
+		static_assert(1 == sizeof(UnknownBitfield), "Animation::Frame::UnknownBitfield is an unexpected size");
 
 		struct Layer {
 			uint16_t bitmapIndex;
@@ -25,6 +29,8 @@ struct Animation {
 			uint8_t frameIndex;
 			Point16 pixelOffset;
 		};
+
+		static_assert(4 + sizeof(Point16), "Animation::Frame::Layer is an unexpected size");
 
 		LayerMetadata layerMetadata;
 		UnknownBitfield unknownBitfield;
@@ -44,6 +50,8 @@ struct Animation {
 		uint32_t unknown3;
 		uint32_t unknown4;
 	};
+
+	static_assert(16 == sizeof(UnknownContainer), "Animation::UnknownContainer is an unexpected size");
 
 	uint32_t unknown;
 	Rect selectionRect; // pixels

--- a/src/Sprites/Animation.h
+++ b/src/Sprites/Animation.h
@@ -10,18 +10,11 @@
 struct Animation {
 	struct Frame {
 		struct LayerMetadata {
-			uint8_t layerCount : 7;
+			uint8_t count : 7;
 			uint8_t bReadOptionalData : 1;
 		};
 
 		static_assert(1 == sizeof(LayerMetadata), "Animation::Frame::LayerMetadata is an unexpected size");
-
-		struct UnknownBitfield {
-			uint8_t unknown : 7;
-			uint8_t bReadOptionalData : 1;
-		};
-
-		static_assert(1 == sizeof(UnknownBitfield), "Animation::Frame::UnknownBitfield is an unexpected size");
 
 		struct Layer {
 			uint16_t bitmapIndex;
@@ -33,7 +26,7 @@ struct Animation {
 		static_assert(4 + sizeof(Point16), "Animation::Frame::Layer is an unexpected size");
 
 		LayerMetadata layerMetadata;
-		UnknownBitfield unknownBitfield;
+		LayerMetadata unknownBitfield;
 
 		uint8_t optional1;
 		uint8_t optional2;

--- a/src/Sprites/ArtReader.cpp
+++ b/src/Sprites/ArtReader.cpp
@@ -115,7 +115,7 @@ Animation::Frame ArtFile::ReadFrame(Stream::SeekableReader& seekableReader) {
 		seekableReader.Read(frame.optional4);
 	}
 
-	frame.layers.resize(frame.layerMetadata.layerCount);
+	frame.layers.resize(frame.layerMetadata.count);
 	seekableReader.Read(frame.layers);
 
 	return frame;

--- a/src/Sprites/ArtWriter.cpp
+++ b/src/Sprites/ArtWriter.cpp
@@ -100,7 +100,7 @@ void ArtFile::WriteAnimation(Stream::SeekableWriter& seekableWriter, const Anima
 
 void ArtFile::WriteFrame(Stream::SeekableWriter& seekableWriter, const Animation::Frame& frame)
 {
-	if (frame.layerMetadata.layerCount != frame.layers.size()) {
+	if (frame.layerMetadata.count != frame.layers.size()) {
 		throw std::runtime_error("Recorded layer count must match number of written layers.");
 	}
 

--- a/src/Sprites/BmpHeader.h
+++ b/src/Sprites/BmpHeader.h
@@ -21,4 +21,6 @@ struct BmpHeader
 	static const uint16_t defaultReserved2;
 };
 
+static_assert(14 == sizeof(BmpHeader), "BmpHeader is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Sprites/Color.h
+++ b/src/Sprites/Color.h
@@ -12,6 +12,8 @@ struct Color {
 	uint8_t alpha;
 };
 
+static_assert(4 == sizeof(Color), "Color is an unexpected size");
+
 #pragma pack(pop)
 
 using Palette = std::array<Color, 256>;

--- a/src/Sprites/ImageHeader.h
+++ b/src/Sprites/ImageHeader.h
@@ -41,4 +41,6 @@ struct ImageHeader
 	static void VerifyIndexedBitCount(uint16_t bitCount);
 };
 
+static_assert(40 == sizeof(ImageHeader), "ImageHeader is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Sprites/ImageMeta.h
+++ b/src/Sprites/ImageMeta.h
@@ -18,6 +18,7 @@ struct ImageMeta {
 		uint16_t unknown4 : 1; // 32
 		uint16_t bTruckBed : 1; // 64
 		uint16_t unknown5 : 1; // 128
+		uint16_t unknown6 : 8;
 	};
 
 	static_assert(2 == sizeof(ImageType), "ImageMeta::ImageType is an unexpected size");

--- a/src/Sprites/ImageMeta.h
+++ b/src/Sprites/ImageMeta.h
@@ -20,6 +20,8 @@ struct ImageMeta {
 		uint16_t unknown5 : 1; // 128
 	};
 
+	static_assert(2 == sizeof(ImageType), "ImageMeta::ImageType is an unexpected size");
+
 	uint32_t scanLineByteWidth; //number of bytes in each scan line of image (this should be the width of the image rounded up to a 32 bit boundary)
 	uint32_t pixelDataOffset; // Offset of the pixel data in the .bmp file
 	uint32_t height; // Height of image in pixels
@@ -27,5 +29,7 @@ struct ImageMeta {
 	ImageType type;
 	uint16_t paletteIndex;
 };
+
+static_assert(18 + sizeof(ImageMeta::ImageType) == sizeof(ImageMeta), "ImageMeta is an unexpected size");
 
 #pragma pack(pop)

--- a/src/Sprites/PaletteHeader.h
+++ b/src/Sprites/PaletteHeader.h
@@ -28,4 +28,6 @@ private:
 	static const std::array<char, 4> TagData;
 };
 
+static_assert(4 + 3 * sizeof(SectionHeader) == sizeof(PaletteHeader), "PaletteHeader is an unexpected size");
+
 #pragma pack(pop)

--- a/src/Sprites/SectionHeader.h
+++ b/src/Sprites/SectionHeader.h
@@ -21,4 +21,6 @@ struct SectionHeader
 	inline std::size_t TotalLength() const { return length + tag.size() * sizeof(decltype(tag)::value_type); };
 };
 
+static_assert(8 == sizeof(SectionHeader), "SectionHeader is an unexpected size");
+
 #pragma pack(pop)


### PR DESCRIPTION
Closes #191 

Also contains some cleanup for non-fixed width integer types used in serialization, missing preprocessor directives to ensure 1 byte aligned structs, etc.

Low priority for merging, but @DanRStevens probably worth a quick look when you have a chance to make sure it all looks good as I've never done anything like this before.

Good news is, Visual Studio would immediately flag warnings for wrong sized structs using static_assert without even making me compile the code. So it definitely works properly on MSVC.