### PR TITLE
Make FileWriter move constructible

### DIFF
--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -43,6 +43,12 @@ namespace Stream
 		}
 	}
 
+	FileWriter::FileWriter(FileWriter&& fileWriter) :
+		filename(std::move(fileWriter.filename)),
+		file(std::move(fileWriter.file))
+	{
+	}
+
 	FileWriter::~FileWriter() {
 		file.close();
 	}

--- a/src/Stream/FileWriter.h
+++ b/src/Stream/FileWriter.h
@@ -27,6 +27,7 @@ namespace Stream
 		//   CanOpenNew
 		// If both flags are specified, no race condition can occur
 		FileWriter(const std::string& filename, OpenMode openMode = OpenMode::Default);
+		FileWriter(FileWriter&& fileWriter);
 		~FileWriter() override;
 
 		// SeekableWriter methods

--- a/test/Stream/FileWriter.test.cpp
+++ b/test/Stream/FileWriter.test.cpp
@@ -53,3 +53,15 @@ TEST(FileWriterOpenMode, PermissionChecks) {
 	// Cleanup temporary file
 	XFile::DeletePath(filename);
 }
+
+
+TEST(FileWriter, MoveConstructible) {
+	std::string filename("TestFile.temp");
+
+	// Move object to new variable
+	Stream::FileWriter writer1("TestFile.temp");
+	EXPECT_NO_THROW(Stream::FileWriter writer2(std::move(writer1)));
+
+	// Cleanup temporary file
+	XFile::DeletePath(filename);
+}


### PR DESCRIPTION
This allows `FileWriter` objects to be returned from functions. A valid copy or move constructor is needed even in the case of copy elision / return value optimization. In that case a copy or move constructor must be defined, even though it is not called.

----

I encountered the need for this while working on test code. The type parameterized test cases need a factory function to create test objects, so they must be returnable from such functions.

The choice of a move constructor over a copy constructor was largely because the wrapped `ofstream` object is move constructible, but not copy constructible.
