### PR TITLE
Add DynamicMemoryWriter class

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -184,6 +184,7 @@
     <ClInclude Include="src\Sprite\OP2BmpLoader.h" />
     <ClInclude Include="src\Sprite\PaletteHeader.h" />
     <ClInclude Include="src\Sprite\SectionHeader.h" />
+    <ClInclude Include="src\Stream\DynamicMemoryWriter.h" />
     <ClInclude Include="src\Stream\SliceReader.h" />
     <ClInclude Include="src\Stream\FileReader.h" />
     <ClInclude Include="src\Stream\FileWriter.h" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -175,6 +175,7 @@
     <ClCompile Include="src\Sprite\SectionHeader.cpp" />
     <ClCompile Include="src\Stream\FileReader.cpp" />
     <ClCompile Include="src\Stream\FileWriter.cpp" />
+    <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryReader.cpp" />
     <ClInclude Include="src\Sprite\Animation.h" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClInclude Include="src\Stream\MemoryWriter.h">
       <Filter>Stream</Filter>
     </ClInclude>
+    <ClInclude Include="src\Stream\DynamicMemoryWriter.h">
+      <Filter>Stream</Filter>
+    </ClInclude>
     <ClInclude Include="src\Stream\Reader.h">
       <Filter>Stream</Filter>
     </ClInclude>
@@ -228,6 +231,9 @@
       <Filter>Stream</Filter>
     </ClCompile>
     <ClCompile Include="src\Stream\MemoryWriter.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
     <ClCompile Include="src\Archive\BitStreamReader.cpp">

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -99,9 +99,6 @@
     <ClInclude Include="src\Stream\MemoryWriter.h">
       <Filter>Stream</Filter>
     </ClInclude>
-    <ClInclude Include="src\Stream\DynamicMemoryWriter.h">
-      <Filter>Stream</Filter>
-    </ClInclude>
     <ClInclude Include="src\Stream\Reader.h">
       <Filter>Stream</Filter>
     </ClInclude>
@@ -185,6 +182,9 @@
     </ClInclude>
     <ClInclude Include="src\Tag.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Stream\DynamicMemoryWriter.h">
+      <Filter>Stream</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stream/DynamicMemoryWriter.cpp
+++ b/src/Stream/DynamicMemoryWriter.cpp
@@ -32,11 +32,11 @@ namespace Stream
 	void DynamicMemoryWriter::SeekForward(uint64_t offset)
 	{
 		auto streamSize = streamBuffer.size();
-		if (offset > std::numeric_limits<decltype(streamBuffer)::size_type>::max() - streamSize) {
+		if (offset > std::numeric_limits<SizeType>::max() - streamSize) {
 			throw std::runtime_error("Seek forward beyond stream size limit");
 		}
 		// Zero fill to new size
-		streamBuffer.resize(static_cast<decltype(streamBuffer)::size_type>(streamSize + offset), 0);
+		streamBuffer.resize(static_cast<SizeType>(streamSize + offset), 0);
 	}
 
 	void DynamicMemoryWriter::SeekBackward(uint64_t offset)
@@ -45,12 +45,12 @@ namespace Stream
 		if (offset > streamSize) {
 			throw std::runtime_error("Seek backward before beginning of stream");
 		}
-		streamBuffer.resize(static_cast<decltype(streamBuffer)::size_type>(streamSize - offset), 0);
+		streamBuffer.resize(static_cast<SizeType>(streamSize - offset), 0);
 	}
 
 	void DynamicMemoryWriter::Seek(uint64_t offset)
 	{
-		streamBuffer.resize(static_cast<decltype(streamBuffer)::size_type>(offset), 0);
+		streamBuffer.resize(static_cast<SizeType>(offset), 0);
 	}
 
 	MemoryReader DynamicMemoryWriter::GetReader() {

--- a/src/Stream/DynamicMemoryWriter.cpp
+++ b/src/Stream/DynamicMemoryWriter.cpp
@@ -1,0 +1,59 @@
+#include "DynamicMemoryWriter.h"
+#include <cstring>    // memcpy
+#include <limits>
+#include <stdexcept>
+
+namespace Stream
+{
+	DynamicMemoryWriter::DynamicMemoryWriter() {
+	}
+
+	DynamicMemoryWriter::DynamicMemoryWriter(std::size_t preallocateSize) {
+		streamBuffer.reserve(preallocateSize);
+	}
+
+	void DynamicMemoryWriter::WriteImplementation(const void* buffer, std::size_t size)
+	{
+		auto streamSize = streamBuffer.size();
+		streamBuffer.resize(streamSize + size);
+		std::memcpy(streamBuffer.data() + streamSize, buffer, size);
+	}
+
+	uint64_t DynamicMemoryWriter::Length()
+	{
+		return streamBuffer.size();
+	}
+
+	uint64_t DynamicMemoryWriter::Position()
+	{
+		return streamBuffer.size();
+	}
+
+	void DynamicMemoryWriter::SeekForward(uint64_t offset)
+	{
+		auto streamSize = streamBuffer.size();
+		if (offset > std::numeric_limits<decltype(streamBuffer)::size_type>::max() - streamSize) {
+			throw std::runtime_error("Seek forward beyond stream size limit");
+		}
+		// Zero fill to new size
+		streamBuffer.resize(streamSize + offset, 0);
+	}
+
+	void DynamicMemoryWriter::SeekBackward(uint64_t offset)
+	{
+		auto streamSize = streamBuffer.size();
+		if (offset > streamSize) {
+			throw std::runtime_error("Seek backward before beginning of stream");
+		}
+		streamBuffer.resize(streamSize - offset, 0);
+	}
+
+	void DynamicMemoryWriter::Seek(uint64_t offset)
+	{
+		streamBuffer.resize(offset, 0);
+	}
+
+	MemoryReader DynamicMemoryWriter::GetReader() {
+		return MemoryReader(streamBuffer.data(), streamBuffer.size());
+	}
+}

--- a/src/Stream/DynamicMemoryWriter.cpp
+++ b/src/Stream/DynamicMemoryWriter.cpp
@@ -36,7 +36,7 @@ namespace Stream
 			throw std::runtime_error("Seek forward beyond stream size limit");
 		}
 		// Zero fill to new size
