### PR TITLE
Rename Seekable Streams

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -190,8 +190,8 @@
     <ClInclude Include="src\Stream\ForwardSeekableWriter.h" />
     <ClInclude Include="src\Stream\MemoryReader.h" />
     <ClInclude Include="src\Stream\MemoryWriter.h" />
-    <ClInclude Include="src\Stream\BidirectionalSeekableReader.h" />
-    <ClInclude Include="src\Stream\BidirectionalSeekableWriter.h" />
+    <ClInclude Include="src\Stream\BidirectionalReader.h" />
+    <ClInclude Include="src\Stream\BidirectionalWriter.h" />
     <ClInclude Include="src\Stream\Reader.h" />
     <ClInclude Include="src\Stream\Writer.h" />
     <ClInclude Include="src\StringHelper.h" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -186,8 +186,8 @@
     <ClInclude Include="src\Stream\SliceReader.h" />
     <ClInclude Include="src\Stream\FileReader.h" />
     <ClInclude Include="src\Stream\FileWriter.h" />
-    <ClInclude Include="src\Stream\ForwardSeekableReader.h" />
-    <ClInclude Include="src\Stream\ForwardSeekableWriter.h" />
+    <ClInclude Include="src\Stream\ForwardReader.h" />
+    <ClInclude Include="src\Stream\ForwardWriter.h" />
     <ClInclude Include="src\Stream\MemoryReader.h" />
     <ClInclude Include="src\Stream\MemoryWriter.h" />
     <ClInclude Include="src\Stream\BidirectionalReader.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -162,10 +162,10 @@
     <ClInclude Include="src\Map\TileMapping.h">
       <Filter>Map</Filter>
     </ClInclude>
-    <ClInclude Include="src\Stream\ForwardSeekableReader.h">
+    <ClInclude Include="src\Stream\ForwardReader.h">
       <Filter>Stream</Filter>
     </ClInclude>
-    <ClInclude Include="src\Stream\ForwardSeekableWriter.h">
+    <ClInclude Include="src\Stream\ForwardWriter.h">
       <Filter>Stream</Filter>
     </ClInclude>
     <ClInclude Include="src\Stream\BidirectionalReader.h">

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -168,10 +168,10 @@
     <ClInclude Include="src\Stream\ForwardSeekableWriter.h">
       <Filter>Stream</Filter>
     </ClInclude>
-    <ClInclude Include="src\Stream\BidirectionalSeekableReader.h">
+    <ClInclude Include="src\Stream\BidirectionalReader.h">
       <Filter>Stream</Filter>
     </ClInclude>
-    <ClInclude Include="src\Stream\BidirectionalSeekableWriter.h">
+    <ClInclude Include="src\Stream\BidirectionalWriter.h">
       <Filter>Stream</Filter>
     </ClInclude>
     <ClInclude Include="src\Map\SavedGameUnits.h">

--- a/src/Archive/ArchiveUnpacker.cpp
+++ b/src/Archive/ArchiveUnpacker.cpp
@@ -1,6 +1,6 @@
 #include "ArchiveUnpacker.h"
 #include "../XFile.h"
-#include "../Stream/BiDirectionalSeekableReader.h"
+#include "../Stream/BidirectionalReader.h"
 #include "../Stream/FileWriter.h"
 #include <array>
 #include <string>
@@ -50,7 +50,7 @@ namespace Archive
 		ExtractFile(GetIndex(name), pathOut);
 	}
 
-	std::unique_ptr<Stream::BidirectionalSeekableReader> ArchiveUnpacker::OpenStream(const std::string& name)
+	std::unique_ptr<Stream::BidirectionalReader> ArchiveUnpacker::OpenStream(const std::string& name)
 	{
 		return OpenStream(GetIndex(name));
 	}

--- a/src/Archive/ArchiveUnpacker.h
+++ b/src/Archive/ArchiveUnpacker.h
@@ -6,7 +6,7 @@
 #include <cstddef>
 
 namespace Stream {
-	class BidirectionalSeekableReader;
+	class BidirectionalReader;
 	class Reader;
 	class Writer;
 }
@@ -30,8 +30,8 @@ namespace Archive
 		virtual uint32_t GetSize(std::size_t index) = 0;
 		virtual void ExtractFile(std::size_t index, const std::string& pathOut) = 0;
 		virtual void ExtractAllFiles(const std::string& destDirectory);
-		virtual std::unique_ptr<Stream::BidirectionalSeekableReader> OpenStream(std::size_t index) = 0;
-		virtual std::unique_ptr<Stream::BidirectionalSeekableReader> OpenStream(const std::string& name);
+		virtual std::unique_ptr<Stream::BidirectionalReader> OpenStream(std::size_t index) = 0;
+		virtual std::unique_ptr<Stream::BidirectionalReader> OpenStream(const std::string& name);
 
 	protected:
 		void VerifyIndexInBounds(std::size_t index);

