### PR TITLE
Fix abs paths for GetResourceStream

### DIFF
--- a/src/Archive/ArchiveUnpacker.h
+++ b/src/Archive/ArchiveUnpacker.h
@@ -4,12 +4,7 @@
 #include <memory>
 #include <cstdint>
 #include <cstddef>
-
-namespace Stream {
-	class BidirectionalSeekableReader;
-	class Reader;
-	class Writer;
-}
+#include "../Stream/BiDirectionalSeekableReader.h"
 
 namespace Archive
 {

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -36,8 +36,8 @@ std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourc
 		throw std::runtime_error("ResourceManager only accepts fully relative paths. Refusing: " + filename);
 	}
 
-	// Absolute paths are used as is, fully relative paths are relative to resourceRootDir
-	const std::string path = XFile::MakeAbsolute(filename, resourceRootDir);
+	// Relative paths are relative to resourceRootDir
+	const std::string path = XFile::Append(resourceRootDir, filename);
 	if (XFile::PathExists(path)) {
 		return std::make_unique<Stream::FileReader>(path);
 	}

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -40,13 +40,11 @@ std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourc
 		return nullptr;
 	}
 
-	std::string internalArchiveFilename = XFile::GetFilename(filename);
-
 	for (const auto& archiveFile : ArchiveFiles)
 	{
 
-		if (archiveFile->Contains(internalArchiveFilename)) {
-			auto index = archiveFile->GetIndex(internalArchiveFilename);
+		if (archiveFile->Contains(filename)) {
+			auto index = archiveFile->GetIndex(filename);
 			return archiveFile->OpenStream(index);
 		}
 	}

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -41,11 +41,13 @@ std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourc
 		return nullptr;
 	}
 
