### PR TITLE
Replace `fstream` with `ofstream` in `FileWriter`

### DIFF
--- a/src/Streams/FileWriter.h
+++ b/src/Streams/FileWriter.h
@@ -29,6 +29,6 @@ namespace Stream
 
 	private:
 		const std::string filename;
-		std::fstream file;
+		std::ofstream file;
 	};
 }


### PR DESCRIPTION
We only need to write to the file, so we should use the write specific class, rather than the more general read/write class.