### PR TITLE
Make XFile::GetFilenamesFromDirectory reject nonFilenames

### DIFF
--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -81,7 +81,12 @@ std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& dir
 	auto pathStr = directory.length() > 0 ? directory : "./";
 
 	std::vector<std::string> filenames;
-	for (const auto& entry : fs::directory_iterator(pathStr)) {
+	for (const auto& entry : fs::directory_iterator(pathStr)) 
+	{
+		if (!is_regular_file(entry.path())) {
+			continue;
+		}
+
 		filenames.push_back(GetFilename(entry.path().generic_string()));
 	}
 

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -81,6 +81,13 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 	EXPECT_EQ("C:/a/b/", XFile::GetDirectory("C:/a/b/"));
 }
 
+TEST(XFileGetFilenamesFromDirectory, DoesNotReturnDirectories) {
+	const auto filenames = XFile::GetFilenamesFromDirectory("");
+
+	for (const auto& filename : filenames) {
+		ASSERT_FALSE(XFile::IsDirectory(filename));
+	}
+}
 
 // Disable due to lack of Google Mock in the Windows CI environment
 #ifndef _WIN32


### PR DESCRIPTION
Might be good to update unit tests. Ran out of time at least for now though.

-Brett