### PR TITLE
Remove non padded pixel write function

### DIFF
--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -30,8 +30,8 @@ void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint
 		throw std::runtime_error("Bitmap size is too large to save to disk.");
 	}
 
-	BmpHeader bmpHeader = BmpHeader::Create(static_cast<uint32_t>(fileSize), static_cast<uint32_t>(pixelOffset));
-	ImageHeader imageHeader = ImageHeader::Create(width, height, bitCount);
+	auto bmpHeader = BmpHeader::Create(static_cast<uint32_t>(fileSize), static_cast<uint32_t>(pixelOffset));
+	auto imageHeader = ImageHeader::Create(width, height, bitCount);
 
 	seekableWriter.Write(bmpHeader);
 	seekableWriter.Write(imageHeader);
@@ -39,8 +39,8 @@ void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint
 
 void IndexedBmpWriter::WritePixels(Stream::SeekableWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount)
 {
-	const unsigned int pitch = CalculatePitch(bitCount, width);
-	const unsigned int bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
+	const auto pitch = CalculatePitch(bitCount, width);
+	const auto bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
 	const std::vector<uint8_t> padding(pitch - bytesOfPixelsPerRow, 0);
 
 	for (std::size_t i = 0; i < pixels.size();) {
@@ -50,15 +50,15 @@ void IndexedBmpWriter::WritePixels(Stream::SeekableWriter& seekableWriter, const
 	}
 }
 
-unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
+std::size_t IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
 {
-	const unsigned int bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
+	const auto bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
 	return ( (bytesOfPixelsPerRow + 3) & ~3 );
 }
 
-unsigned int IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)
+std::size_t IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)
 {
-	const unsigned int bitsPerByte = 8;
+	const std::size_t bitsPerByte = 8;
 	return ((width * bitCount) + (bitsPerByte - 1)) / bitsPerByte;
 }
 

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -38,10 +38,9 @@ void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint
 
 unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
 {
-	const uint16_t bitsPerByte = 8;
+	const std::size_t bitsPerByte = 8;
 	// Does not include padding
-	const uint16_t bytesOfPixelsPerRow = ((width * bitCount) + (bitsPerByte - 1)) / bitsPerByte;
-
+	const std::size_t bytesOfPixelsPerRow = ((width * bitCount) + (bitsPerByte - 1)) / bitsPerByte;
 	return ( (bytesOfPixelsPerRow + 3) & ~3 );
 }
 

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -37,15 +37,11 @@ void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint
 
 unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
 {
-	const uint16_t bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
+	const uint16_t bitsPerByte = 8;
+	// Does not include padding
+	const uint16_t bytesOfPixelsPerRow = ((width * bitCount) + (bitsPerByte - 1)) / bitsPerByte;
 
 	return ( (bytesOfPixelsPerRow + 3) & ~3 );
-}
-
-unsigned int IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t width)
-{
-	const uint16_t bitsPerByte = 8;
-	return ((width * bitCount) + (bitsPerByte - 1)) / bitsPerByte;
 }
 
 void IndexedBmpWriter::VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize)

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -50,7 +50,7 @@ unsigned int IndexedBmpWriter::CalcPixelByteWidth(uint16_t bitCount, int32_t wid
 
 void IndexedBmpWriter::VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize)
 {
-	if (paletteSize > static_cast<uint16_t>(2 << bitCount)) {
+	if (paletteSize > std::size_t{ 1 } << bitCount) {
 		throw std::runtime_error("Too many colors listed on the indexed palette");
 	}
 }

--- a/src/Sprites/IndexedBmpWriter.cpp
+++ b/src/Sprites/IndexedBmpWriter.cpp
@@ -2,38 +2,21 @@
 #include "ImageHeader.h"
 #include "../Streams/FileWriter.h"
 #include "../Streams/SeekableReader.h"
-#include <algorithm>
 #include <stdexcept>
 #include <cmath>
-#include <cstddef>
 
-void IndexedBmpWriter::WritePixelsIncludingPadding(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& pixelsWithPadding)
+void IndexedBmpWriter::Write(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& indexedPixels)
 {
 	ImageHeader::VerifyIndexedBitCount(bitCount);
 	VerifyPaletteSizeDoesNotExceedBitCount(bitCount, palette.size());
-	VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(bitCount, width, height, pixelsWithPadding.size());
-	VerifyPixelsContainedInPalette(bitCount, palette.size(), pixelsWithPadding);
+	VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(bitCount, width, height, indexedPixels.size());
+	VerifyPixelsContainedInPalette(bitCount, palette.size(), indexedPixels);
 
 	Stream::FileWriter fileWriter(filename);
 
 	WriteHeaders(fileWriter, bitCount, width, height, palette);
 	fileWriter.Write(palette);
-	fileWriter.Write(pixelsWithPadding);
-}
-
-// Writes a Bitmap with an indexed color palette
-void IndexedBmpWriter::Write(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& pixels)
-{
-	ImageHeader::VerifyIndexedBitCount(bitCount);
-	VerifyPaletteSizeDoesNotExceedBitCount(bitCount, palette.size());
-	VerifyPixelBufferSizeMatchesImageDimensions(bitCount, std::abs(height) * width, pixels.size());
-	VerifyPixelsContainedInPalette(bitCount, palette.size(), pixels);
-
-	Stream::FileWriter fileWriter(filename);
-
-	WriteHeaders(fileWriter, bitCount, width, height, palette);
-	fileWriter.Write(palette);
-	WritePixels(fileWriter, bitCount, width, height, pixels);
+	fileWriter.Write(indexedPixels);
 }
 
 void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette)
