### PR TITLE
Add XFile::GetDirectory tests

### DIFF
--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -180,7 +180,7 @@ std::string XFile::GetDirectory(const std::string& pathStr)
 	}
 
 	fs::path p(pathStr);
-	return p.parent_path().string() + "/";
+	return p.parent_path().generic_string() + "/";
 }
 
 void XFile::DeletePath(const std::string& pathStr)

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -172,22 +172,15 @@ bool XFile::PathsAreEqual(std::string pathStr1, std::string pathStr2)
 
 std::string XFile::GetDirectory(const std::string& pathStr)
 {
+	if (pathStr.size() == 0) {
+		return "";
+	}
+	if (pathStr.back() == '/') {
+		return pathStr;
+	}
+
 	fs::path p(pathStr);
-
-	if (p.has_relative_path())
-	{
-		if (p.relative_path() == p.filename()) {
-			return "./";
-		}
-
-		return p.remove_filename().relative_path().string();
-	}
-
-	if (p.has_root_path()) {
-		return p.remove_filename().root_path().string();
-	}
-
-	return "./";
+	return p.parent_path().string() + "/";
 }
 
 void XFile::DeletePath(const std::string& pathStr)

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="Streams\FileReader.test.cpp" />
     <ClCompile Include="Streams\FileSliceReader.test.cpp" />
     <ClCompile Include="Streams\MemoryStreamReader.test.cpp" />
+    <ClCompile Include="XFile.test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OP2Utility.vcxproj">

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -44,6 +44,7 @@
     <ClCompile Include="Bitmaps\BitmapFile.test.cpp">
       <Filter>Bitmaps</Filter>
     </ClCompile>
+    <ClCompile Include="XFile.test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -28,7 +28,8 @@ TEST(XFileGetDirectory, PosixAbsolutePathToDirectory) {
 	EXPECT_EQ("/a/b/", XFile::GetDirectory("/a/b/"));
 }
 
-#ifdef _WIN32
+// The follow two tests use paths that only apply to Windows (yet still pass on Linux)
+
 TEST(XFileGetDirectory, WindowsAbsolutePathToFile) {
 	EXPECT_EQ("C:/a/", XFile::GetDirectory("C:/a/file.ext"));
 	EXPECT_EQ("C:/a/b/", XFile::GetDirectory("C:/a/b/file.ext"));
@@ -38,7 +39,6 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 	EXPECT_EQ("C:/a/", XFile::GetDirectory("C:/a/"));
 	EXPECT_EQ("C:/a/b/", XFile::GetDirectory("C:/a/b/"));
 }
-#endif
 
 
 TEST(XFileGetFilesFromDirectory, EmptyPath) {

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -1,5 +1,7 @@
 #include "../src/XFile.h"
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <regex>
 
 
 TEST(XFileGetDirectory, EmptyPath) {
@@ -37,3 +39,16 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 	EXPECT_EQ("C:/a/b/", XFile::GetDirectory("C:/a/b/"));
 }
 #endif
+
+
+TEST(XFileGetFilesFromDirectory, EmptyPath) {
+	EXPECT_THAT(XFile::GetFilesFromDirectory(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilesFromDirectory("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+}
+
+TEST(XFileGetFilesFromDirectory, ExplicitCurrentDirectory) {
+	EXPECT_THAT(XFile::GetFilesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+}

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -1,0 +1,9 @@
+#include "../src/XFile.h"
+#include <gtest/gtest.h>
+
+
+TEST(XFile, GetDirectory) {
+	// Relative path to file
+	EXPECT_EQ("a/", XFile::GetDirectory("a/file.ext"));
+	EXPECT_EQ("a/b/", XFile::GetDirectory("a/b/file.ext"));
+}

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -2,8 +2,38 @@
 #include <gtest/gtest.h>
 
 
-TEST(XFile, GetDirectory) {
-	// Relative path to file
+TEST(XFileGetDirectory, EmptyPath) {
+	EXPECT_EQ("", XFile::GetDirectory(""));
+}
+
+TEST(XFileGetDirectory, RelativePathToFile) {
 	EXPECT_EQ("a/", XFile::GetDirectory("a/file.ext"));
 	EXPECT_EQ("a/b/", XFile::GetDirectory("a/b/file.ext"));
 }
+
+TEST(XFileGetDirectory, RelativePathToDirectory) {
+	EXPECT_EQ("a/", XFile::GetDirectory("a/"));
+	EXPECT_EQ("a/b/", XFile::GetDirectory("a/b/"));
+}
+
+TEST(XFileGetDirectory, PosixAbsolutePathToFile) {
+	EXPECT_EQ("/a/", XFile::GetDirectory("/a/file.ext"));
+	EXPECT_EQ("/a/b/", XFile::GetDirectory("/a/b/file.ext"));
+}
+
+TEST(XFileGetDirectory, PosixAbsolutePathToDirectory) {
+	EXPECT_EQ("/a/", XFile::GetDirectory("/a/"));
+	EXPECT_EQ("/a/b/", XFile::GetDirectory("/a/b/"));
+}
+
+#ifdef _WIN32
+TEST(XFileGetDirectory, WindowsAbsolutePathToFile) {
+	EXPECT_EQ("C:/a/", XFile::GetDirectory("C:/a/file.ext"));
+	EXPECT_EQ("C:/a/b/", XFile::GetDirectory("C:/a/b/file.ext"));
+}
+
+TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
+	EXPECT_EQ("C:/a/", XFile::GetDirectory("C:/a/"));
+	EXPECT_EQ("C:/a/b/", XFile::GetDirectory("C:/a/b/"));
+}
+#endif

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -1,7 +1,11 @@
 #include "../src/XFile.h"
 #include <gtest/gtest.h>
+
+// Disable due to lack of Google Mock in the Windows CI environment
+#ifndef _WIN32
 #include <gmock/gmock.h>
 #include <regex>
+#endif
 
 
 TEST(XFileGetDirectory, EmptyPath) {

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -41,6 +41,8 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 }
 
 
+// Disable due to lack of Google Mock in the Windows CI environment
+#ifndef _WIN32
 TEST(XFileGetFilesFromDirectory, EmptyPath) {
 	EXPECT_THAT(XFile::GetFilesFromDirectory(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
@@ -52,3 +54,4 @@ TEST(XFileGetFilesFromDirectory, ExplicitCurrentDirectory) {
 	EXPECT_THAT(XFile::GetFilesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
+#endif


### PR DESCRIPTION
This should close #215.

Please review or adjust the tests based on expected return values.

Feel free to expand the tests for missing cases.

----

For the test names, I was uncertain if I should put the "GetDirectory" part as part of the first parameter or the second parameter. I would appreciate some feedback on that.

Ex:
```cpp
TEST(XFileGetDirectory, EmptyPath) {
```

Versus:
```cpp
TEST(XFile, GetDirectoryEmptyPath) {
```
