### PR TITLE
Allow Map::Read to read saved game portions without crashing

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -131,6 +131,7 @@
     <ClInclude Include="src\Map\CellType.h" />
     <ClInclude Include="src\Map\Map.h" />
     <ClInclude Include="src\Map\MapHeader.h" />
+    <ClInclude Include="src\Map\SavedGameDataSection2.h" />
     <ClInclude Include="src\Map\TerrainType.h" />
     <ClInclude Include="src\Map\TileData.h" />
     <ClInclude Include="src\Map\TileGroup.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -171,6 +171,9 @@
     <ClInclude Include="src\Map\Map.h">
       <Filter>Map</Filter>
     </ClInclude>
+    <ClInclude Include="src\Map\SavedGameDataSection2.h">
+      <Filter>Map</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\XFile.cpp">

--- a/src/Map/Map.cpp
+++ b/src/Map/Map.cpp
@@ -55,3 +55,15 @@ std::size_t Map::GetTileIndex(std::size_t x, std::size_t y) const
 	auto upperX = x >> 5;   // ... 1110 0000
 	return (upperX * mapTileHeight + y) * 32 + lowerX;
 }
+
+void Map::CheckMinVersionTag(uint32_t versionTag)
+{
+	if (versionTag < MapHeader::MinMapVersion)
+	{
+		throw std::runtime_error(
+			"All instances of version tag in .map and .op2 files should be greater than " +
+			std::to_string(MapHeader::MinMapVersion) + ".\n" +
+			"Found version tag is " + std::to_string(versionTag) + "."
+		);
+	}
+}

--- a/src/Map/Map.cpp
+++ b/src/Map/Map.cpp
@@ -2,6 +2,7 @@
 #include "MapHeader.h"
 #include "CellType.h"
 #include <algorithm>
+#include <stdexcept>
 
 Map::Map() :
 	versionTag(MapHeader::MinMapVersion),

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -97,7 +97,7 @@ private:
 	static void WriteContainerSize(Stream::Writer& streamWriter, std::size_t size);
 
 	// Read
-	static Map Map::ReadMapBeginning(Stream::Reader& streamReader);
+	static Map ReadMapBeginning(Stream::Reader& streamReader);
 	static void SkipSaveGameHeader(Stream::SeekableReader& streamReader);
 	static void ReadTilesetSources(Stream::Reader& streamReader, Map& map, std::size_t tilesetCount);
 	static void ReadTilesetHeader(Stream::Reader& streamReader);

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -34,7 +34,7 @@ public:
 	Map();
 
 	static Map ReadMap(std::string filename);
-	static Map ReadMap(Stream::SeekableReader& seekableReader);
+	static Map ReadMap(Stream::Reader& seekableReader);
 	static Map ReadSavedGame(std::string filename);
 	static Map ReadSavedGame(Stream::SeekableReader& seekableReader);
 
@@ -95,11 +95,12 @@ private:
 	static void WriteContainerSize(Stream::Writer& streamWriter, std::size_t size);
 
 	// Read
+	static Map Map::ReadMapBeginning(Stream::Reader& streamReader);
 	static void SkipSaveGameHeader(Stream::SeekableReader& streamReader);
 	static void ReadTilesetSources(Stream::Reader& streamReader, Map& map, std::size_t tilesetCount);
 	static void ReadTilesetHeader(Stream::Reader& streamReader);
 	static void ReadVersionTag(Stream::Reader& streamReader);
-	static void ReadSavedGameSecondChunk(Stream::SeekableReader& streamReader);
+	static void ReadSavedGameSection2(Stream::SeekableReader& streamReader);
 	static void ReadTileGroups(Stream::Reader& streamReader, Map& map);
 	static TileGroup ReadTileGroup(Stream::Reader& streamReader);
 };

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -101,7 +101,7 @@ private:
 	static void SkipSaveGameHeader(Stream::SeekableReader& streamReader);
 	static void ReadTilesetSources(Stream::Reader& streamReader, Map& map, std::size_t tilesetCount);
 	static void ReadTilesetHeader(Stream::Reader& streamReader);