-		streamBuffer.resize(streamSize + offset, 0);
+		streamBuffer.resize(static_cast<std::size_t>(streamSize + offset), 0);
 	}
 
 	void DynamicMemoryWriter::SeekBackward(uint64_t offset)
@@ -45,12 +45,12 @@ namespace Stream
 		if (offset > streamSize) {
 			throw std::runtime_error("Seek backward before beginning of stream");
 		}
-		streamBuffer.resize(streamSize - offset, 0);
+		streamBuffer.resize(static_cast<std::size_t>(streamSize - offset), 0);
 	}
 
 	void DynamicMemoryWriter::Seek(uint64_t offset)
 	{
-		streamBuffer.resize(offset, 0);
+		streamBuffer.resize(static_cast<std::size_t>(offset), 0);
 	}
 
 	MemoryReader DynamicMemoryWriter::GetReader() {

--- a/src/Stream/DynamicMemoryWriter.cpp
+++ b/src/Stream/DynamicMemoryWriter.cpp
@@ -36,7 +36,7 @@ namespace Stream
 			throw std::runtime_error("Seek forward beyond stream size limit");
 		}
 		// Zero fill to new size
-		streamBuffer.resize(static_cast<std::size_t>(streamSize + offset), 0);
+		streamBuffer.resize(static_cast<decltype(streamBuffer)::size_type>(streamSize + offset), 0);
 	}
 
 	void DynamicMemoryWriter::SeekBackward(uint64_t offset)
@@ -45,12 +45,12 @@ namespace Stream
 		if (offset > streamSize) {
 			throw std::runtime_error("Seek backward before beginning of stream");
 		}
