### PR TITLE
Fix GetDirectory

### DIFF
--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -178,7 +178,11 @@ std::string XFile::GetDirectory(const std::string& pathStr)
 	}
 
 	fs::path p(pathStr);
-	return p.parent_path().generic_string() + "/";
+	auto returnPathStr = p.parent_path().generic_string();
+	if (returnPathStr.size() > 0) {
+		returnPathStr += "/";
+	}
+	return returnPathStr;
 }
 
 void XFile::DeletePath(const std::string& pathStr)

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -23,6 +23,11 @@ TEST(XFileGetDirectory, EmptyPath) {
 	EXPECT_EQ("", XFile::GetDirectory(""));
 }
 
+TEST(XFileGetDirectory, OnlyFile) {
+	EXPECT_EQ("", XFile::GetDirectory("file.ext"));
+	EXPECT_EQ("", XFile::GetDirectory(".ext"));
+}
+
 TEST(XFileGetDirectory, RelativePathToFile) {
 	EXPECT_EQ("a/", XFile::GetDirectory("a/file.ext"));
 	EXPECT_EQ("a/b/", XFile::GetDirectory("a/b/file.ext"));


### PR DESCRIPTION
Seems I wrote a bug into `GetDirectory` when I (unconditionally) added the trailing "/". I also missed the test case that checks only a filename with no path component, which highlights this bug.

I believe this is the root cause of the problem from PR #243.