-	static void ReadVersionTag(Stream::Reader& streamReader);
+	static void ReadVersionTag(Stream::Reader& streamReader, uint32_t lastVersionTag);
 	static void ReadSavedGameSection2(Stream::SeekableReader& streamReader);
 	static void ReadTileGroups(Stream::Reader& streamReader, Map& map);
 	static TileGroup ReadTileGroup(Stream::Reader& streamReader);

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -77,6 +77,8 @@ public:
 	std::size_t GetTilesetIndex(std::size_t x, std::size_t y) const;
 	std::size_t GetImageIndex(std::size_t x, std::size_t y) const;
 
+	static void CheckMinVersionTag(uint32_t versionTag);
+
 	void TrimTilesetSources();
 
 private:

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -34,7 +34,7 @@ public:
 	Map();
 
 	static Map ReadMap(std::string filename);
-	static Map ReadMap(Stream::Reader& seekableReader);
+	static Map ReadMap(Stream::SeekableReader& seekableReader);
 	static Map ReadSavedGame(std::string filename);
 	static Map ReadSavedGame(Stream::SeekableReader& seekableReader);
 
@@ -99,6 +99,7 @@ private:
 	static void ReadTilesetSources(Stream::Reader& streamReader, Map& map, std::size_t tilesetCount);
 	static void ReadTilesetHeader(Stream::Reader& streamReader);
 	static void ReadVersionTag(Stream::Reader& streamReader);
+	static void ReadSavedGameSecondChunk(Stream::SeekableReader& streamReader);
 	static void ReadTileGroups(Stream::Reader& streamReader, Map& map);
 	static TileGroup ReadTileGroup(Stream::Reader& streamReader);
 };

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -62,6 +62,7 @@ Map Map::ReadMapBeginning(Stream::Reader& streamReader)
 {
 	MapHeader mapHeader;
 	streamReader.Read(mapHeader);
+	CheckMinVersionTag(mapHeader.versionTag);
 
 	Map map;
 	map.versionTag = mapHeader.versionTag;
@@ -114,14 +115,7 @@ void Map::ReadVersionTag(Stream::Reader& streamReader)
 	uint32_t versionTag;
 	streamReader.Read(versionTag);
 
-	if (versionTag < MapHeader::MinMapVersion)
-	{
-		throw std::runtime_error(
-			"All instances of version tag in .map and .op2 files should be greater than " +
-			std::to_string(MapHeader::MinMapVersion) + ".\n" +
-			"Found version tag is " + std::to_string(versionTag) + "."
-		);
-	}
+	CheckMinVersionTag(versionTag);
 }
 
 void Map::ReadSavedGameSection2(Stream::SeekableReader& streamReader)

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -144,8 +144,8 @@ void Map::ReadSavedGameSection2(Stream::SeekableReader& streamReader)
 	streamReader.Read(savedGameData.unitID1);
 	streamReader.Read(savedGameData.unitID2);
 
-	//streamReader.Read(savedGameData.unitRecord);
-	streamReader.SeekRelative(0x3BF88);
+	savedGameData.unitRecord.resize(2047);
+	streamReader.Read(savedGameData.unitRecord);
 }
 
 void Map::ReadTileGroups(Stream::Reader& streamReader, Map& map)

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -144,7 +144,6 @@ void Map::ReadSavedGameSection2(Stream::SeekableReader& streamReader)
 	streamReader.Read(savedGameData.unitID1);
 	streamReader.Read(savedGameData.unitID2);
 
-	savedGameData.unitRecord.resize(2047);
 	streamReader.Read(savedGameData.unitRecord);
 }
 

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -19,8 +19,8 @@ Map Map::ReadMap(Stream::Reader& streamReader)
 {
 	Map map = ReadMapBeginning(streamReader);
 
-	ReadVersionTag(streamReader);
-	ReadVersionTag(streamReader);
+	ReadVersionTag(streamReader, map.versionTag);
+	ReadVersionTag(streamReader, map.versionTag);
 
 	ReadTileGroups(streamReader, map);
 
@@ -39,11 +39,11 @@ Map Map::ReadSavedGame(Stream::SeekableReader& streamReader)
 
 	Map map = ReadMapBeginning(streamReader);
 	
-	ReadVersionTag(streamReader);
+	ReadVersionTag(streamReader, map.versionTag);
 
 	ReadSavedGameSection2(streamReader);
 	
-	ReadVersionTag(streamReader);
+	ReadVersionTag(streamReader, map.versionTag);
 
 	// TODO: Read data after final version tag.
 
@@ -110,12 +110,17 @@ void Map::ReadTilesetSources(Stream::Reader& streamReader, Map& map, std::size_t
 	}
 }
 