@@ -50,56 +33,6 @@ void IndexedBmpWriter::WriteHeaders(Stream::SeekableWriter& seekableWriter, uint
 
 	seekableWriter.Write(bmpHeader);
 	seekableWriter.Write(imageHeader);
-}
-
-void IndexedBmpWriter::WritePixels(Stream::SeekableWriter& seekableWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels)
-{
-	// If height > 0, top line of pixels is bottom line in file. 
-	// If height < 0, top line of pixels is top line in file
-	if (height < 0) {
-		WritePixelsTopDown(seekableWriter, bitCount, width, height, pixels);
-	}
-	else {
-		WritePixelsBottomUp(seekableWriter, bitCount, width, height, pixels);
-	}
-}
-
-void IndexedBmpWriter::WritePixelsTopDown(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels)
-{
-	const uint16_t bytesOfSetPixelsPerRow = CalcPixelByteWidth(bitCount, width);
-	std::vector<uint8_t> buffer( (bytesOfSetPixelsPerRow + 3) & ~3 );
-	int index = 0; //Index is in bytes, not necessarily pixels
-
-	for (int row = 0; row < -1 * height; ++row)
-	{
-		// 0 pad the end of each line so it is a multiple of 4 bytes
-		std::fill(buffer.begin(), buffer.end(), 0);
-		std::copy(pixels.begin() + index,
-			pixels.begin() + index + bytesOfSetPixelsPerRow,
-			buffer.begin());
-		fileWriter.Write(buffer);
-
-		index += bytesOfSetPixelsPerRow;
-	}
-}
-
-void IndexedBmpWriter::WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels)
-{
-	const uint16_t bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
-	std::vector<uint8_t> buffer( (bytesOfPixelsPerRow + 3) & ~3 );
-	int index = bytesOfPixelsPerRow * height; //Index is in bytes, not necessarily pixels
-
-	for (int row = 0; row < height; ++row)
-	{
-		// 0 pad the end of each line so it is a multiple of 4 bytes
-		std::fill(buffer.begin(), buffer.end(), 0);
-		std::copy(pixels.begin() + index - bytesOfPixelsPerRow,
-			pixels.begin() + index,
-			buffer.begin());
-		fileWriter.Write(buffer);
-
-		index -= bytesOfPixelsPerRow;
-	}
 }
 
 unsigned int IndexedBmpWriter::CalculatePitch(uint16_t bitCount, int32_t width)
