### PR TITLE
Update CircleCI Dockerfile

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -22,12 +22,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Google Test
+# Install Google Test (source package and build dependencies)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     libgtest-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# Compile and install Google Test
 ARG gtestBuildDir=/tmp/gtest/
 RUN mkdir -p ${gtestBuildDir} && \
   cd ${gtestBuildDir} && \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,17 +1,17 @@
 # For building on CircleCI with Google Test
 
 # Build from the root project folder with:
-#   docker build .circleci/ --tag outpostuniverse/circleci-gcc-googletest
+#   docker build .circleci/ --tag outpostuniverse/circleci-gcc-clang-googletest
 # Push image to DockerHub with:
 #   docker login
-#   docker push outpostuniverse/circleci-gcc-googletest
+#   docker push outpostuniverse/circleci-gcc-clang-googletest
 
 # Run locally using the CircleCI command line interface:
 #   circleci build
 # Validate .circleci/config.yml file with:
 #   circleci config validate
 
-FROM gcc:8
+FROM ubuntu:18.04
 
 # Install CircleCI tools needed for primary containers
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,6 +20,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tar \
     gzip \
     ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install gcc and clang compilers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Google Test (source package and build dependencies)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: outpostuniverse/circleci-gcc-googletest
+      - image: outpostuniverse/circleci-gcc-clang-googletest
     steps:
       - checkout
       - run: make -k CXX=g++

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,5 @@ jobs:
       - image: outpostuniverse/circleci-gcc-clang-googletest
     steps:
       - checkout
-      - run: make -k CXX=g++
-      - run: make check CXX=g++
+      - run: make -k CXX=clang++
+      - run: make check CXX=clang++


### PR DESCRIPTION
Add Clang to the Docker image, and switch to Clang as the default compiler in the CircleCI config.yml.

Image supports building with either Clang or GCC. Image includes Google Test with Google Mock.

This image is a bit larger than before, so that may slow builds slightly, though more can be done with this single image.