-void Map::ReadVersionTag(Stream::Reader& streamReader)
+void Map::ReadVersionTag(Stream::Reader& streamReader, uint32_t lastVersionTag)
 {
-	uint32_t versionTag;
-	streamReader.Read(versionTag);
+	uint32_t nextVersionTag;
+	streamReader.Read(nextVersionTag);
 
-	CheckMinVersionTag(versionTag);
+	CheckMinVersionTag(nextVersionTag);
+
+	if (nextVersionTag != lastVersionTag) {
+		throw std::runtime_error("Mismatched version tags detected. Version tag 1: " + 
+			std::to_string(lastVersionTag) + ". Version tag 2: " + std::to_string(nextVersionTag));
+	}
 }
 
 void Map::ReadSavedGameSection2(Stream::SeekableReader& streamReader)

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -136,7 +136,7 @@ void Map::ReadSavedGameSection2(Stream::SeekableReader& streamReader)
 	streamReader.Read(savedGameData.objectCount1);
 	streamReader.Read(savedGameData.objectCount2);
 
-	savedGameData.objects1.resize(512 * savedGameData.objectCount1);
+	savedGameData.objects1.resize(savedGameData.objectCount1);
 	streamReader.Read(savedGameData.objects1);
 	savedGameData.objects2.resize(savedGameData.objectCount2);
 	streamReader.Read(savedGameData.objects2);

--- a/src/Map/SavedGameDataSection2.h
+++ b/src/Map/SavedGameDataSection2.h
@@ -10,6 +10,12 @@ struct ObjectType1
 	std::array<uint8_t, 512> data;
 };
 
+// Placeholder struct for unit data
+struct UnitRecord
+{
+	std::array<uint8_t, 120> data;
+};
+
 // Second section of saved game specifc data (not included in .map files)
 struct SavedGameDataSection2
 {
@@ -24,5 +30,5 @@ struct SavedGameDataSection2
 	std::vector<uint32_t> objects2;
 	uint32_t unitID1;
 	uint32_t unitID2;
-	std::vector<uint8_t> unitRecord;
+	std::vector<UnitRecord> unitRecord;
 };

--- a/src/Map/SavedGameDataSection2.h
+++ b/src/Map/SavedGameDataSection2.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+// Second section of saved game specifc data (not included in .map files)
+struct SavedGameDataSection2
+{
+	uint32_t unitCount;
+	uint32_t unknown1;
+	uint32_t unknown2;
+	uint32_t unknown3;
+	uint32_t sizeOfUnit;
+	uint32_t objectCount1;
+	uint32_t objectCount2;
+	std::vector<uint8_t> objects1;
+	std::vector<uint32_t> objects2;
+	uint32_t unitID1;
+	uint32_t unitID2;
+	std::vector<uint8_t> unitRecord;
+};

--- a/src/Map/SavedGameDataSection2.h
+++ b/src/Map/SavedGameDataSection2.h
@@ -2,6 +2,13 @@
 
 #include <cstdint>
 #include <vector>
+#include <array>
+
+// Placeholder for unknown object
+struct ObjectType1
+{
+	std::array<uint8_t, 512> data;
+};
 
 // Second section of saved game specifc data (not included in .map files)
 struct SavedGameDataSection2
@@ -13,7 +20,7 @@ struct SavedGameDataSection2
 	uint32_t sizeOfUnit;
 	uint32_t objectCount1;
 	uint32_t objectCount2;
-	std::vector<uint8_t> objects1;
+	std::vector<ObjectType1> objects1;
 	std::vector<uint32_t> objects2;
 	uint32_t unitID1;
 	uint32_t unitID2;

--- a/src/Map/SavedGameDataSection2.h
+++ b/src/Map/SavedGameDataSection2.h
@@ -30,5 +30,5 @@ struct SavedGameDataSection2
 	std::vector<uint32_t> objects2;
 	uint32_t unitID1;
 	uint32_t unitID2;
-	std::vector<UnitRecord> unitRecord;
+	std::array<UnitRecord, 2047> unitRecord;
 };


### PR DESCRIPTION
I'm not sure our documentation is correct for a saved game after unitID2 is read. However, this will parse without throwing an error and properly reads in map data from a saved game.

-Brett