### PR TITLE
Fix static_assert

### DIFF
--- a/src/Sprite/Animation.h
+++ b/src/Sprite/Animation.h
@@ -23,7 +23,7 @@ struct Animation {
 			Point16 pixelOffset;
 		};
 
-		static_assert(4 + sizeof(Point16), "Animation::Frame::Layer is an unexpected size");
+		static_assert(8 == sizeof(Layer), "Animation::Frame::Layer is an unexpected size");
 
 		LayerMetadata layerMetadata;
 		LayerMetadata unknownBitfield;


### PR DESCRIPTION
A non-zero value is true, which allowed this static_assert to pass without actually checking what it intended to check.

----

Related to this change, though not because of this change, I think the `static_assert` checks on struct sizes used in serialization should always use a literal constant for the size, rather than a constant expression which sums the component parts. The single literal is easier to reason about.