@@ -119,15 +52,6 @@ void IndexedBmpWriter::VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount,
 {
 	if (paletteSize > static_cast<uint16_t>(2 << bitCount)) {
 		throw std::runtime_error("Too many colors listed on the indexed palette");
-	}
-}
-
-// pixelContainerSize: Number of entries in the pixel container. 
-//                     Each entry will represent multiple pixels for a 1 or 4 bit count.
-void IndexedBmpWriter::VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitCount, std::size_t pixelCount, std::size_t pixelContainerSize) 
-{
-	if (pixelCount != pixelContainerSize * (8 / bitCount)) {
-		throw std::runtime_error("Number of expected pixels does not match size of pixel container");
 	}
 }
 

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -11,32 +11,19 @@
 enum class BitCount : uint16_t;
 
 namespace Stream {
-	class SeekableReader;
 	class SeekableWriter;
 }
 
 // BMP Writer only supporting Indexed Color palettes (1, 2, and 8 bit BMPs). 
-// Properly writes BMPs with pixels in Bottom Up format (positive height) and Top Down format (negative height)
 class IndexedBmpWriter
 {
 public:
-	// The pixel container includes dummy information to fill each image row out to the next 4 byte memory border.
-	// Only supports a 4 byte pitch.
-	static void WritePixelsIncludingPadding(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& pixelsWithPadding);
-
-	// Dummy information is inserted at the end of each pixel row to reach the next 4 byte memory border
+	// @indexedPixels: Must include padding to fill each image row out to the next 4 byte memory border (pitch).
 	static void Write(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& indexedPixels);
+
 
 private:
 	static void WriteHeaders(Stream::SeekableWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette);
-
-	static void WritePixels(Stream::SeekableWriter& seekableWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels);
-
-	// If height is a negative number, pixel rows are written top down (as displayed on screen)
-	static void WritePixelsTopDown(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels);
-
-	// If height is a positive number, the top row of pixels is written at the end of the file 
-	static void WritePixelsBottomUp(Stream::SeekableWriter& fileWriter, uint16_t bitCount, int32_t width, int32_t height, const std::vector<uint8_t>& pixels);
 
 	static unsigned int CalculatePitch(uint16_t bitCount, int32_t width);
 
@@ -44,7 +31,6 @@ private:
 	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);
 
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);
-	static void VerifyPixelBufferSizeMatchesImageDimensions(uint16_t bitCount, std::size_t pixelCount, std::size_t pixelArraySize);
 
 	// Check the pixel count is correct if it already includes dummy pixels out to next 4 byte boundary.
 	// @width: Width in pixels. Do not include the pitch in width.

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -8,8 +8,6 @@
 #include <cstdint>
 #include <cstddef>
 
-enum class BitCount : uint16_t;
-
 namespace Stream {
 	class SeekableWriter;
 }

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -25,10 +25,10 @@ private:
 
 	static void WritePixels(Stream::SeekableWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount);
 
-	static unsigned int CalculatePitch(uint16_t bitCount, int32_t width);
+	static std::size_t CalculatePitch(uint16_t bitCount, int32_t width);
 
 	// Does not include padding
-	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);
+	static std::size_t CalcPixelByteWidth(uint16_t bitCount, int32_t width);
 
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);
 

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -23,7 +23,12 @@ public:
 private:
 	static void WriteHeaders(Stream::SeekableWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette);
 
+	static void WritePixels(Stream::SeekableWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount);
+
 	static unsigned int CalculatePitch(uint16_t bitCount, int32_t width);
+
+	// Does not include padding
+	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);
 
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);
 

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -17,7 +17,7 @@ class IndexedBmpWriter
 {
 public:
 	// @indexedPixels: Must include padding to fill each image row out to the next 4 byte memory border (pitch).
-	static void Write(std::string filename, uint16_t bitCount, int32_t width, int32_t height, const std::vector<Color>& palette, const std::vector<uint8_t>& indexedPixels);
+	static void Write(std::string filename, uint16_t bitCount, int32_t width, int32_t height, std::vector<Color> palette, const std::vector<uint8_t>& indexedPixels);
 
 
 private:
@@ -31,6 +31,4 @@ private:
 	// @width: Width in pixels. Do not include the pitch in width.
 	// @pixelsWithPitchSize: Number of pixels including padding pixels to next 4 byte boundary.
 	static void VerifyPixelBufferSizeMatchesImageDimensionsWithPitch(uint16_t bitCount, int32_t width, int32_t height, std::size_t pixelsWithPitchSize);
-
-	static void VerifyPixelsContainedInPalette(uint16_t bitCount, std::size_t paletteEntryCount, const std::vector<uint8_t>& pixels);
 };