--- a/src/Archive/ClmFile.cpp
+++ b/src/Archive/ClmFile.cpp
@@ -81,7 +81,7 @@ namespace Archive
 		}
 	}
 
-	std::unique_ptr<Stream::BidirectionalSeekableReader> ClmFile::OpenStream(std::size_t index)
+	std::unique_ptr<Stream::BidirectionalReader> ClmFile::OpenStream(std::size_t index)
 	{
 		VerifyIndexInBounds(index);
 		const auto& indexEntry = indexEntries[index];
@@ -194,7 +194,7 @@ namespace Archive
 	// Searches through the wave file to find the given chunk length
 	// The current stream position is set the the first byte after the chunk header
 	// Returns the chunk length if found or -1 otherwise
-	uint32_t ClmFile::FindChunk(Tag chunkTag, Stream::BidirectionalSeekableReader& seekableStreamReader)
+	uint32_t ClmFile::FindChunk(Tag chunkTag, Stream::BidirectionalReader& seekableStreamReader)
 	{
 		uint64_t fileSize = seekableStreamReader.Length();
 

--- a/src/Archive/ClmFile.h
+++ b/src/Archive/ClmFile.h
@@ -24,7 +24,7 @@ namespace Archive
 		void ExtractFile(std::size_t index, const std::string& pathOut) override;
 
 		// Opens a stream containing packed audio PCM data
-		std::unique_ptr<Stream::BidirectionalSeekableReader> OpenStream(std::size_t index) override;
+		std::unique_ptr<Stream::BidirectionalReader> OpenStream(std::size_t index) override;
 
 		void Repack() override;
 
@@ -68,7 +68,7 @@ namespace Archive
 
 		// Private functions for packing files
 		static void ReadAllWaveHeaders(std::vector<std::unique_ptr<Stream::FileReader>>& filesToPackReaders, std::vector<WaveFormatEx>& waveFormats, std::vector<IndexEntry>& indexEntries);
-		static uint32_t FindChunk(Tag chunkTag, Stream::BidirectionalSeekableReader& seekableStreamReader);
+		static uint32_t FindChunk(Tag chunkTag, Stream::BidirectionalReader& seekableStreamReader);
 		static void CompareWaveFormats(const std::vector<WaveFormatEx>& waveFormatsconst, const std::vector<std::string>& filesToPack);
 		static void WriteArchive(const std::string& archiveFilename, const std::vector<std::unique_ptr<Stream::FileReader>>& filesToPackReaders,
 			std::vector<IndexEntry>& indexEntries, const std::vector<std::string>& names, const WaveFormatEx& waveFormat);

--- a/src/Archive/VolFile.cpp
+++ b/src/Archive/VolFile.cpp
@@ -60,7 +60,7 @@ namespace Archive
 		return m_IndexEntries[index].filenameOffset;
 	}
 
-	std::unique_ptr<Stream::BidirectionalSeekableReader> VolFile::OpenStream(std::size_t index)
+	std::unique_ptr<Stream::BidirectionalReader> VolFile::OpenStream(std::size_t index)
 	{
 		SectionHeader sectionHeader = GetSectionHeader(index);
 

--- a/src/Archive/VolFile.h
+++ b/src/Archive/VolFile.h
@@ -30,7 +30,7 @@ namespace Archive
 		void ExtractFile(std::size_t index, const std::string& pathOut) override;
 
 		// Opens a stream containing a packed file
-		std::unique_ptr<Stream::BidirectionalSeekableReader> OpenStream(std::size_t index) override;
+		std::unique_ptr<Stream::BidirectionalReader> OpenStream(std::size_t index) override;
 
 		// Volume Creation
 		void Repack() override;
@@ -80,7 +80,7 @@ namespace Archive
 		struct CreateVolumeInfo
 		{
 			std::vector<IndexEntry> indexEntries;
-			std::vector<std::unique_ptr<Stream::BidirectionalSeekableReader>> fileStreamReaders;
+			std::vector<std::unique_ptr<Stream::BidirectionalReader>> fileStreamReaders;
 			std::vector<std::string> filesToPack;
 			std::vector<std::string> names;
 			uint32_t stringTableLength;

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -9,8 +9,8 @@
 #include <cstddef>
 
 namespace Stream {
-	class BidirectionalSeekableWriter;
-	class BidirectionalSeekableReader;
+	class BidirectionalWriter;
+	class BidirectionalReader;
 }
 
 // BMP Writer only supporting Indexed Color palettes (1, 2, and 8 bit BMPs). 
@@ -26,12 +26,12 @@ public:
 
 	// BMP Reader only supports Indexed Color palettes (1, 2, and 8 bit BMPs).
 	static BitmapFile ReadIndexed(const std::string& filename);
-	static BitmapFile ReadIndexed(Stream::BidirectionalSeekableReader& seekableReader);
+	static BitmapFile ReadIndexed(Stream::BidirectionalReader& seekableReader);
 
 	// BMP Writer only supporting Indexed Color palettes (1, 2, and 8 bit BMPs).
 	// @indexedPixels: Must include padding to fill each image row out to the next 4 byte memory border (pitch).
 	static void WriteIndexed(std::string filename, uint16_t bitCount, int32_t width, int32_t height, std::vector<Color> palette, const std::vector<uint8_t>& indexedPixels);
-	static void WriteIndexed(Stream::BidirectionalSeekableWriter& seekableWriter, uint16_t bitCount, int32_t width, int32_t height, std::vector<Color> palette, const std::vector<uint8_t>& indexedPixels);
+	static void WriteIndexed(Stream::BidirectionalWriter& seekableWriter, uint16_t bitCount, int32_t width, int32_t height, std::vector<Color> palette, const std::vector<uint8_t>& indexedPixels);
 	static void WriteIndexed(std::string filename, const BitmapFile& bitmapFile);
 
 	void VerifyIndexedPaletteSizeDoesNotExceedBitCount() const;
@@ -49,14 +49,14 @@ private:
 	static void VerifyIndexedImageForSerialization(uint16_t bitCount);
 
 	// Read
-	static BmpHeader ReadBmpHeader(Stream::BidirectionalSeekableReader& seekableReader);
-	static ImageHeader ReadImageHeader(Stream::BidirectionalSeekableReader& seekableReader);
-	static void ReadPalette(Stream::BidirectionalSeekableReader& seekableReader, BitmapFile& bitmapFile);
-	static void ReadPixels(Stream::BidirectionalSeekableReader& seekableReader, BitmapFile& bitmapFile);
+	static BmpHeader ReadBmpHeader(Stream::BidirectionalReader& seekableReader);
+	static ImageHeader ReadImageHeader(Stream::BidirectionalReader& seekableReader);
+	static void ReadPalette(Stream::BidirectionalReader& seekableReader, BitmapFile& bitmapFile);
+	static void ReadPixels(Stream::BidirectionalReader& seekableReader, BitmapFile& bitmapFile);
 
 	// Write
-	static void WriteHeaders(Stream::BidirectionalSeekableWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette);
-	static void WritePixels(Stream::BidirectionalSeekableWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount);
+	static void WriteHeaders(Stream::BidirectionalWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette);
+	static void WritePixels(Stream::BidirectionalWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount);
 };
 
 bool operator==(const BitmapFile& lhs, const BitmapFile& rhs);

--- a/src/Bitmap/IndexedBmpReader.cpp
+++ b/src/Bitmap/IndexedBmpReader.cpp
@@ -8,7 +8,7 @@ BitmapFile BitmapFile::ReadIndexed(const std::string& filename)
 	return ReadIndexed(fileReader);
 }
 
-BitmapFile BitmapFile::ReadIndexed(Stream::BidirectionalSeekableReader& seekableReader)
+BitmapFile BitmapFile::ReadIndexed(Stream::BidirectionalReader& seekableReader)
 {
 	BitmapFile bitmapFile;
 	bitmapFile.bmpHeader = ReadBmpHeader(seekableReader);
@@ -20,7 +20,7 @@ BitmapFile BitmapFile::ReadIndexed(Stream::BidirectionalSeekableReader& seekable
 	return bitmapFile;
 }
 
-BmpHeader BitmapFile::ReadBmpHeader(Stream::BidirectionalSeekableReader& seekableReader)
+BmpHeader BitmapFile::ReadBmpHeader(Stream::BidirectionalReader& seekableReader)
 {
 	BmpHeader bmpHeader;
 	seekableReader.Read(bmpHeader);
@@ -34,7 +34,7 @@ BmpHeader BitmapFile::ReadBmpHeader(Stream::BidirectionalSeekableReader& seekabl
 	return bmpHeader;
 }
 
-ImageHeader BitmapFile::ReadImageHeader(Stream::BidirectionalSeekableReader& seekableReader)
+ImageHeader BitmapFile::ReadImageHeader(Stream::BidirectionalReader& seekableReader)
 {
 	ImageHeader imageHeader;
 	seekableReader.Read(imageHeader);
@@ -46,7 +46,7 @@ ImageHeader BitmapFile::ReadImageHeader(Stream::BidirectionalSeekableReader& see
 	return imageHeader;
 }
 
-void BitmapFile::ReadPalette(Stream::BidirectionalSeekableReader& seekableReader, BitmapFile& bitmapFile)
+void BitmapFile::ReadPalette(Stream::BidirectionalReader& seekableReader, BitmapFile& bitmapFile)
 {
 	bitmapFile.palette.clear();
 
@@ -60,7 +60,7 @@ void BitmapFile::ReadPalette(Stream::BidirectionalSeekableReader& seekableReader
 	seekableReader.Read(bitmapFile.palette);
 }
 
-void BitmapFile::ReadPixels(Stream::BidirectionalSeekableReader& seekableReader, BitmapFile& bitmapFile)
+void BitmapFile::ReadPixels(Stream::BidirectionalReader& seekableReader, BitmapFile& bitmapFile)
 {
 	std::size_t pixelContainerSize = bitmapFile.bmpHeader.size - bitmapFile.bmpHeader.pixelOffset;
 	BitmapFile::VerifyPixelSizeMatchesImageDimensionsWithPitch(bitmapFile.imageHeader.bitCount, bitmapFile.imageHeader.width, bitmapFile.imageHeader.height, pixelContainerSize);

--- a/src/Bitmap/IndexedBmpWriter.cpp
+++ b/src/Bitmap/IndexedBmpWriter.cpp
@@ -21,7 +21,7 @@ void BitmapFile::WriteIndexed(std::string filename, uint16_t bitCount, int32_t w
 	WriteIndexed(fileWriter, bitCount, width, height, palette, indexedPixels);
 }
 
-void BitmapFile::WriteIndexed(Stream::BidirectionalSeekableWriter& seekableWriter, uint16_t bitCount, int32_t width, int32_t height, std::vector<Color> palette, const std::vector<uint8_t>& indexedPixels)
+void BitmapFile::WriteIndexed(Stream::BidirectionalWriter& seekableWriter, uint16_t bitCount, int32_t width, int32_t height, std::vector<Color> palette, const std::vector<uint8_t>& indexedPixels)
 {
 	VerifyIndexedImageForSerialization(bitCount);
 	VerifyIndexedPaletteSizeDoesNotExceedBitCount(bitCount, palette.size());
@@ -35,7 +35,7 @@ void BitmapFile::WriteIndexed(Stream::BidirectionalSeekableWriter& seekableWrite
 	WritePixels(seekableWriter, indexedPixels, width, bitCount);
 }
 
-void BitmapFile::WriteHeaders(Stream::BidirectionalSeekableWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette)
+void BitmapFile::WriteHeaders(Stream::BidirectionalWriter& seekableWriter, uint16_t bitCount, int width, int height, const std::vector<Color>& palette)
 {
 	std::size_t pixelOffset = sizeof(BmpHeader) + sizeof(ImageHeader) + palette.size() * sizeof(Color);
 	std::size_t fileSize = pixelOffset + ImageHeader::CalculatePitch(bitCount, width) * std::abs(height);
@@ -51,7 +51,7 @@ void BitmapFile::WriteHeaders(Stream::BidirectionalSeekableWriter& seekableWrite
 	seekableWriter.Write(imageHeader);
 }
 
-void BitmapFile::WritePixels(Stream::BidirectionalSeekableWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount)
+void BitmapFile::WritePixels(Stream::BidirectionalWriter& seekableWriter, const std::vector<uint8_t>& pixels, int32_t width, uint16_t bitCount)
 {
 	const auto pitch = ImageHeader::CalculatePitch(bitCount, width);
 	const auto bytesOfPixelsPerRow = ImageHeader::CalcPixelByteWidth(bitCount, width);

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -18,7 +18,7 @@ struct MapHeader;
 namespace Stream {
 	class Writer;
 	class Reader;
-	class BidirectionalSeekableReader;
+	class BidirectionalReader;
 }
 
 // FILE FORMAT DOCUMENTATION:
@@ -36,7 +36,7 @@ public:
 	static Map ReadMap(std::string filename);
 	static Map ReadMap(Stream::Reader& mapStream);
 	static Map ReadSavedGame(std::string filename);
-	static Map ReadSavedGame(Stream::BidirectionalSeekableReader& savedGameStream);
+	static Map ReadSavedGame(Stream::BidirectionalReader& savedGameStream);
 
 	void Write(const std::string& filename) const;
 	void Write(Stream::Writer& streamWriter) const;
@@ -98,11 +98,11 @@ private:
 
 	// Read
 	static Map ReadMapBeginning(Stream::Reader& stream);
-	static void SkipSaveGameHeader(Stream::BidirectionalSeekableReader& stream);
+	static void SkipSaveGameHeader(Stream::BidirectionalReader& stream);
 	static void ReadTilesetSources(Stream::Reader& stream, Map& map, std::size_t tilesetCount);
 	static void ReadTilesetHeader(Stream::Reader& stream);
 	static void ReadVersionTag(Stream::Reader& stream, uint32_t lastVersionTag);
-	static void ReadSavedGameUnits(Stream::BidirectionalSeekableReader& stream);
+	static void ReadSavedGameUnits(Stream::BidirectionalReader& stream);
 	static void ReadTileGroups(Stream::Reader& stream, Map& map);
 	static TileGroup ReadTileGroup(Stream::Reader& stream);
 };

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -33,7 +33,7 @@ Map Map::ReadSavedGame(std::string filename)
 	return ReadSavedGame(savedGameStream);
 }
 
-Map Map::ReadSavedGame(Stream::BidirectionalSeekableReader& savedGameStream)
+Map Map::ReadSavedGame(Stream::BidirectionalReader& savedGameStream)
 {
 	SkipSaveGameHeader(savedGameStream);
 
@@ -54,7 +54,7 @@ Map Map::ReadSavedGame(Stream::BidirectionalSeekableReader& savedGameStream)
 // == Private methods ==
 
 
-void Map::SkipSaveGameHeader(Stream::BidirectionalSeekableReader& stream)
+void Map::SkipSaveGameHeader(Stream::BidirectionalReader& stream)
 {
 	stream.SeekForward(0x1E025);
 }
@@ -124,7 +124,7 @@ void Map::ReadVersionTag(Stream::Reader& stream, uint32_t lastVersionTag)
 	}
 }
 
-void Map::ReadSavedGameUnits(Stream::BidirectionalSeekableReader& stream)
+void Map::ReadSavedGameUnits(Stream::BidirectionalReader& stream)
 {
 	SavedGameUnits savedGameUnits;
 

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -1,7 +1,7 @@
 #include "ResourceManager.h"
 #include "Archive/VolFile.h"
 #include "Archive/ClmFile.h"
-#include "Stream/BiDirectionalSeekableReader.h"
+#include "Stream/BidirectionalReader.h"
 #include "XFile.h"
 #include <regex>
 
@@ -29,7 +29,7 @@ ResourceManager::ResourceManager(const std::string& archiveDirectory) :
 
 // First searches for resources loosely in provided directory.
 // Then, if accessArhives = true, searches the preloaded archives for the resource.
-std::unique_ptr<Stream::BidirectionalSeekableReader> ResourceManager::GetResourceStream(const std::string& filename, bool accessArchives)
+std::unique_ptr<Stream::BidirectionalReader> ResourceManager::GetResourceStream(const std::string& filename, bool accessArchives)
 {
 	const std::string path = XFile::Append(resourceRootDir, filename);
 	if (XFile::PathExists(path)) {

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 
 namespace Stream {
-	class BidirectionalSeekableReader;
+	class BidirectionalReader;
 }
 
 // Use to find files/resources either on disk or contained in an archive file (.vol|.clm).
@@ -16,7 +16,7 @@ class ResourceManager
 public:
 	ResourceManager(const std::string& archiveDirectory);
 
-	std::unique_ptr<Stream::BidirectionalSeekableReader> GetResourceStream(const std::string& filename, bool accessArchives = true);
+	std::unique_ptr<Stream::BidirectionalReader> GetResourceStream(const std::string& filename, bool accessArchives = true);
 
 	std::vector<std::string> GetAllFilenames(const std::string& filenameRegexStr, bool accessArchives = true);
 	std::vector<std::string> GetAllFilenamesOfType(const std::string& extension, bool accessArchives = true);

--- a/src/Sprite/ArtFile.h
+++ b/src/Sprite/ArtFile.h
@@ -10,8 +10,8 @@
 #include <cstddef>
 
 namespace Stream {
-	class BidirectionalSeekableReader;
-	class BidirectionalSeekableWriter;
+	class BidirectionalReader;
+	class BidirectionalWriter;
 }
 
 struct ArtFile
@@ -23,27 +23,27 @@ public:
 	uint32_t unknownAnimationCount;
 
 	static ArtFile Read(std::string filename);
-	static ArtFile Read(Stream::BidirectionalSeekableReader& seekableReader);
+	static ArtFile Read(Stream::BidirectionalReader& seekableReader);
 	static void Write(std::string filename, const ArtFile& artFile);
-	static void Write(Stream::BidirectionalSeekableWriter&, const ArtFile& artFile);
+	static void Write(Stream::BidirectionalWriter&, const ArtFile& artFile);
 
 	void VerifyImageIndexInBounds(std::size_t index);
 
 private:
 	// Read Functions
-	static void ReadPalette(Stream::BidirectionalSeekableReader& seekableReader, ArtFile& artFile);
-	static void ReadImageMetadata(Stream::BidirectionalSeekableReader& seekableReader, ArtFile& artFile);
-	static void ReadAnimations(Stream::BidirectionalSeekableReader& seekableReader, ArtFile& artFile);
-	static Animation ReadAnimation(Stream::BidirectionalSeekableReader& seekableReader);
-	static Animation::Frame ReadFrame(Stream::BidirectionalSeekableReader& seekableReader);
+	static void ReadPalette(Stream::BidirectionalReader& seekableReader, ArtFile& artFile);
+	static void ReadImageMetadata(Stream::BidirectionalReader& seekableReader, ArtFile& artFile);
+	static void ReadAnimations(Stream::BidirectionalReader& seekableReader, ArtFile& artFile);
+	static Animation ReadAnimation(Stream::BidirectionalReader& seekableReader);
+	static Animation::Frame ReadFrame(Stream::BidirectionalReader& seekableReader);
 	static void VerifyCountsMatchHeader(const ArtFile& artFile, std::size_t frameCount, std::size_t layerCount, std::size_t unknownCount);
 
 
 	// Write Functions
-	static void WritePalettes(Stream::BidirectionalSeekableWriter& seekableWriter, const ArtFile& artFile);
-	static void WriteAnimations(Stream::BidirectionalSeekableWriter& seekableWriter, const ArtFile& artFile);
-	static void WriteAnimation(Stream::BidirectionalSeekableWriter& seekableWriter, const Animation& animation);
-	static void WriteFrame(Stream::BidirectionalSeekableWriter& seekableWriter, const Animation::Frame& frame);
+	static void WritePalettes(Stream::BidirectionalWriter& seekableWriter, const ArtFile& artFile);
+	static void WriteAnimations(Stream::BidirectionalWriter& seekableWriter, const ArtFile& artFile);
+	static void WriteAnimation(Stream::BidirectionalWriter& seekableWriter, const Animation& animation);
+	static void WriteFrame(Stream::BidirectionalWriter& seekableWriter, const Animation::Frame& frame);
 
 
 	void ValidateImageMetadata() const;

--- a/src/Sprite/ArtReader.cpp
+++ b/src/Sprite/ArtReader.cpp
@@ -11,7 +11,7 @@ ArtFile ArtFile::Read(std::string filename) {
 	return Read(mapReader);
 }
 
-ArtFile ArtFile::Read(Stream::BidirectionalSeekableReader& seekableReader) {
+ArtFile ArtFile::Read(Stream::BidirectionalReader& seekableReader) {
 	ArtFile artFile;
 
 	ReadPalette(seekableReader, artFile);
@@ -21,7 +21,7 @@ ArtFile ArtFile::Read(Stream::BidirectionalSeekableReader& seekableReader) {
 	return artFile;
 }
 
-void ArtFile::ReadPalette(Stream::BidirectionalSeekableReader& seekableReader, ArtFile& artFile)
+void ArtFile::ReadPalette(Stream::BidirectionalReader& seekableReader, ArtFile& artFile)
 {
 	SectionHeader paletteSectionHeader;
 	seekableReader.Read(paletteSectionHeader);
@@ -45,14 +45,14 @@ void ArtFile::ReadPalette(Stream::BidirectionalSeekableReader& seekableReader, A
 	}
 }
 
-void ArtFile::ReadImageMetadata(Stream::BidirectionalSeekableReader& seekableReader, ArtFile& artFile)
+void ArtFile::ReadImageMetadata(Stream::BidirectionalReader& seekableReader, ArtFile& artFile)
 {
 	seekableReader.Read<uint32_t>(artFile.imageMetas);
 
 	artFile.ValidateImageMetadata();
 }
 
-void ArtFile::ReadAnimations(Stream::BidirectionalSeekableReader& seekableReader, ArtFile& artFile)
+void ArtFile::ReadAnimations(Stream::BidirectionalReader& seekableReader, ArtFile& artFile)
 {
 	uint32_t animationCount;
 	seekableReader.Read(animationCount);
@@ -74,7 +74,7 @@ void ArtFile::ReadAnimations(Stream::BidirectionalSeekableReader& seekableReader
 	VerifyCountsMatchHeader(artFile, frameCount, layerCount, artFile.unknownAnimationCount);
 }
 
-Animation ArtFile::ReadAnimation(Stream::BidirectionalSeekableReader& seekableReader)
+Animation ArtFile::ReadAnimation(Stream::BidirectionalReader& seekableReader)
 {
 	Animation animation;
 
@@ -96,7 +96,7 @@ Animation ArtFile::ReadAnimation(Stream::BidirectionalSeekableReader& seekableRe
 	return animation;
 }
 
-Animation::Frame ArtFile::ReadFrame(Stream::BidirectionalSeekableReader& seekableReader) {
+Animation::Frame ArtFile::ReadFrame(Stream::BidirectionalReader& seekableReader) {
 	Animation::Frame frame;
 	frame.optional1 = 0;
 	frame.optional2 = 0;

--- a/src/Sprite/ArtWriter.cpp
+++ b/src/Sprite/ArtWriter.cpp
@@ -11,7 +11,7 @@ void ArtFile::Write(std::string filename, const ArtFile& artFile)
 	Write(artWriter, artFile);
 }
 
-void ArtFile::Write(Stream::BidirectionalSeekableWriter& seekableWriter, const ArtFile& artFile)
+void ArtFile::Write(Stream::BidirectionalWriter& seekableWriter, const ArtFile& artFile)
 {
 	artFile.ValidateImageMetadata();
 
@@ -22,7 +22,7 @@ void ArtFile::Write(Stream::BidirectionalSeekableWriter& seekableWriter, const A
 	WriteAnimations(seekableWriter, artFile);
 }
 
-void ArtFile::WritePalettes(Stream::BidirectionalSeekableWriter& seekableWriter, const ArtFile& artFile)
+void ArtFile::WritePalettes(Stream::BidirectionalWriter& seekableWriter, const ArtFile& artFile)
 {
 	if (artFile.palettes.size() > UINT32_MAX) {
 		throw std::runtime_error("Art file contains too many palettes.");
@@ -43,7 +43,7 @@ void ArtFile::WritePalettes(Stream::BidirectionalSeekableWriter& seekableWriter,
 	}
 }
 
-void ArtFile::WriteAnimations(Stream::BidirectionalSeekableWriter& seekableWriter, const ArtFile& artFile)
+void ArtFile::WriteAnimations(Stream::BidirectionalWriter& seekableWriter, const ArtFile& artFile)
 {
 	if (artFile.animations.size() > UINT32_MAX) {
 		throw std::runtime_error("There are too many animations contained in the ArtFile.");
@@ -78,7 +78,7 @@ void ArtFile::WriteAnimations(Stream::BidirectionalSeekableWriter& seekableWrite
 	}
 }
 
-void ArtFile::WriteAnimation(Stream::BidirectionalSeekableWriter& seekableWriter, const Animation& animation)
+void ArtFile::WriteAnimation(Stream::BidirectionalWriter& seekableWriter, const Animation& animation)
 {
 	seekableWriter.Write(animation.unknown);
 	seekableWriter.Write(animation.selectionRect);
@@ -98,7 +98,7 @@ void ArtFile::WriteAnimation(Stream::BidirectionalSeekableWriter& seekableWriter
 	seekableWriter.Write<uint32_t>(animation.unknownContainer);
 }
 
-void ArtFile::WriteFrame(Stream::BidirectionalSeekableWriter& seekableWriter, const Animation::Frame& frame)
+void ArtFile::WriteFrame(Stream::BidirectionalWriter& seekableWriter, const Animation::Frame& frame)
 {
 	if (frame.layerMetadata.count != frame.layers.size()) {
 		throw std::runtime_error("Recorded layer count must match number of written layers.");

--- a/src/Stream/BidirectionalReader.h
+++ b/src/Stream/BidirectionalReader.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "ForwardSeekableReader.h"
+#include "ForwardReader.h"
 #include <cstdint>
 
 namespace Stream
 {
-	class BidirectionalReader : public ForwardSeekableReader {
+	class BidirectionalReader : public ForwardReader {
 	public:
 		// Seek backward by a relative amount, given as offset from current position
 		virtual void SeekBackward(uint64_t offset) = 0;

--- a/src/Stream/BidirectionalReader.h
+++ b/src/Stream/BidirectionalReader.h
@@ -5,7 +5,7 @@
 
 namespace Stream
 {
-	class BidirectionalSeekableReader : public ForwardSeekableReader {
+	class BidirectionalReader : public ForwardSeekableReader {
 	public:
 		// Seek backward by a relative amount, given as offset from current position
 		virtual void SeekBackward(uint64_t offset) = 0;

--- a/src/Stream/BidirectionalWriter.h
+++ b/src/Stream/BidirectionalWriter.h
@@ -5,7 +5,7 @@
 
 namespace Stream
 {
-	class BidirectionalSeekableWriter : public ForwardSeekableWriter
+	class BidirectionalWriter : public ForwardSeekableWriter
 	{
 	public:
 		// Seek backward by a relative amount, given as offset from current position

--- a/src/Stream/BidirectionalWriter.h
+++ b/src/Stream/BidirectionalWriter.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "ForwardSeekableWriter.h"
+#include "ForwardWriter.h"
 #include <cstdint>
 
 namespace Stream
 {
-	class BidirectionalWriter : public ForwardSeekableWriter
+	class BidirectionalWriter : public ForwardWriter
 	{
 	public:
 		// Seek backward by a relative amount, given as offset from current position

--- a/src/Stream/FileReader.h
+++ b/src/Stream/FileReader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "BiDirectionalSeekableReader.h"
+#include "BidirectionalReader.h"
 #include <string>
 #include <fstream>
 #include <cstddef>
@@ -12,7 +12,7 @@ namespace Stream
 	template <class WrappedStreamType> class SliceReader;
 	using FileSliceReader = SliceReader<FileReader>;
 
-	class FileReader : public BidirectionalSeekableReader {
+	class FileReader : public BidirectionalReader {
 	public:
 		FileReader(std::string filename);
 		FileReader(const FileReader& fileStreamReader);
@@ -20,7 +20,7 @@ namespace Stream
 
 		std::size_t ReadPartial(void* buffer, std::size_t size) noexcept override;
 
-		// BidirectionalSeekableReader methods
+		// BidirectionalReader methods
 		uint64_t Length() override;
 		uint64_t Position() override;
 

--- a/src/Stream/FileWriter.h
+++ b/src/Stream/FileWriter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "BiDirectionalSeekableWriter.h"
+#include "BidirectionalWriter.h"
 #include <string>
 #include <fstream>
 #include <cstddef>
@@ -8,7 +8,7 @@
 
 namespace Stream
 {
-	class FileWriter : public BidirectionalSeekableWriter
+	class FileWriter : public BidirectionalWriter
 	{
 	public:
 		// Open mode bit flags

--- a/src/Stream/ForwardReader.h
+++ b/src/Stream/ForwardReader.h
@@ -5,7 +5,7 @@
 
 namespace Stream
 {
-	class ForwardSeekableReader : public Reader {
+	class ForwardReader : public Reader {
 	public:
 		// Get the size of the stream
 		virtual uint64_t Length() = 0;

--- a/src/Stream/ForwardWriter.h
+++ b/src/Stream/ForwardWriter.h
@@ -5,7 +5,7 @@
 
 namespace Stream
 {
-	class ForwardSeekableWriter : public Writer
+	class ForwardWriter : public Writer
 	{
 	public:
 		// Get the size of the stream

--- a/src/Stream/MemoryReader.h
+++ b/src/Stream/MemoryReader.h
@@ -1,18 +1,18 @@
 #pragma once
 
-#include "BiDirectionalSeekableReader.h"
+#include "BidirectionalReader.h"
 #include <cstddef>
 #include <cstdint>
 
 namespace Stream
 {
-	class MemoryReader : public BidirectionalSeekableReader {
+	class MemoryReader : public BidirectionalReader {
 	public:
 		MemoryReader(const void* const buffer, std::size_t size);
 
 		std::size_t ReadPartial(void* buffer, std::size_t size) noexcept override;
 
-		// BidirectionalSeekableReader methods
+		// BidirectionalReader methods
 		uint64_t Length() override;
 		uint64_t Position() override;
 		

--- a/src/Stream/MemoryWriter.h
+++ b/src/Stream/MemoryWriter.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "BiDirectionalSeekableWriter.h"
+#include "BidirectionalWriter.h"
 #include <cstddef>
 #include <cstdint>
 
 namespace Stream
 {
-	class MemoryWriter : public BidirectionalSeekableWriter
+	class MemoryWriter : public BidirectionalWriter
 	{
 	public:
 		// buffer: where data will be written to.

--- a/src/Stream/SliceReader.h
+++ b/src/Stream/SliceReader.h
@@ -13,7 +13,7 @@ namespace Stream
 	// Access is bounds checked according to the slice parameters.
 	// The underlying stream must be copy constructible, so that an independent stream can be created.
 	template<class WrappedStreamType>
-	class SliceReader : public BidirectionalSeekableReader
+	class SliceReader : public BidirectionalReader
 	{
 	public:
 

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -74,7 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Stream\Reader.test.h" />
-    <ClInclude Include="Stream\BidirectionalSeekableReader.test.h" />
+    <ClInclude Include="Stream\BidirectionalReader.test.h" />
   </ItemGroup>
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -84,7 +84,7 @@
     <ClInclude Include="Stream\Reader.test.h">
       <Filter>Stream</Filter>
     </ClInclude>
-    <ClInclude Include="Stream\BidirectionalSeekableReader.test.h">
+    <ClInclude Include="Stream\BidirectionalReader.test.h">
       <Filter>Stream</Filter>
     </ClInclude>
   </ItemGroup>

--- a/test/Stream/BidirectionalReader.test.h
+++ b/test/Stream/BidirectionalReader.test.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Stream/BiDirectionalSeekableReader.h"
+#include "Stream/BidirectionalReader.h"
 #include <gtest/gtest.h>
 
 

--- a/test/Stream/FileReader.test.cpp
+++ b/test/Stream/FileReader.test.cpp
@@ -1,4 +1,4 @@
-#include "BiDirectionalSeekableReader.test.h"
+#include "BidirectionalReader.test.h"
 #include "Stream/FileReader.h"
 #include <array>
 

--- a/test/Stream/MemoryStreamReader.test.cpp
+++ b/test/Stream/MemoryStreamReader.test.cpp
@@ -1,5 +1,5 @@
 #include "Reader.test.h"
-#include "BiDirectionalSeekableReader.test.h"
+#include "BidirectionalReader.test.h"
 #include "Stream/MemoryReader.h"
 #include <array>
 

--- a/test/Stream/SliceReader.test.cpp
+++ b/test/Stream/SliceReader.test.cpp
@@ -1,4 +1,4 @@
-#include "BiDirectionalSeekableReader.test.h"
+#include "BidirectionalReader.test.h"
 #include "Stream/SliceReader.h"
 
 template <>


### PR DESCRIPTION
This closes #261.

As I got into this, I realized `ForwardSeekableReader`/`Writer` was similar, and so renamed that as well for consistency.

I think the shorter names are a little more pleasant to work with, and still reasonably clear and descriptive. Though that is of course a subjective opinion.
