### PR TITLE
Convert ArtFile::Write to const member

### DIFF
--- a/src/Sprite/ArtFile.h
+++ b/src/Sprite/ArtFile.h
@@ -24,8 +24,8 @@ public:
 
 	static ArtFile Read(std::string filename);
 	static ArtFile Read(Stream::Reader& reader);
-	static void Write(std::string filename, const ArtFile& artFile);
-	static void Write(Stream::Writer&, const ArtFile& artFile);
+	void Write(std::string filename) const;
+	void Write(Stream::Writer& writer) const;
 
 	void VerifyImageIndexInBounds(std::size_t index);
 

--- a/src/Sprite/ArtFile.h
+++ b/src/Sprite/ArtFile.h
@@ -40,8 +40,8 @@ private:
 
 
 	// Write Functions
-	static void WritePalettes(Stream::Writer& writer, const ArtFile& artFile);
-	static void WriteAnimations(Stream::Writer& writer, const ArtFile& artFile);
+	void WritePalettes(Stream::Writer& writer) const;
+	void WriteAnimations(Stream::Writer& writer) const;
 	static void WriteAnimation(Stream::Writer& writer, const Animation& animation);
 	static void WriteFrame(Stream::Writer& writer, const Animation::Frame& frame);
 

--- a/src/Sprite/ArtWriter.cpp
+++ b/src/Sprite/ArtWriter.cpp
@@ -15,25 +15,25 @@ void ArtFile::Write(Stream::Writer& writer) const
 {
 	ValidateImageMetadata();
 
-	WritePalettes(writer, *this);
+	WritePalettes(writer);
 
 	writer.Write<uint32_t>(imageMetas);
 
-	WriteAnimations(writer, *this);
+	WriteAnimations(writer);
 }
 