+	std::string internalArchiveFilename = XFile::GetFilename(filename);
+
 	for (const auto& archiveFile : ArchiveFiles)
 	{
 
-		if (archiveFile->Contains(filename)) {
-			auto index = archiveFile->GetIndex(filename);
+		if (archiveFile->Contains(internalArchiveFilename)) {
+			auto index = archiveFile->GetIndex(internalArchiveFilename);
 			return archiveFile->OpenStream(index);
 		}
 	}

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -31,7 +31,8 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 // Then, if accessArhives = true, searches the preloaded archives for the resource.
 std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourceStream(const std::string& filename, bool accessArchives)
 {
-	const std::string path = XFile::Append(resourceRootDir, filename);
+	// Absolute paths are used as is, fully relative paths are relative to resourceRootDir
+	const std::string path = XFile::MakeAbsolute(filename, resourceRootDir);
 	if (XFile::PathExists(path)) {
 		return std::make_unique<Stream::FileReader>(path);
 	}

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -40,9 +40,10 @@ std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourc
 		return nullptr;
 	}
 
+	std::string internalArchiveFilename = XFile::GetFilename(filename);
+
 	for (const auto& archiveFile : ArchiveFiles)
 	{
-		std::string internalArchiveFilename = XFile::GetFilename(filename);
 
 		if (archiveFile->Contains(internalArchiveFilename)) {
 			auto index = archiveFile->GetIndex(internalArchiveFilename);

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -46,13 +46,11 @@ std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourc
 		return nullptr;
 	}
 
-	std::string internalArchiveFilename = XFile::GetFilename(filename);
-
 	for (const auto& archiveFile : ArchiveFiles)
 	{
 
-		if (archiveFile->Contains(internalArchiveFilename)) {
-			auto index = archiveFile->GetIndex(internalArchiveFilename);
+		if (archiveFile->Contains(filename)) {
+			auto index = archiveFile->GetIndex(filename);
 			return archiveFile->OpenStream(index);
 		}
 	}

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -31,6 +31,11 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 // Then, if accessArhives = true, searches the preloaded archives for the resource.
 std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourceStream(const std::string& filename, bool accessArchives)
 {
+	// Only fully relative paths are supported
+	if (XFile::HasRootComponent(filename)) {
+		throw std::runtime_error("ResourceManager only accepts fully relative paths. Refusing: " + filename);
+	}
+
 	// Absolute paths are used as is, fully relative paths are relative to resourceRootDir
 	const std::string path = XFile::MakeAbsolute(filename, resourceRootDir);
 	if (XFile::PathExists(path)) {

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -54,6 +54,17 @@ bool XFile::PathExists(const std::string& pathStr)
 	return fs::exists(fs::path(pathStr));
 }
 
+bool XFile::HasRootComponent(const std::string& pathStr)
+{
+	fs::path path(pathStr);
+	return path.has_root_name() || path.has_root_directory();
+}
+
+std::string XFile::MakeAbsolute(const std::string& pathStr, const std::string& relativeRootDirStr)
+{
+	return XFile::HasRootComponent(pathStr) ? pathStr : XFile::Append(relativeRootDirStr, pathStr);
+}
+
 std::string XFile::Append(const std::string& path1, const std::string& relativePath2)
 {
 	fs::path nestedPath(relativePath2);

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -31,6 +31,14 @@ namespace XFile
 
 	bool PathExists(const std::string& pathStr);
 
+	// True if the path has a drive specifier (on Windows, "C:") or root folder specifier (leading "/")
+	// Note: This basically tests if the path is not fully relative
+	bool HasRootComponent(const std::string& pathStr);
+
+	// Returns absolute paths as is. Returns relative paths with relativePathRoot prepended
+	// Note: This allows easy construction of absolute paths, using an arbitrary base for relative paths
+	std::string MakeAbsolute(const std::string& path, const std::string& relativeRootPath);
+
 	std::string Append(const std::string& path1, const std::string& relativePath2);
 
 	// Adds a string to the end of the filenameStr, but before the file's extension.

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -1,0 +1,15 @@
+#include "../src/ResourceManager.h"
+#include <gtest/gtest.h>
+
+
+TEST(ResourceManager, GetResourceStream) {
+	ResourceManager resourceManager("");
+
+	// Refuses absolute paths
+#ifdef _WIN32
+	EXPECT_THROW(resourceManager.GetResourceStream("C:/Archive.vol"), std::runtime_error);
+	EXPECT_THROW(resourceManager.GetResourceStream("C:/PathTo/Archive.vol"), std::runtime_error);
+#endif
+	EXPECT_THROW(resourceManager.GetResourceStream("/Archive.vol"), std::runtime_error);
+	EXPECT_THROW(resourceManager.GetResourceStream("/PathTo/Archive.vol"), std::runtime_error);
+}

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -30,6 +30,13 @@ TEST(XFile, MakeAbsolute) {
 #endif
 	EXPECT_EQ("C:/A/file.ext", XFile::MakeAbsolute("A/file.ext", "C:/"));
 	EXPECT_EQ("C:/A/file.ext", XFile::MakeAbsolute("file.ext", "C:/A/"));
+
+	#ifdef _WIN32
+		// For possible future extension on Windows
+		// Note: Behavior is currently unimplemented
+		// EXPECT_EQ("C:/file.ext", XFile::MakeAbsolute("/file.ext", "C:"));
+		// EXPECT_EQ("C:/file.ext", XFile::MakeAbsolute("C:file.ext", "/"));
+	#endif
 }
 
 TEST(XFile, Append) {

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -8,6 +8,30 @@
 #endif
 
 
+TEST(XFile, HasRootComponent) {
+	EXPECT_TRUE(XFile::HasRootComponent("/Path/File.ext"));
+#ifdef _WIN32
+		// Note: The "C:/" prefix is only considered absolute on Windows
+	EXPECT_TRUE(XFile::HasRootComponent("C:/Path/File.ext"));
+#endif
+
+	EXPECT_FALSE(XFile::HasRootComponent("Path/File.ext"));
+	EXPECT_FALSE(XFile::HasRootComponent("File.ext"));
+}
+
+TEST(XFile, MakeAbsolute) {
+	EXPECT_EQ("/A/file.ext", XFile::MakeAbsolute("/A/file.ext", "Anything"));
+	EXPECT_EQ("/A/file.ext", XFile::MakeAbsolute("A/file.ext", "/"));
+	EXPECT_EQ("/A/file.ext", XFile::MakeAbsolute("file.ext", "/A/"));
+
+#ifdef _WIN32
+	// Note: The "C:/" prefix is only considered absolute on Windows
+	EXPECT_EQ("C:/A/file.ext", XFile::MakeAbsolute("C:/A/file.ext", "Anything"));
+#endif
+	EXPECT_EQ("C:/A/file.ext", XFile::MakeAbsolute("A/file.ext", "C:/"));
+	EXPECT_EQ("C:/A/file.ext", XFile::MakeAbsolute("file.ext", "C:/A/"));
+}
+
 TEST(XFile, Append) {
 	EXPECT_EQ("a/b/", XFile::Append("a/", "b/"));
 	EXPECT_EQ("/a/b/", XFile::Append("/a/", "b/"));


### PR DESCRIPTION
Noticed a few issues with OP2MapImager related to other recent changes. I believe this sorts out those problems.
