### PR TITLE
Make map version check throw instead of log to cerr

### DIFF
--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -95,7 +95,11 @@ void Map::ReadVersionTag(Stream::Reader& streamReader)
 
 	if (versionTag < MapHeader::MinMapVersion)
 	{
-		std::cerr << "All instances of version tag in .map and .op2 files should be greater than " + std::to_string(MapHeader::MinMapVersion);
+		throw std::runtime_error(
+			"All instances of version tag in .map and .op2 files should be greater than " +
+			std::to_string(MapHeader::MinMapVersion) + ".\n" +
+			"Found version tag is " + std::to_string(versionTag) + "."
+		);
 	}
 }
 


### PR DESCRIPTION
Parsing should stop when a bad version number is found, so throwing is more appropriate. It also allows the caller to control how and where output is displayed, which logging to `cerr` doesn't.

Added additional diagnostic output to error message.

This update relates to issue #239, but doesn't solve it. This change should be considered separate.