-void ArtFile::WritePalettes(Stream::Writer& writer, const ArtFile& artFile)
+void ArtFile::WritePalettes(Stream::Writer& writer) const
 {
-	if (artFile.palettes.size() > UINT32_MAX) {
+	if (palettes.size() > UINT32_MAX) {
 		throw std::runtime_error("Art file contains too many palettes.");
 	}
 
-	writer.Write(SectionHeader(TagPalette, static_cast<uint32_t>(artFile.palettes.size())));
+	writer.Write(SectionHeader(TagPalette, static_cast<uint32_t>(palettes.size())));
 
 	// Intentially do not pass palette as reference to allow local modification
 	// Switch red and blue color to match Outpost 2 custom format.
-	for (auto pallete : artFile.palettes) {
-		writer.Write(PaletteHeader(artFile));
+	for (auto pallete : palettes) {
+		writer.Write(PaletteHeader(*this));
 
 		for (auto& color : pallete) {
 			std::swap(color.red, color.blue);
@@ -43,18 +43,18 @@ void ArtFile::WritePalettes(Stream::Writer& writer, const ArtFile& artFile)
 	}
 }
 
-void ArtFile::WriteAnimations(Stream::Writer& writer, const ArtFile& artFile)
+void ArtFile::WriteAnimations(Stream::Writer& writer) const
 {
-	if (artFile.animations.size() > UINT32_MAX) {
+	if (animations.size() > UINT32_MAX) {
 		throw std::runtime_error("There are too many animations contained in the ArtFile.");
 	}
 
-	writer.Write(static_cast<uint32_t>(artFile.animations.size()));
+	writer.Write(static_cast<uint32_t>(animations.size()));
 
 	std::size_t frameCount;
 	std::size_t layerCount;
 	std::size_t unknownCount;
-	artFile.CountFrames(frameCount, layerCount, unknownCount);
+	CountFrames(frameCount, layerCount, unknownCount);
 
 	if (frameCount > UINT32_MAX) {
 		throw std::runtime_error("There are too many frames to write to file.");
@@ -72,7 +72,7 @@ void ArtFile::WriteAnimations(Stream::Writer& writer, const ArtFile& artFile)
 	writer.Write(static_cast<uint32_t>(layerCount));
 	writer.Write(static_cast<uint32_t>(unknownCount));
 
-	for (const auto& animation : artFile.animations)
+	for (const auto& animation : animations)
 	{
 		WriteAnimation(writer, animation);
 	}

--- a/src/Sprite/ArtWriter.cpp
+++ b/src/Sprite/ArtWriter.cpp
@@ -5,21 +5,21 @@
 #include <stdexcept>
 #include <algorithm>
 
-void ArtFile::Write(std::string filename, const ArtFile& artFile)
+void ArtFile::Write(std::string filename) const
 {
 	Stream::FileWriter artWriter(filename);
-	Write(artWriter, artFile);
+	Write(artWriter);
 }
 
-void ArtFile::Write(Stream::Writer& writer, const ArtFile& artFile)
+void ArtFile::Write(Stream::Writer& writer) const
 {
-	artFile.ValidateImageMetadata();
+	ValidateImageMetadata();
 
-	WritePalettes(writer, artFile);
+	WritePalettes(writer, *this);
 
-	writer.Write<uint32_t>(artFile.imageMetas);
+	writer.Write<uint32_t>(imageMetas);
 
-	WriteAnimations(writer, artFile);
+	WriteAnimations(writer, *this);
 }
 
 void ArtFile::WritePalettes(Stream::Writer& writer, const ArtFile& artFile)

--- a/test/Sprite/ArtWriter.test.cpp
+++ b/test/Sprite/ArtWriter.test.cpp
@@ -10,17 +10,17 @@ TEST(ArtWriter, Empty)
 {
 	// Write to File
 	const std::string testFilename("Sprite/data/test.prt");
-	EXPECT_NO_THROW(ArtFile::Write(testFilename, ArtFile()));
+	EXPECT_NO_THROW(ArtFile().Write(testFilename));
 	XFile::DeletePath(testFilename);
 
 	// Write to Memory
 	Stream::DynamicMemoryWriter writer;
-	EXPECT_NO_THROW(ArtFile::Write(writer, ArtFile()));
+	EXPECT_NO_THROW(ArtFile().Write(writer));
 }
 
 TEST(ArtWriter, BlankFilename)
 {
-	EXPECT_THROW(ArtFile::Write("", ArtFile()), std::runtime_error);
+	EXPECT_THROW(ArtFile().Write(""), std::runtime_error);
 }
 
 class SimpleArtFile : public ::testing::Test {
@@ -43,19 +43,19 @@ TEST_F(SimpleArtFile, Write_ScanLineByteWidth)
 	Stream::DynamicMemoryWriter writer;
 
 	// Check no throw if scanLine next 4 byte aligned
-	EXPECT_NO_THROW(ArtFile::Write(writer, artFile));
+	EXPECT_NO_THROW(artFile.Write(writer));
 
 	// Check throw if scanLine > width && < 4 byte aligned
 	artFile.imageMetas[0].scanLineByteWidth = 11;
-	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
+	EXPECT_THROW(artFile.Write(writer), std::runtime_error);
 
 	// Check throw if scanLine > first 4 byte align
 	artFile.imageMetas[0].scanLineByteWidth = 16;
-	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
+	EXPECT_THROW(artFile.Write(writer), std::runtime_error);
 
 	// Check throw if scanLine < width but still 4 byte aligned
 	artFile.imageMetas[0].scanLineByteWidth = 8;
-	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
+	EXPECT_THROW(artFile.Write(writer), std::runtime_error);
 }
 
 TEST_F(SimpleArtFile, Write_PaletteIndexRange) 
@@ -63,12 +63,12 @@ TEST_F(SimpleArtFile, Write_PaletteIndexRange)
 	Stream::DynamicMemoryWriter writer;
 
 	// Check for no throw when ImageMeta.paletteIndex is within palette container's range
-	EXPECT_NO_THROW(ArtFile::Write(writer, artFile));
+	EXPECT_NO_THROW(artFile.Write(writer));
 
 	artFile.palettes.clear();
 
 	// Check for throw due to ImageMeta.paletteIndex outside of palette container's range
-	EXPECT_THROW(ArtFile::Write(writer, artFile), std::runtime_error);
+	EXPECT_THROW(artFile.Write(writer), std::runtime_error);
 }
 
 TEST_F(SimpleArtFile, Write_PaletteColors)
@@ -79,7 +79,7 @@ TEST_F(SimpleArtFile, Write_PaletteColors)
 
 	Stream::DynamicMemoryWriter writer;
 
-	EXPECT_NO_THROW(ArtFile::Write(writer, artFile));
+	EXPECT_NO_THROW(artFile.Write(writer));
 
 	// Check ArtFile palette remains unchanged after write
 	EXPECT_EQ(red, artFile.palettes[0][0].red);


### PR DESCRIPTION
I think the design would be more natural if this became a const member method, rather than a static method which takes a const parameter. If we necessarily have to pass an `ArtFile` object, it should probably just be a member, and access the data through the implicit `this` pointer.

----

Related, I noticed `PaletteHeader` has a constructor which takes a `const ArtFile&`, which is never used. I was about to remove the parameter until I realized the constructor was overloaded, and removing the parameter would make it ambiguous. As the overloads do different initialization, I left it for now.

----

Related, the internals of this section of code can potentially be updated with proposals in Issue #277 and Issue #278.