-		streamBuffer.resize(static_cast<std::size_t>(streamSize - offset), 0);
+		streamBuffer.resize(static_cast<decltype(streamBuffer)::size_type>(streamSize - offset), 0);
 	}
 
 	void DynamicMemoryWriter::Seek(uint64_t offset)
 	{
-		streamBuffer.resize(static_cast<std::size_t>(offset), 0);
+		streamBuffer.resize(static_cast<decltype(streamBuffer)::size_type>(offset), 0);
 	}
 
 	MemoryReader DynamicMemoryWriter::GetReader() {

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -17,11 +17,11 @@ namespace Stream
 		uint64_t Length() override;
 		uint64_t Position() override;
 
-		// Note: SeekForward will set a new stream size and 0 fill the buffer gap
+		// SeekForward will set a new stream size and 0 fill the buffer gap
 		void SeekForward(uint64_t offset) override;
-		// Note: SeekBackward will set a new stream size and truncate the stream
+		// SeekBackward will set a new stream size and truncate the stream
 		void SeekBackward(uint64_t offset) override;
-		// Note: Seek will set a new stream size (either by 0 filling or by truncating)
+		// Seek will set a new stream size (either by 0 filling or by truncating)
 		void Seek(uint64_t position) override;
 
 		// Get read access to the written data

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -8,6 +8,14 @@
 
 namespace Stream
 {
+	/**
+	 * \brief Memory backed stream, which grows dynamically in size as data is added
+	 *
+	 * An internal memory buffer is managed by DynamicMemoryWriter, which grows as needed to accommodate new data.
+	 * This is in contrast to MemoryWriter, which is a view to a non-owned pre-set sized buffer, which can not grow.
+	 *
+	 * \note Adding additional data to the stream after calling GetReader may invalidate existing readers.
+	 */
 	class DynamicMemoryWriter : public BidirectionalWriter
 	{
 	public:

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -40,5 +40,7 @@ namespace Stream
 
 	private:
 		std::vector<uint8_t> streamBuffer;
+
+		using SizeType = decltype(streamBuffer)::size_type;
 	};
 }

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "BiDirectionalSeekableWriter.h"
+#include "MemoryReader.h"
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace Stream
+{
+	class DynamicMemoryWriter : public BidirectionalSeekableWriter
+	{
+	public:
+		DynamicMemoryWriter();
+		DynamicMemoryWriter(std::size_t preallocateSize);
+
+		uint64_t Length() override;
+		uint64_t Position() override;
+
+		// Note: SeekForward will set a new stream size and 0 fill the buffer gap
+		void SeekForward(uint64_t offset) override;
+		// Note: SeekBackward will set a new stream size and truncate the stream
+		void SeekBackward(uint64_t offset) override;
+		// Note: Seek will set a new stream size (either by 0 filling or by truncating)
+		void Seek(uint64_t position) override;
+
+		// Get read access to the written data
+		MemoryReader GetReader();
+
+	protected:
+		void WriteImplementation(const void* buffer, std::size_t size) override;
+
+	private:
+		std::vector<uint8_t> streamBuffer;
+	};
+}

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -11,10 +11,16 @@ namespace Stream
 	/**
 	 * \brief Memory backed stream, which grows dynamically in size as data is added
 	 *
+	 * This stream can be used as a destination when the output size is not known exactly ahead of time.
+	 * Written data can later be accessed by calling GetReader to retrieve a MemoryReader for the written data.
+	 * The DynamicMemoryWriter is particularly useful when writing test code for stream serializaation,
+	 * as it does not need to write to disk, nor cleanup temporary files, during round-trip testing.
+	 *
 	 * An internal memory buffer is managed by DynamicMemoryWriter, which grows as needed to accommodate new data.
 	 * This is in contrast to MemoryWriter, which is a view to a non-owned pre-set sized buffer, which can not grow.
 	 *
-	 * \note Adding additional data to the stream after calling GetReader may invalidate existing readers.
+	 * \note Adding additional data to the stream after calling GetReader invalidates existing readers.
+	 * (They may be left pointing at old memory after a re-allocation).
 	 */
 	class DynamicMemoryWriter : public BidirectionalWriter
 	{

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "BiDirectionalSeekableWriter.h"
+#include "BidirectionalWriter.h"
 #include "MemoryReader.h"
 #include <cstddef>
 #include <cstdint>
@@ -8,7 +8,7 @@
 
 namespace Stream
 {
-	class DynamicMemoryWriter : public BidirectionalSeekableWriter
+	class DynamicMemoryWriter : public BidirectionalWriter
 	{
 	public:
 		DynamicMemoryWriter();

--- a/test/Map/MapWriter.test.cpp
+++ b/test/Map/MapWriter.test.cpp
@@ -1,6 +1,6 @@
 #include "Map/Map.h"
 #include "Map/MapHeader.h"
-#include "Stream/MemoryWriter.h"
+#include "Stream/DynamicMemoryWriter.h"
 #include "XFile.h"
 #include <gtest/gtest.h>
 #include <vector>
@@ -14,9 +14,8 @@ TEST(MapWriter, EmptyMap)
 	XFile::DeletePath(testFilename);
 
 	// Write to Memory
-	std::vector<char> buffer(1024);
-	Stream::MemoryWriter memoryWriter(buffer.data(), buffer.size() * sizeof(decltype(buffer)::value_type));
-	EXPECT_NO_THROW(Map().Write(memoryWriter));
+	Stream::DynamicMemoryWriter writer;
+	EXPECT_NO_THROW(Map().Write(writer));
 }
 
 TEST(MapWriter, BlankFilename)

--- a/test/Map/MapWriter.test.cpp
+++ b/test/Map/MapWriter.test.cpp
@@ -24,11 +24,9 @@ TEST(MapWriter, BlankFilename)
 }
 
 TEST(MapWriter, AllowInvalidVersionTag) {
-	const std::string testFilename("Map/data/test.map");
+	Stream::DynamicMemoryWriter writer;
 	Map map;
 
 	map.SetVersionTag(MapHeader::MinMapVersion - 1);
-	EXPECT_NO_THROW(Map().Write(testFilename));
-
-	XFile::DeletePath(testFilename);
+	EXPECT_NO_THROW(Map().Write(writer));
 }

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="Rect.test.cpp" />
     <ClCompile Include="Sprite\ArtReader.test.cpp" />
     <ClCompile Include="Sprite\ArtWriter.test.cpp" />
+    <ClCompile Include="Stream\DynamicMemoryWriter.test.cpp" />
     <ClCompile Include="Stream\FileReader.test.cpp" />
     <ClCompile Include="Stream\SliceReader.test.cpp" />
     <ClCompile Include="Stream\FileWriter.test.cpp" />

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -59,6 +59,9 @@
       <Filter>Stream</Filter>
     </ClCompile>
     <ClCompile Include="Tag.test.cpp" />
+    <ClCompile Include="Stream\DynamicMemoryWriter.test.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/test/Sprite/ArtWriter.test.cpp
+++ b/test/Sprite/ArtWriter.test.cpp
@@ -77,18 +77,17 @@ TEST_F(SimpleArtFile, Write_PaletteColors)
 	const uint8_t blue = 0;
 	artFile.palettes[0][0] = Color{ red, 0, blue, 0 };
 
-	std::string filename = "Sprite/data/test.prt";
+	Stream::DynamicMemoryWriter writer;
 
-	EXPECT_NO_THROW(ArtFile::Write(filename, artFile));
+	EXPECT_NO_THROW(ArtFile::Write(writer, artFile));
 
 	// Check ArtFile palette remains unchanged after write
 	EXPECT_EQ(red, artFile.palettes[0][0].red);
 	EXPECT_EQ(blue, artFile.palettes[0][0].blue);
 
 	// Check ArtFile palette written to disk properly
-	artFile = ArtFile::Read(filename);
+	auto reader = writer.GetReader();
+	artFile = ArtFile::Read(reader);
 	EXPECT_EQ(red, artFile.palettes[0][0].red);
 	EXPECT_EQ(blue, artFile.palettes[0][0].blue);
-
-	XFile::DeletePath(filename);
 }

--- a/test/Sprite/ArtWriter.test.cpp
+++ b/test/Sprite/ArtWriter.test.cpp
@@ -40,24 +40,22 @@ protected:
 
 TEST_F(SimpleArtFile, Write_ScanLineByteWidth)
 {
-	std::string filename = "Sprite/data/test.prt";
+	Stream::DynamicMemoryWriter writer;
 
 	// Check no throw if scanLine next 4 byte aligned
-	EXPECT_NO_THROW(ArtFile::Write(filename, artFile));
+	EXPECT_NO_THROW(ArtFile::Write(writer, artFile));
 
 	// Check throw if scanLine > width && < 4 byte aligned
 	artFile.imageMetas[0].scanLineByteWidth = 11;
-	EXPECT_THROW(ArtFile::Write(filename, artFile), std::runtime_error);
+	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
 
 	// Check throw if scanLine > first 4 byte align
 	artFile.imageMetas[0].scanLineByteWidth = 16;
-	EXPECT_THROW(ArtFile::Write(filename, artFile), std::runtime_error);
+	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
 
 	// Check throw if scanLine < width but still 4 byte aligned
 	artFile.imageMetas[0].scanLineByteWidth = 8;
-	EXPECT_THROW(ArtFile::Write(filename, artFile), std::runtime_error);
-
-	XFile::DeletePath(filename);
+	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
 }
 
 TEST_F(SimpleArtFile, Write_PaletteIndexRange) 

--- a/test/Sprite/ArtWriter.test.cpp
+++ b/test/Sprite/ArtWriter.test.cpp
@@ -1,6 +1,6 @@
 #include "../src/Sprite/ArtFile.h"
 #include "../src/XFile.h"
-#include "Stream/MemoryWriter.h"
+#include "Stream/DynamicMemoryWriter.h"
 #include "XFile.h"
 #include <gtest/gtest.h>
 #include <string>
@@ -14,9 +14,8 @@ TEST(ArtWriter, Empty)
 	XFile::DeletePath(testFilename);
 
 	// Write to Memory
-	std::vector<char> buffer(1024);
-	Stream::MemoryWriter memoryWriter(buffer.data(), buffer.size() * sizeof(decltype(buffer)::value_type));
-	EXPECT_NO_THROW(ArtFile::Write(memoryWriter, ArtFile()));
+	Stream::DynamicMemoryWriter writer;
+	EXPECT_NO_THROW(ArtFile::Write(writer, ArtFile()));
 }
 
 TEST(ArtWriter, BlankFilename)

