### PR TITLE
Resolve Compiler Warnings within IndexedBmpWriter

### DIFF
--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -138,8 +138,6 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitC
 
 void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelsWithPitchSize)
 {
-	const uint16_t pixelsPerByte = 8 / bitCount;
-
 	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
 	if (pixelsWithPitchSize != static_cast<uint32_t>(CalculatePitchSize(bitCount, width) * std::abs(height))) {
 		throw std::runtime_error("An incorrect number of pixels were passed.");

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -63,7 +63,7 @@ void IndexedBmpWriter::WritePixels(Stream::SeekableWriter& seekableWriter, uint1
 	}
 }
 
-int32_t IndexedBmpWriter::CalculatePitchSize(uint16_t bitCount, int32_t width)
+unsigned int IndexedBmpWriter::CalculatePitchSize(uint16_t bitCount, int32_t width)
 {
 	const uint16_t bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
 
@@ -108,7 +108,7 @@ void IndexedBmpWriter::WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, u
 	}
 }
 
-uint32_t IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)
+unsigned int IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)
 {
 	const uint16_t bitsPerByte = 8;
 	uint32_t pixelByteWidth = width * bitCount / bitsPerByte;
@@ -139,7 +139,7 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitC
 void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelsWithPitchSize)
 {
 	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
-	if (pixelsWithPitchSize != static_cast<uint32_t>(CalculatePitchSize(bitCount, width) * std::abs(height))) {
+	if (pixelsWithPitchSize != CalculatePitchSize(bitCount, width) * std::abs(height)) {
 		throw std::runtime_error("An incorrect number of pixels were passed.");
 	}
 }

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -111,13 +111,7 @@ void IndexedBmpWriter::WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, u
 unsigned int IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)
 {
 	const uint16_t bitsPerByte = 8;
-	uint32_t pixelByteWidth = width * bitCount / bitsPerByte;
-
-	if (width * bitCount % bitsPerByte != 0) {
-		pixelByteWidth += 1;
-	}
-
-	return pixelByteWidth;
+	return ((width * bitCount) + (bitsPerByte - 1)) / bitsPerByte;
 }
 
 void IndexedBmpWriter::VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize)

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -63,13 +63,6 @@ void IndexedBmpWriter::WritePixels(Stream::SeekableWriter& seekableWriter, uint1
 	}
 }
 
-unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
-{
-	const uint16_t bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
-
-	return ( (bytesOfPixelsPerRow + 3) & ~3 );
-}
-
 void IndexedBmpWriter::WritePixelsTopDown(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels)
 {
 	const uint16_t bytesOfSetPixelsPerRow = CalcPixelByteWidth(bitCount, width);
@@ -106,6 +99,13 @@ void IndexedBmpWriter::WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, u
 
 		index -= bytesOfPixelsPerRow;
 	}