--- a/src/Sprites/IndexedBmpWriter.h
+++ b/src/Sprites/IndexedBmpWriter.h
@@ -25,9 +25,6 @@ private:
 
 	static unsigned int CalculatePitch(uint16_t bitCount, int32_t width);
 
-	// Does not include padding
-	static unsigned int CalcPixelByteWidth(uint16_t bitCount, int32_t width);
-
 	static void VerifyPaletteSizeDoesNotExceedBitCount(uint16_t bitCount, std::size_t paletteSize);
 
 	// Check the pixel count is correct if it already includes dummy pixels out to next 4 byte boundary.

--- a/src/Sprites/OP2BmpLoader.cpp
+++ b/src/Sprites/OP2BmpLoader.cpp
@@ -23,6 +23,7 @@ void OP2BmpLoader::ExtractImage(std::size_t index, const std::string& filenameOu
 	std::vector<uint8_t> pixelContainer(imageMeta.scanLineByteWidth * imageMeta.height);
 	(*pixels).Read(pixelContainer);
 
+	// Outpost 2 stores pixels in normal raster scan order (top-down). This requires a negative height for BMP file format.
 	IndexedBmpWriter::Write(filenameOut, imageMeta.GetBitCount(), imageMeta.width, -1 * imageMeta.height, palette, pixelContainer);
 }
 

--- a/src/Sprites/OP2BmpLoader.cpp
+++ b/src/Sprites/OP2BmpLoader.cpp
@@ -23,7 +23,7 @@ void OP2BmpLoader::ExtractImage(std::size_t index, const std::string& filenameOu
 	std::vector<uint8_t> pixelContainer(imageMeta.scanLineByteWidth * imageMeta.height);
 	(*pixels).Read(pixelContainer);
 
-	IndexedBmpWriter::WritePixelsIncludingPadding(filenameOut, imageMeta.GetBitCount(), imageMeta.width, -1 * imageMeta.height, palette, pixelContainer);
+	IndexedBmpWriter::Write(filenameOut, imageMeta.GetBitCount(), imageMeta.width, -1 * imageMeta.height, palette, pixelContainer);
 }
 
 std::unique_ptr<Stream::FileSliceReader> OP2BmpLoader::GetPixels(std::size_t startingIndex, std::size_t length)

--- a/test/Sprites/IndexedBmpWriter.test.cpp
+++ b/test/Sprites/IndexedBmpWriter.test.cpp
@@ -8,22 +8,19 @@
 
 TEST(IndexedBmpWriter, WriteMonochrome) 
 {
-	std::vector<Color> palette{ DiscreteColor::Red, DiscreteColor::Blue };
+	std::vector<Color> palette{ DiscreteColor::Black, DiscreteColor::White };
 	std::string filename = "Sprites/data/MonochromeTest.bmp";
 
-	std::vector<uint8_t> pixels { 255, 255, 255, 0, 0, 0 };
+	std::vector<uint8_t> pixels{ 128, 0, 0, 0, 128 , 0, 0, 0};
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 1, 2, palette, pixels));
 
-	// Test width 1 byte less than scan line
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 24, -2, palette, pixels));
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 24, 2, palette, pixels));
+	// Test padding 1 byte less than pitch
+	pixels = std::vector<uint8_t>{ 128, 0, 0, 128, 0, 0 };
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 2, palette, pixels), std::runtime_error);
 
-	// Test width equal to scan line
-	pixels = std::vector<uint8_t>{ 255, 255, 255, 255, 0, 0, 0, 0 };
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 32, -2, palette, pixels));
-
-	// Test width 1 byte greater than scan line
-	pixels = std::vector<uint8_t>{ 255, 255, 255, 255, 255, 0, 0, 0, 0, 0 };
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 40, -2, palette, pixels));
+	// Test padding 1 byte greater than pitch
+	pixels = std::vector<uint8_t>{ 128, 0, 0, 0, 0, 128 , 0, 0, 0, 0 };
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 2, palette, pixels), std::runtime_error);
 
 	XFile::DeletePath(filename);
 }
