### PR TITLE
Fix resource manager constructor bug

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -10,7 +10,9 @@ using namespace Archive;
 ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 	resourceRootDir(archiveDirectory)
 {
-	auto volFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".vol");
+	if (!XFile::IsDirectory(archiveDirectory)) {
+		throw std::runtime_error("Resource manager must be passed an archive directory.");
+	}
 
 	const auto volFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".vol");
 

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -12,11 +12,13 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 {
 	auto volFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".vol");
 
+	const auto volFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".vol");
+
 	for (const auto& volFilename : volFilenames) {
 		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename));
 	}
 
-	auto clmFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".clm");
+	const auto clmFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".clm");
 
 	for (const auto& clmFilename : clmFilenames) {
 		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename));

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -17,13 +17,13 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 	const auto volFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".vol");
 
 	for (const auto& volFilename : volFilenames) {
-		ArchiveFiles.push_back(std::make_unique<VolFile>(volFilename));
+		ArchiveFiles.push_back(std::make_unique<VolFile>(XFile::Append(archiveDirectory, volFilename)));
 	}
 
 	const auto clmFilenames = XFile::GetFilenamesFromDirectory(archiveDirectory, ".clm");
 
 	for (const auto& clmFilename : clmFilenames) {
-		ArchiveFiles.push_back(std::make_unique<ClmFile>(clmFilename));
+		ArchiveFiles.push_back(std::make_unique<ClmFile>(XFile::Append(archiveDirectory, clmFilename)));
 	}
 }
 


### PR DESCRIPTION
Hopefully this is the last bug to fix before releasing OP2MapImager. There always seems to be another problem with finding filenames/directories in that project.