### PR TITLE
Remove ClmHeader constructors

### DIFF
--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -245,7 +245,7 @@ namespace Archives
 		const WaveFormatEx& waveFormat)
 	{
 		// ClmFile cannot contain more than 32 bit size internal file count.
-		ClmHeader header(waveFormat, static_cast<uint32_t>(names.size()));
+		ClmHeader header = ClmHeader::MakeHeader(waveFormat, static_cast<uint32_t>(names.size()));
 
 		Stream::FileWriter clmFileWriter(archiveFilename);
 
@@ -315,12 +315,16 @@ namespace Archives
 	const std::array<char, 32> standardFileVersion { "OP2 Clump File Version 1.0\x01A\0\0\0\0" };
 	const std::array<char, 6> standardUnknown { 0, 0, 0, 0, 1, 0 };
 
-	ClmFile::ClmHeader::ClmHeader(WaveFormatEx waveFormat, uint32_t packedFilesCount) {
-		fileVersion = standardFileVersion;
-		unknown = standardUnknown;
+	ClmFile::ClmHeader ClmFile::ClmHeader::MakeHeader(WaveFormatEx waveFormat, uint32_t packedFilesCount) {
+		ClmHeader header;
 
-		this->waveFormat = waveFormat;
-		this->packedFilesCount = packedFilesCount;
+		header.fileVersion = standardFileVersion;
+		header.unknown = standardUnknown;
+
+		header.waveFormat = waveFormat;
+		header.packedFilesCount = packedFilesCount;
+
+		return header;
 	}
 
 	bool ClmFile::ClmHeader::CheckFileVersion() const {

--- a/src/Archives/ClmFile.cpp
+++ b/src/Archives/ClmFile.cpp
@@ -316,15 +316,7 @@ namespace Archives
 	const std::array<char, 6> standardUnknown { 0, 0, 0, 0, 1, 0 };
 
 	ClmFile::ClmHeader ClmFile::ClmHeader::MakeHeader(WaveFormatEx waveFormat, uint32_t packedFilesCount) {
-		ClmHeader header;
-
-		header.fileVersion = standardFileVersion;
-		header.unknown = standardUnknown;
-
-		header.waveFormat = waveFormat;
-		header.packedFilesCount = packedFilesCount;
-
-		return header;
+		return ClmHeader{ standardFileVersion,  waveFormat, standardUnknown, packedFilesCount };
 	}
 
 	bool ClmFile::ClmHeader::CheckFileVersion() const {

--- a/src/Archives/ClmFile.h
+++ b/src/Archives/ClmFile.h
@@ -34,9 +34,6 @@ namespace Archives
 #pragma pack(push, 1)
 		struct ClmHeader
 		{
-			ClmHeader() {};
-			ClmHeader(WaveFormatEx waveFormatEx, uint32_t packFileCount);
-
 			std::array<char, 32> fileVersion;
 			WaveFormatEx waveFormat;
 			std::array<char, 6> unknown;
@@ -47,6 +44,8 @@ namespace Archives
 
 			void VerifyFileVersion() const; // Exception raised if invalid version
 			void VerifyUnknown() const; // Exception raised if invalid version
+
+			static ClmHeader MakeHeader(WaveFormatEx waveFormatEx, uint32_t packFileCount);
 		};
 
 		static_assert(42 + sizeof(WaveFormatEx) == sizeof(ClmHeader), "ClmHeader is an unexpected size");


### PR DESCRIPTION
Replace non-trivial constructor with static factory method.

@Brett208, please check if this addresses the warnings from Issue #217.