@@ -31,12 +28,19 @@ TEST(IndexedBmpWriter, WriteMonochrome)
 TEST(IndexedBmpWriter, Write4Bit)
 {
 	std::string filename = "Sprites/data/4BitTest.bmp";
-	std::vector<uint8_t> pixels{ 0, 0, 0b00010001,  0b00010001 };
-	std::vector<Color> palette(16, DiscreteColor::Blue);
-	palette[0] = DiscreteColor::Red;
+	std::vector<uint8_t> pixels{ 0, 0, 0, 0, 0, 0, 0, 0 };
+	std::vector<Color> palette(16, DiscreteColor::Black);
+	palette[0] = DiscreteColor::White;
 
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 4, 4, -2, palette, pixels));
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 4, 4, 2, palette, pixels));
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 4, 1, 2, palette, pixels));
+
+	// Test padding 1 byte less than pitch
+	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0 };
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
+
+	// Test padding 1 byte greater than pitch
+	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
 
 	XFile::DeletePath(filename);
 }
@@ -45,12 +49,19 @@ TEST(IndexedBmpWriter, Write8Bit)
 {
 	std::string filename = "Sprites/data/8BitTest.bmp";
 
-	std::vector<uint8_t> pixels{ 0, 0, 0, 1, 1, 1 };
-	std::vector<Color> palette(256, DiscreteColor::Blue);
-	palette[0] = DiscreteColor::Red;
+	std::vector<uint8_t> pixels{ 0, 0, 0, 0, 0, 0, 0, 0 };
+	std::vector<Color> palette(256, DiscreteColor::Black);
+	palette[0] = DiscreteColor::White;
 	
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 8, 3, -2, palette, pixels));
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 8, 3, 2, palette, pixels));
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels));
+
+	// Test padding 1 byte less than pitch
+	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0 };
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
+
+	// Test padding 1 byte greater than pitch
+	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
 
 	XFile::DeletePath(filename);
 }

--- a/test/Sprites/IndexedBmpWriter.test.cpp
+++ b/test/Sprites/IndexedBmpWriter.test.cpp
@@ -6,62 +6,56 @@
 #include <vector>
 #include <cstdint>
 
-TEST(IndexedBmpWriter, WriteMonochrome) 
+TEST(IndexedBmpWriter, Write)
 {
-	std::vector<Color> palette{ DiscreteColor::Black, DiscreteColor::White };
-	std::string filename = "Sprites/data/MonochromeTest.bmp";
+	const std::string filename = "Sprites/data/BitmapTest.bmp";
+	const std::vector<uint8_t> pixels(4, 0);
 
-	std::vector<uint8_t> pixels{ 128, 0, 0, 0, 128 , 0, 0, 0};
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 1, 2, palette, pixels));
+	std::vector<Color> palette(2);
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 1, 1, palette, pixels));
 
-	// Test padding 1 byte less than pitch
-	pixels = std::vector<uint8_t>{ 128, 0, 0, 128, 0, 0 };
-	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 2, palette, pixels), std::runtime_error);
+	palette.resize(16);
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 4, 1, 1, palette, pixels));
 
-	// Test padding 1 byte greater than pitch
-	pixels = std::vector<uint8_t>{ 128, 0, 0, 0, 0, 128 , 0, 0, 0, 0 };
-	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 2, palette, pixels), std::runtime_error);
+	palette.resize(256);
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 8, 1, 1, palette, pixels));
 
 	XFile::DeletePath(filename);
 }
 
-TEST(IndexedBmpWriter, Write4Bit)
+TEST(IndexedBmpWriter, InvalidBitCount)
 {
-	std::string filename = "Sprites/data/4BitTest.bmp";
-	std::vector<uint8_t> pixels{ 0, 0, 0, 0, 0, 0, 0, 0 };
-	std::vector<Color> palette(16, DiscreteColor::Black);
-	palette[0] = DiscreteColor::White;
+	const std::vector<Color> palette(8);
+	const std::vector<uint8_t> pixels(4, 0);
+	const std::string filename = "Sprites/data/MonochromeTest.bmp";
 
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 4, 1, 2, palette, pixels));
-
-	// Test padding 1 byte less than pitch
-	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0 };
-	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
-
-	// Test padding 1 byte greater than pitch
-	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 3, 1, 1, palette, pixels), std::runtime_error);
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 32, 1, 1, palette, pixels), std::runtime_error);
 
 	XFile::DeletePath(filename);
 }
 
