### PR TITLE
Strip directory from GetFilenamesFromDirectory Return

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -10,13 +10,13 @@ using namespace Archive;
 ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 	resourceRootDir(archiveDirectory)
 {
-	auto volFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".vol");
+	auto volFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".vol");
 
 	for (const auto& volFilename : volFilenames) {
 		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename));
 	}
 
-	auto clmFilenames = XFile::GetFilesFromDirectory(archiveDirectory, ".clm");
+	auto clmFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".clm");
 
 	for (const auto& clmFilename : clmFilenames) {
 		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename));
@@ -53,7 +53,7 @@ std::vector<std::string> ResourceManager::GetAllFilenames(const std::string& fil
 {
 	std::regex filenameRegex(filenameRegexStr, std::regex_constants::icase);
 
-	std::vector<std::string> filenames = XFile::GetFilesFromDirectory(resourceRootDir, filenameRegex);
+	std::vector<std::string> filenames = XFile::GetFilenamesFromDirectory(resourceRootDir, filenameRegex);
 
 	if (!accessArchives) {
 		return filenames;
@@ -74,7 +74,7 @@ std::vector<std::string> ResourceManager::GetAllFilenames(const std::string& fil
 
 std::vector<std::string> ResourceManager::GetAllFilenamesOfType(const std::string& extension, bool accessArchives)
 {
-	std::vector<std::string> filenames = XFile::GetFilesFromDirectory(resourceRootDir, extension);
+	std::vector<std::string> filenames = XFile::GetFilenamesFromDirectory(resourceRootDir, extension);
 
 	if (!accessArchives) {
 		return filenames;

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -75,22 +75,22 @@ std::string XFile::AppendToFilename(const std::string& filename, const std::stri
 	return newPath.string();
 }
 
-std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directory)
+std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& directory)
 {
 	// Brett208 6Aug17: Creating a path with an empty string will prevent the directory_iterator from finding files in the current relative path.
 	auto pathStr = directory.length() > 0 ? directory : "./";
 
 	std::vector<std::string> filenames;
 	for (const auto& entry : fs::directory_iterator(pathStr)) {
-		filenames.push_back(entry.path().string());
+		filenames.push_back(GetFilename(entry.path().generic_string()));
 	}
 
 	return filenames;
 }
 
-std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directory, const std::regex& filenameRegex)
+std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& directory, const std::regex& filenameRegex)
 {
-	std::vector<std::string> filenames = GetFilesFromDirectory(directory);
+	std::vector<std::string> filenames = GetFilenamesFromDirectory(directory);
 
 	// Loop starts at index size - 1 and ends after index 0 executes
 	for (std::size_t i = filenames.size(); i-- > 0; )
@@ -103,9 +103,9 @@ std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directo
 	return filenames;
 }
 
-std::vector<std::string> XFile::GetFilesFromDirectory(const std::string& directory, const std::string& fileType)
+std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& directory, const std::string& fileType)
 {
-	std::vector<std::string> filenames = GetFilesFromDirectory(directory);
+	std::vector<std::string> filenames = GetFilenamesFromDirectory(directory);
 
 	// Loop starts at index size - 1 and ends after index 0 executes
 	for (std::size_t i = filenames.size(); i-- > 0; )

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -20,11 +20,10 @@ namespace XFile
 
 	bool IsFile(const std::string& path);
 
-	std::vector<std::string> GetFilesFromDirectory(const std::string& directory);
-
-	std::vector<std::string> GetFilesFromDirectory(const std::string& directory, const std::string& fileType);
-
-	std::vector<std::string> GetFilesFromDirectory(const std::string& directory, const std::regex& filenameRegex);
+	// Non-recursive search of directory that returns filename only (no directory)
+	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory);
+	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, const std::string& fileType);
+	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, const std::regex& filenameRegex);
 
 	std::string ChangeFileExtension(const std::string& filename, const std::string& newExtension);
 

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -84,15 +84,15 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 
 // Disable due to lack of Google Mock in the Windows CI environment
 #ifndef _WIN32
-TEST(XFileGetFilesFromDirectory, EmptyPath) {
-	EXPECT_THAT(XFile::GetFilesFromDirectory(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilesFromDirectory("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+TEST(XFileGetFilenamesFromDirectory, EmptyPath) {
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 
-TEST(XFileGetFilesFromDirectory, ExplicitCurrentDirectory) {
-	EXPECT_THAT(XFile::GetFilesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+TEST(XFileGetFilenamesFromDirectory, ExplicitCurrentDirectory) {
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 #endif


### PR DESCRIPTION
Closes #252

Also add usage comment to GetFilenamesFromDirectory

There was some discussion of recursively searching for filenames in the issue. I think it is a good idea in generally, but I don't have a current use case, so I was just proceeding without it.

Thanks,
Brett