+}
+
+unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
+{
+	const uint16_t bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
+
+	return ( (bytesOfPixelsPerRow + 3) & ~3 );
 }
 
 unsigned int IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -133,7 +133,6 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitC
 
 void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelsWithPitchSize)
 {
-	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
 	if (pixelsWithPitchSize != CalculatePitch(bitCount, width) * std::abs(height)) {
 		throw std::runtime_error("An incorrect number of pixels were passed.");
 	}
@@ -142,8 +141,7 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint
 void IndexedBmpWriter::VerifyPixelsContainedInPalette(uint16_t bitCount, std::size_t paletteEntryCount, const std::vector<uint8_t>& pixels)
 {
 	// Check if palette is full
-	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
-	// MSVC will flag warning C4334 on x64 compilation if bit shift not set to 64 bit integer
+	// Use explicit size_t type to avoid compiler warnings for signedness or size
 	if (paletteEntryCount == std::size_t{1} << bitCount) {
 		return;
 	}

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -38,7 +38,7 @@ void IndexedBmpWriter::Write(std::string filename, uint16_t bitCount, int32_t wi
 void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette)
 {
 	std::size_t pixelOffset = sizeof(BmpHeader) + sizeof(ImageHeader) + palette.size() * sizeof(Color);
-	std::size_t fileSize = pixelOffset + CalculatePitchSize(bitCount, width) * std::abs(height);
+	std::size_t fileSize = pixelOffset + CalculatePitch(bitCount, width) * std::abs(height);
 
 	if (fileSize > UINT32_MAX) {
 		throw std::runtime_error("Bitmap size is too large to save to disk.");
@@ -63,7 +63,7 @@ void IndexedBmpWriter::WritePixels(Stream::SeekableWriter& seekableWriter, uint1
 	}
 }
 
-unsigned int IndexedBmpWriter::CalculatePitchSize(uint16_t bitCount, int32_t width)
+unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
 {
 	const uint16_t bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
 
@@ -139,7 +139,7 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitC
 void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelsWithPitchSize)
 {
 	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
-	if (pixelsWithPitchSize != CalculatePitchSize(bitCount, width) * std::abs(height)) {
+	if (pixelsWithPitchSize != CalculatePitch(bitCount, width) * std::abs(height)) {
 		throw std::runtime_error("An incorrect number of pixels were passed.");
 	}
 }

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -145,7 +145,7 @@ void IndexedBmpWriter::VerifyPixelsContainedInPalette(uint16_t bitCount, std::si
 	// Check if palette is full
 	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
 	// MSVC will flag warning C4334 on x64 compilation if bit shift not set to 64 bit integer
-	if (paletteEntryCount == 1ui64 << bitCount) {
+	if (paletteEntryCount == static_cast<uint64_t>(1) << bitCount) {
 		return;
 	}
 

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -134,7 +134,8 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint
 {
 	const uint16_t pixelsPerByte = 8 / bitCount;
 
-	if (pixelCountIncludingPitch * pixelsPerByte != CalcScanlinePitch(bitCount, width) * std::abs(height)) {
+	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
+	if (pixelCountIncludingPitch * pixelsPerByte != static_cast<uint32_t>(CalcScanlinePitch(bitCount, width) * std::abs(height))) {
 		throw std::runtime_error("An incorrect number of pixels were passed.");
 	}
 }
@@ -142,7 +143,9 @@ void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint
 void IndexedBmpWriter::VerifyPixelsContainedInPalette(uint16_t bitCount, std::size_t paletteEntryCount, const std::vector<uint8_t>& pixels)
 {
 	// Check if palette is full
-	if (paletteEntryCount == 1 << bitCount) {
+	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
+	// MSVC will flag warning C4334 on x64 compilation if bit shift not set to 64 bit integer
+	if (paletteEntryCount == 1ui64 << bitCount) {
 		return;
 	}
 

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cmath>
+#include <cstddef>
 
 void IndexedBmpWriter::WritePixelsIncludingPadding(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& pixelsWithPadding)
 {
@@ -143,7 +144,7 @@ void IndexedBmpWriter::VerifyPixelsContainedInPalette(uint16_t bitCount, std::si
 	// Check if palette is full
 	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
 	// MSVC will flag warning C4334 on x64 compilation if bit shift not set to 64 bit integer
-	if (paletteEntryCount == 1u << bitCount) {
+	if (paletteEntryCount == std::size_t{1} << bitCount) {
 		return;
 	}
 

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -149,7 +149,7 @@ void IndexedBmpWriter::VerifyPixelsContainedInPalette(uint16_t bitCount, std::si
 	// Check if palette is full
 	// G++ will flag warning -Wsign-compare if comparing a signed and unsigned value
 	// MSVC will flag warning C4334 on x64 compilation if bit shift not set to 64 bit integer
-	if (paletteEntryCount == static_cast<uint64_t>(1) << bitCount) {
+	if (paletteEntryCount == 1u << bitCount) {
 		return;
 	}
 

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -38,18 +38,18 @@ private:
 	// If height is a positive number, the top row of pixels is written at the end of the file 
 	static void WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels);
 
-	// Returns pixel row including scan line extension size in bytes
-	static int32_t CalcScanlinePitch(uint16_t bitCount, int32_t width);
+	static int32_t CalculatePitchSize(uint16_t bitCount, int32_t width);
 
-	static uint32_t CalcScanlineByteWidth(uint16_t bitCount, int32_t width);
+	// Does not include Pitch
+	static uint32_t CalcPixelByteWidth(uint16_t bitCount, int32_t width);
 
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);
 	static void VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitCount, std::size_t pixelCount, std::size_t pixelArraySize);
 
 	// Check the pixel count is correct if it already includes dummy pixels out to next 4 byte boundary.
 	// @width: Width in pixels. Do not include the pitch in width.
-	// @pixelCountIncludingPitch: Number of pixels including padding pixels to next 4 byte boundary.
-	static void VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelCountIncludingPitch);
+	// @pixelsWithPitchSize: Number of pixels including padding pixels to next 4 byte boundary.
+	static void VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelsWithPitchSize);
 
 	static void VerifyPixelsContainedInPalette(uint16_t bitCount, std::size_t paletteEntryCount, const std::vector<uint8_t>& pixels);
 };

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -40,7 +40,7 @@ private:
 
 	static unsigned int CalculatePitch(uint16_t bitCount, int32_t width);
 
-	// Does not include Pitch
+	// Does not include padding
 	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);
 
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -38,10 +38,10 @@ private:
 	// If height is a positive number, the top row of pixels is written at the end of the file 
 	static void WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels);
 
-	static int32_t CalculatePitchSize(uint16_t bitCount, int32_t width);
+	static unsigned int CalculatePitchSize(uint16_t bitCount, int32_t width);
 
 	// Does not include Pitch
-	static uint32_t CalcPixelByteWidth(uint16_t bitCount, int32_t width);
+	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);
 
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);
 	static void VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitCount, std::size_t pixelCount, std::size_t pixelArraySize);

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -38,7 +38,7 @@ private:
 	// If height is a positive number, the top row of pixels is written at the end of the file 
 	static void WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels);
 
-	static unsigned int CalculatePitchSize(uint16_t bitCount, int32_t width);
+	static unsigned int CalculatePitch(uint16_t bitCount, int32_t width);
 
 	// Does not include Pitch
 	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);


### PR DESCRIPTION
 - MSVC: C4334 'operator' : result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
 - G++: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

Closes #196 

@DanRStevens, Another low priority branch. Worth you looking over since I'm not great with bitwise operations. 