### PR TITLE
Add CircleCI Workflows for both GCC and Clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,24 @@
 version: 2
+
 jobs:
-  build:
+  gcc:
+    docker:
+      - image: outpostuniverse/circleci-gcc-clang-googletest
+    steps:
+      - checkout
+      - run: make -k CXX=g++
+      - run: make check CXX=g++
+  clang:
     docker:
       - image: outpostuniverse/circleci-gcc-clang-googletest
     steps:
       - checkout
       - run: make -k CXX=clang++
       - run: make check CXX=clang++
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - gcc
+      - clang


### PR DESCRIPTION
This enables CircleCI to run builds with both GCC and Clang, and potentially in parallel.