### PR TITLE
Add Google Mock on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   # Use -k to continue after errors, ensuring full build log with all errors
   - make -k
   - make gtest
+  - make gmock
   - make check
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
-            - libgtest-dev
             - google-mock
     - os: linux
       env: CXX=clang++-6.0 CC=clang-6.0
@@ -23,13 +22,11 @@ matrix:
           packages:
             - clang-6.0
             - libstdc++-6-dev
-            - libgtest-dev
             - google-mock
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors
   - make -k
-  - make gtest
   - make gmock
   - make check
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
           packages:
             - g++-6
             - libgtest-dev
+            - google-mock
     - os: linux
       env: CXX=clang++-6.0 CC=clang-6.0
       addons:
@@ -23,6 +24,7 @@ matrix:
             - clang-6.0
             - libstdc++-6-dev
             - libgtest-dev
+            - google-mock
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors

--- a/makefile
+++ b/makefile
@@ -56,12 +56,19 @@ clean-all:
 
 
 GTESTDIR := $(BUILDDIR)/gtest
+GMOCKDIR := $(BUILDDIR)/gmock
 
 .PHONY:gtest
 gtest:
 	mkdir -p $(GTESTDIR)
-	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/gtest/
+	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gtest/
 	make -C $(GTESTDIR)
+
+.PHONY:gmock
+gmock:
+	mkdir -p $(GMOCKDIR)
+	cd $(GMOCKDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gmock/
+	make -C $(GMOCKDIR)
 
 
 TESTDIR := test
@@ -69,7 +76,7 @@ TESTOBJDIR := $(BUILDDIR)/testObj
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
-TESTLDFLAGS := -L./ -L$(GTESTDIR)
+TESTLDFLAGS := -L./ -L$(GTESTDIR) -L$(GMOCKDIR)
 TESTLIBS := -lgtest -lgtest_main -lpthread -lOP2Utility -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 

--- a/makefile
+++ b/makefile
@@ -55,33 +55,44 @@ clean-all:
 	-rm -rf $(BUILDDIR)
 
 
+# Either of these should be a complete combined package. Only build one.
+GTESTSRCDIR := /usr/src/gtest/
+GMOCKSRCDIR := /usr/src/gmock/
 GTESTDIR := $(BUILDDIR)/gtest
 GMOCKDIR := $(BUILDDIR)/gmock
 
 .PHONY:gtest
 gtest:
 	mkdir -p $(GTESTDIR)
-	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gtest/
+	cd $(GTESTDIR) && cmake -DCMAKE_CXX="$(CXX)" -DCMAKE_CXX_FLAGS="-std=c++17" $(GTESTSRCDIR)
 	make -C $(GTESTDIR)
 
 .PHONY:gmock
 gmock:
 	mkdir -p $(GMOCKDIR)
-	cd $(GMOCKDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gmock/
+	cd $(GMOCKDIR) && cmake -DCMAKE_CXX="$(CXX)" -DCMAKE_CXX_FLAGS="-std=c++17" $(GMOCKSRCDIR)
 	make -C $(GMOCKDIR)
 
+# This is used to detect if a separate GMock library was built, in which case, use it
+GMOCKLIB := $(wildcard $(GMOCKDIR)/libgmock.a)
 
 TESTDIR := test
 TESTOBJDIR := $(BUILDDIR)/testObj
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
-TESTLDFLAGS := -L./ -L$(GTESTDIR) -L$(GMOCKDIR)
-TESTLIBS := -lgtest -lgtest_main -lpthread -lOP2Utility -lstdc++fs
+TESTCPPFLAGS := -I$(SRCDIR) -I$(GMOCKSRCDIR)/gtest/include
+TESTLDFLAGS := -L./ -L$(GMOCKDIR) -L$(GMOCKDIR)/gtest/ -L$(GTESTDIR)
+TESTLIBS := -lOP2Utility -lgtest -lgtest_main -lpthread -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
+# Conditionally add GMock if we built it separately
+# This is conditional to avoid errors in case the library is not found
+ifneq ($(strip $(GMOCKLIB)),)
+	TESTLIBS := -lgmock $(TESTLIBS)
+endif
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td
-TESTCOMPILE.cpp = $(CXX) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
+TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
 TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 
 .PHONY:check


### PR DESCRIPTION
This adds support for using the older `google-mock` Apt package on Ubuntu 14.04. This package contains both Google Mock and Google Test.

The newer `libgtest-dev` package can continue to be used on newer distributions (Ubuntu 16.04, 18.04). This package also contains both Google Test and Google Mock, and in a more standard layout. Unfortunately this newer package does not exist on Ubuntu 14.04, which TravisCI still uses.