-TEST(IndexedBmpWriter, Write8Bit)
+TEST(IndexedBmpWriter, TooManyPaletteEntries)
 {
-	std::string filename = "Sprites/data/8BitTest.bmp";
+	const std::vector<Color> palette(3);
+	const std::vector<uint8_t> pixels(4, 0);
+	const std::string filename("Sprites/data/PaletteRangeTest.bmp");
 
-	std::vector<uint8_t> pixels{ 0, 0, 0, 0, 0, 0, 0, 0 };
-	std::vector<Color> palette(256, DiscreteColor::Black);
-	palette[0] = DiscreteColor::White;
-	
-	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels));
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 1, palette, pixels), std::runtime_error);
 
-	// Test padding 1 byte less than pitch
-	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0 };
-	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
+	XFile::DeletePath(filename);
+}
 
-	// Test padding 1 byte greater than pitch
-	pixels = std::vector<uint8_t>{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-	EXPECT_THROW(IndexedBmpWriter::Write(filename, 8, 1, 2, palette, pixels), std::runtime_error);
+TEST(IndexedBmpWriter, IncorrectPixelPadding)
+{
+	const std::vector<Color> palette(2);
+	const std::string filename("Sprites/data/IncorrectPixelPaddingTest.bmp");
+
+	std::vector<uint8_t> pixels(3, 0);
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 1, palette, pixels), std::runtime_error);
+
+	pixels.resize(5, 0);
+	EXPECT_THROW(IndexedBmpWriter::Write(filename, 1, 1, 1, palette, pixels), std::runtime_error);
 
 	XFile::DeletePath(filename);
 }

--- a/test/Sprites/IndexedBmpWriter.test.cpp
+++ b/test/Sprites/IndexedBmpWriter.test.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include <cstdint>
 
-TEST(IndexedBmpWriter, Write)
+TEST(IndexedBmpWriter, WriteAllPalettizedBitDepths)
 {
 	const std::string filename = "Sprites/data/BitmapTest.bmp";
 	const std::vector<uint8_t> pixels(4, 0);
@@ -23,7 +23,7 @@ TEST(IndexedBmpWriter, Write)
 	XFile::DeletePath(filename);
 }
 
-TEST(IndexedBmpWriter, InvalidBitCount)
+TEST(IndexedBmpWriter, InvalidBitCountThrows)
 {
 	const std::vector<Color> palette(8);
 	const std::vector<uint8_t> pixels(4, 0);
@@ -35,7 +35,7 @@ TEST(IndexedBmpWriter, InvalidBitCount)
 	XFile::DeletePath(filename);
 }
 
-TEST(IndexedBmpWriter, TooManyPaletteEntries)
+TEST(IndexedBmpWriter, TooManyPaletteEntriesThrows)
 {
 	const std::vector<Color> palette(3);
 	const std::vector<uint8_t> pixels(4, 0);
@@ -46,7 +46,18 @@ TEST(IndexedBmpWriter, TooManyPaletteEntries)
 	XFile::DeletePath(filename);
 }
 
-TEST(IndexedBmpWriter, IncorrectPixelPadding)
+TEST(IndexedBmpWriter, WritePartiallyFilledPalette)
+{
+	const std::vector<Color> palette(1);
+	const std::vector<uint8_t> pixels(4, 0);
+	const std::string filename("Sprites/data/PaletteRangeTest.bmp");
+
+	EXPECT_NO_THROW(IndexedBmpWriter::Write(filename, 1, 1, 1, palette, pixels));
+
+	XFile::DeletePath(filename);
+}
+
+TEST(IndexedBmpWriter, IncorrectPixelPaddingThrows)
 {
 	const std::vector<Color> palette(2);
 	const std::string filename("Sprites/data/IncorrectPixelPaddingTest.bmp");


### PR DESCRIPTION
This push is bittersweet. It removes very large chunks of the IndexedBmpWriter code base. Some of that code I was proud of, but I do not believe it is needed in the final product.

I rewrote the test suite to be more specific in what is being tested. It still doesn't test if the BMP file is well formed, only if exceptions are properly raised or not raised based on data input. Perhaps this would be a good effort for another branch.

Closes #194 