### PR TITLE
Fix msvc bug in x file get files from directory

### DIFF
--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -71,6 +71,11 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 	// Brett208 6Aug17: Creating a path with an empty string will prevent the directory_iterator from finding files in the current relative path.
 	auto pathStr = directory.length() > 0 ? directory : "./";
 
+	// 20Jan19: On MSVC, the directory_iterator will not find files if passed '/'.
+	if (pathStr == "/") {
+		pathStr = "./";
+	}
+
 	std::vector<std::string> filenames;
 	for (const auto& entry : fs::directory_iterator(pathStr)) {
 		filenames.push_back(entry.path().string());

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -68,5 +68,10 @@ TEST(XFileGetFilesFromDirectory, ExplicitCurrentDirectory) {
 	EXPECT_THAT(XFile::GetFilesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	
+	
+	EXPECT_THAT(XFile::GetFilesFromDirectory("/"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilesFromDirectory("/", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilesFromDirectory("/", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 #endif


### PR DESCRIPTION
Typing OP2MapImager sgame6.op2 does not work on MSVC. The ResourceManager cannot find any archives because it is passed a relative directory of '/' (not './').