--- a/test/Sprite/ArtWriter.test.cpp
+++ b/test/Sprite/ArtWriter.test.cpp
@@ -60,17 +60,15 @@ TEST_F(SimpleArtFile, Write_ScanLineByteWidth)
 
 TEST_F(SimpleArtFile, Write_PaletteIndexRange) 
 {
-	std::string filename = "Sprite/data/test.prt";
+	Stream::DynamicMemoryWriter writer;
 
 	// Check for no throw when ImageMeta.paletteIndex is within palette container's range
-	EXPECT_NO_THROW(ArtFile::Write(filename, artFile));
+	EXPECT_NO_THROW(ArtFile::Write(writer, artFile));
 
 	artFile.palettes.clear();
 
 	// Check for throw due to ImageMeta.paletteIndex outside of palette container's range
-	EXPECT_THROW(ArtFile::Write(filename, artFile), std::runtime_error);
-
-	XFile::DeletePath(filename);
+	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
 }
 
 TEST_F(SimpleArtFile, Write_PaletteColors)

--- a/test/Stream/DynamicMemoryWriter.test.cpp
+++ b/test/Stream/DynamicMemoryWriter.test.cpp
@@ -1,0 +1,50 @@
+#include "Stream/DynamicMemoryWriter.h"
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <array>
+
+
+TEST(DynamicMemoryWriter, LengthAutoExpands) {
+	const std::array<uint8_t, 4> data = {0, 1, 2, 3};
+	Stream::DynamicMemoryWriter writer;
+
+	// Initially stream has 0 length
+	EXPECT_EQ(0, writer.Length());
+
+	// Length grows as data is added
+	EXPECT_NO_THROW(writer.Write(data));
+	EXPECT_EQ(4, writer.Length());
+
+	// Seeking forward past the end expands the stream
+	EXPECT_NO_THROW(writer.SeekForward(1));
+	EXPECT_EQ(5, writer.Length());
+
+	// Additional data is added after the expansion gap
+	EXPECT_NO_THROW(writer.Write(data));
+	EXPECT_EQ(9, writer.Length());
+}
+
+TEST(DynamicMemoryWriter, ReadsBackStoredData) {
+	const std::array<uint8_t, 4> data = {0, 1, 2, 3};
+	Stream::DynamicMemoryWriter writer;
+
+	// Add data to stream
+	EXPECT_NO_THROW(writer.Write(data));
+	// Seeking forward 0 fills
+	EXPECT_NO_THROW(writer.SeekForward(1));
+	// Write more data after the gap
+	EXPECT_NO_THROW(writer.Write(data));
+
+	// Get stream to read back data
+	auto reader = writer.GetReader();
+	std::array<uint8_t, 4> readData;
+	uint8_t readDataByte;
+
+	// Read data back, and ensure it matches up
+	EXPECT_NO_THROW(reader.Read(readData));
+	EXPECT_EQ(data, readData);
+	EXPECT_NO_THROW(reader.Read(readDataByte));
+	EXPECT_EQ(0, readDataByte);
+	EXPECT_NO_THROW(reader.Read(readData));
+	EXPECT_EQ(data, readData);
+}


### PR DESCRIPTION
I'm still working on the test code for this one, but I thought I'd get the code up early for review purposes.

I was at first thinking of just making this a `Writer`, then thought a `ForwardWriter` would also be easy, and slightly more useful. Then I thought why not make it `BidirectionalWriter`, though I took one slight shortcut in the implementation, where seeking sets the length of the stream (either by truncating, or 0 filling).

----

This writes to a dynamically allocated and resizable memory buffer. After writing, the `GetReader()` method will return a `MemoryReader` object with a view of the memory.

This class can be used to aid writing test code. Writing can be done in-memory, and then verified with the associated `MemoryReader` object. There is no need to write to a slow disk, nor any need to clean up temporary files. This makes writing test code simpler and faster.
