### PR TITLE
Add OpenMode parameter to FileWriter constructor

### DIFF
--- a/src/Streams/FileWriter.cpp
+++ b/src/Streams/FileWriter.cpp
@@ -21,7 +21,7 @@ namespace Stream
 
 		// Translate flags to ios_base flags
 		std::ios_base::openmode iosOpenMode = std::ios_base::out | std::ios_base::binary;
-		if ((openMode & OpenMode::PreserveContents) == 0) {
+		if ((openMode & OpenMode::Truncate) != 0) {
 			iosOpenMode |= std::ios_base::trunc;
 		}
 		if ((openMode & OpenMode::Append) != 0) {

--- a/src/Streams/FileWriter.cpp
+++ b/src/Streams/FileWriter.cpp
@@ -5,21 +5,21 @@ namespace fs = std::experimental::filesystem;
 
 namespace Stream
 {
-	std::ios_base::openmode FileWriter::TranslateFlags(const std::string& filename, FileWriter::OpenMode openMode) {
+	std::ios_base::openmode FileWriter::TranslateFlags(const std::string& filename, OpenMode openMode) {
 		// Check for bad flag combinations
-		if ((openMode & FileWriter::OpenMode::FailIfExist) != 0 && (openMode & FileWriter::OpenMode::FailIfNoExist) != 0) {
-			throw std::invalid_argument("Bad open mode for file write. Can not specify file be both pre-existing and not pre-existing. Filename: " + filename);
+		if ((openMode & (OpenMode::CanOpenExisting | OpenMode::CanOpenNew)) == 0) {
+			throw std::invalid_argument("Bad open mode for file write. Must allow open to succeed for at least one of existing or new files. Filename: " + filename);
 		}
-		if ((openMode & FileWriter::OpenMode::Truncate) != 0 && (openMode & FileWriter::OpenMode::Append) != 0) {
+		if ((openMode & OpenMode::Truncate) != 0 && (openMode & OpenMode::Append) != 0) {
 			throw std::invalid_argument("Bad open mode for file write. Can not specify file be opened both for append, and to truncate existing contents. Filename: " + filename);
 		}
 
 		// File existance checks
-		if ((openMode & FileWriter::OpenMode::FailIfExist) != 0 && fs::exists(filename)) {
-			throw std::runtime_error("Bad open mode for file write. File required to be not pre-existing, but already exists. Filename: " + filename);
+		if ((openMode & OpenMode::CanOpenExisting) == 0 && fs::exists(filename)) {
+			throw std::runtime_error("Failed to open file for writing. Access to existing file not requested, and file already exists. Filename: " + filename);
 		}
-		if ((openMode & FileWriter::OpenMode::FailIfNoExist) != 0 && !fs::exists(filename)) {
-			throw std::runtime_error("Bad open mode for file write. File required to be pre-existing, but does not currently exist. Filename: " + filename);
+		if ((openMode & OpenMode::CanOpenNew) == 0 && !fs::exists(filename)) {
+			throw std::runtime_error("Failed to open file for writing. Access to open new file not requested, and file does not currently exist. Filename: " + filename);
 		}
 
 		// Translate flags to ios_base flags

--- a/src/Streams/FileWriter.cpp
+++ b/src/Streams/FileWriter.cpp
@@ -8,10 +8,10 @@ namespace Stream
 	std::ios_base::openmode FileWriter::TranslateFlags(const std::string& filename, FileWriter::OpenMode openMode) {
 		// Check for bad flag combinations
 		if ((openMode & FileWriter::OpenMode::FailIfExist) != 0 && (openMode & FileWriter::OpenMode::FailIfNoExist) != 0) {
-			throw std::runtime_error("Bad open mode for file write. Can not specify file be both pre-existing and not pre-existing. Filename: " + filename);
+			throw std::invalid_argument("Bad open mode for file write. Can not specify file be both pre-existing and not pre-existing. Filename: " + filename);
 		}
 		if ((openMode & FileWriter::OpenMode::Truncate) != 0 && (openMode & FileWriter::OpenMode::Append) != 0) {
-			throw std::runtime_error("Bad open mode for file write. Can not specify file be opened both for append, and to truncate existing contents. Filename: " + filename);
+			throw std::invalid_argument("Bad open mode for file write. Can not specify file be opened both for append, and to truncate existing contents. Filename: " + filename);
 		}
 
 		// File existance checks

--- a/src/Streams/FileWriter.cpp
+++ b/src/Streams/FileWriter.cpp
@@ -10,6 +10,9 @@ namespace Stream
 		if ((openMode & FileWriter::OpenMode::FailIfExist) != 0 && (openMode & FileWriter::OpenMode::FailIfNoExist) != 0) {
 			throw std::runtime_error("Bad open mode for file write. Can not specify file be both pre-existing and not pre-existing. Filename: " + filename);
 		}
+		if ((openMode & FileWriter::OpenMode::Truncate) != 0 && (openMode & FileWriter::OpenMode::Append) != 0) {
+			throw std::runtime_error("Bad open mode for file write. Can not specify file be opened both for append, and to truncate existing contents. Filename: " + filename);
+		}
 
 		// File existance checks
 		if ((openMode & FileWriter::OpenMode::FailIfExist) != 0 && fs::exists(filename)) {

--- a/src/Streams/FileWriter.h
+++ b/src/Streams/FileWriter.h
@@ -11,7 +11,16 @@ namespace Stream
 	class FileWriter : public SeekableWriter
 	{
 	public:
-		FileWriter(const std::string& filename);
+		// Open mode bit flags
+		enum OpenMode {
+			Default = 0,
+			FailIfExist = 0b0000'0001,
+			FailIfNoExist = 0b0000'0010,
+			PreserveContents = 0b0000'0100,
+			Append = 0b0000'1000,
+		};
+
+		FileWriter(const std::string& filename, OpenMode openMode = OpenMode::Default);
 		~FileWriter() override;
 
 		// SeekableWriter methods
@@ -26,6 +35,8 @@ namespace Stream
 
 	protected:
 		void WriteImplementation(const void* buffer, std::size_t size) override;
+
+		static std::ios_base::openmode TranslateFlags(const std::string& filename, OpenMode openMode);
 
 	private:
 		const std::string filename;

--- a/src/Streams/FileWriter.h
+++ b/src/Streams/FileWriter.h
@@ -21,6 +21,11 @@ namespace Stream
 			Default = CanOpenExisting | CanOpenNew | Truncate,
 		};
 
+		// Note: A Time-of-check to time-of-use race condition may exist when
+		// certain OpenMode flags are cleared:
+		//   CanOpenExisting
+		//   CanOpenNew
+		// If both flags are specified, no race condition can occur
 		FileWriter(const std::string& filename, OpenMode openMode = OpenMode::Default);
 		~FileWriter() override;
 

--- a/src/Streams/FileWriter.h
+++ b/src/Streams/FileWriter.h
@@ -13,11 +13,12 @@ namespace Stream
 	public:
 		// Open mode bit flags
 		enum OpenMode {
-			Default = 0,
 			FailIfExist = 0b0000'0001,
 			FailIfNoExist = 0b0000'0010,
-			PreserveContents = 0b0000'0100,
+			Truncate = 0b0000'0100,
 			Append = 0b0000'1000,
+
+			Default = Truncate,
 		};
 
 		FileWriter(const std::string& filename, OpenMode openMode = OpenMode::Default);

--- a/src/Streams/FileWriter.h
+++ b/src/Streams/FileWriter.h
@@ -13,12 +13,12 @@ namespace Stream
 	public:
 		// Open mode bit flags
 		enum OpenMode {
-			FailIfExist = 0b0000'0001,
-			FailIfNoExist = 0b0000'0010,
+			CanOpenExisting = 0b0000'0001,
+			CanOpenNew = 0b0000'0010,
 			Truncate = 0b0000'0100,
 			Append = 0b0000'1000,
 
-			Default = Truncate,
+			Default = CanOpenExisting | CanOpenNew | Truncate,
 		};
 
 		FileWriter(const std::string& filename, OpenMode openMode = OpenMode::Default);

--- a/test/Streams/FileWriter.test.cpp
+++ b/test/Streams/FileWriter.test.cpp
@@ -1,0 +1,55 @@
+#include "Streams/FileWriter.h"
+#include "XFile.h"
+#include <gtest/gtest.h>
+
+
+TEST(FileWriterOpenMode, BadFlagCombinations) {
+	using OpenMode = Stream::FileWriter::OpenMode;
+	const std::string filename("OpenModeBadFlagCombinations.temp");
+
+	// Must specify at least one of CanOpenExisting or CanOpenNew
+	EXPECT_THROW(Stream::FileWriter writer(filename, OpenMode::Truncate), std::invalid_argument);
+	// Can not specify both Truncate and Append
+	OpenMode mode = static_cast<OpenMode>(OpenMode::Truncate | OpenMode::Append);
+	EXPECT_THROW(Stream::FileWriter writer(filename, mode), std::invalid_argument);
+}
+
+TEST(FileWriterOpenMode, ImplicitDefaultFlags) {
+	// Default flags should allow opening new or existing files
+	const std::string filename("OpenModeImplicitDefaultFlags.temp");
+	EXPECT_NO_THROW(Stream::FileWriter writer(filename));  // File gets created (new)
+	EXPECT_NO_THROW(Stream::FileWriter writer(filename));  // File gets re-opened (existing)
+	XFile::DeletePath(filename);
+}
+
+TEST(FileWriterOpenMode, ExplicitDefaultFlags) {
+	using OpenMode = Stream::FileWriter::OpenMode;
+
+	// Default flags includes both CanOpenExisting and CanOpenNew
+	ASSERT_TRUE(OpenMode::Default & OpenMode::CanOpenExisting);
+	ASSERT_TRUE(OpenMode::Default & OpenMode::CanOpenNew);
+
+	// Open should always succeed when both existing and new files are allowed
+	const std::string filename("OpenModeExplicitDefaultFlags.temp");
+	ASSERT_NO_THROW(Stream::FileWriter writer(filename, OpenMode::Default));  // File gets created (new)
+	ASSERT_NO_THROW(Stream::FileWriter writer(filename, OpenMode::Default));  // File gets re-opened (existing)
+	XFile::DeletePath(filename);
+}
+
+TEST(FileWriterOpenMode, PermissionChecks) {
+	using OpenMode = Stream::FileWriter::OpenMode;
+	std::string filename("OpenModePermissionChecks.temp");
+
+	// Try to open new file without permission to create new files
+	ASSERT_THROW(Stream::FileWriter writer(filename, OpenMode::CanOpenExisting), std::runtime_error);
+
+	// Create new file, and then re-open existing file
+	EXPECT_NO_THROW(Stream::FileWriter writer(filename, OpenMode::CanOpenNew));
+	EXPECT_NO_THROW(Stream::FileWriter writer(filename, OpenMode::CanOpenExisting));
+
+	// Try to open existing file without permission for existing files
+	ASSERT_THROW(Stream::FileWriter writer(filename, OpenMode::CanOpenNew), std::runtime_error);
+
+	// Cleanup temporary file
+	XFile::DeletePath(filename);
+}


### PR DESCRIPTION
This implements open mode support for the constructor of the `FileWriter` stream class.

This is based partly on the old branch to add open modes. The old branch has grown stale, being half a year old, and files and classes have been moved and renamed since then. I figured a fresh branch would be easier to work with.

I think this matches the overall structure of what we need, though I would like a bit of feedback on some of the details.

I'm not entirely happy with the `OpenMode` names, and would appreciate some feedback there.

We should add documentation on race conditions with the file existence checks. Any thoughts on where or how to document this? Should this be a function level comment in the header file? For reference: [Time of Check to Time of Use (TOCTTOU)](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use)


Once we get this polished, this should close #22.
