### PR TITLE
Add guard to vector write in Stream code

### DIFF
--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -31,13 +31,17 @@ namespace Stream
 
 		// Trivially copyable data types
 		template<typename T>
-		inline std::enable_if_t<std::is_trivially_copyable<T>::value> Write(const T& object) {
+		inline
+		std::enable_if_t<std::is_trivially_copyable<T>::value>
+		Write(const T& object) {
 			WriteImplementation(&object, sizeof(object));
 		}
 
 		// Vector of trvially copyable data types
 		template<typename T, typename A>
-		inline std::enable_if_t<std::is_trivially_copyable<T>::value> Write(const std::vector<T, A>& vector) {
+		inline
+		std::enable_if_t<std::is_trivially_copyable<T>::value>
+		Write(const std::vector<T, A>& vector) {
 			// Size calculation can't possibly overflow since the vector size necessarily fits in memory
 			WriteImplementation(vector.data(), vector.size() * sizeof(T));
 		}

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -35,9 +35,9 @@ namespace Stream
 			WriteImplementation(&object, sizeof(object));
 		}
 
-		// Vector data types
+		// Vector of trvially copyable data types
 		template<typename T, typename A>
-		inline void Write(const std::vector<T, A>& vector) {
+		inline std::enable_if_t<std::is_trivially_copyable<T>::value> Write(const std::vector<T, A>& vector) {
 			// Size calculation can't possibly overflow since the vector size necessarily fits in memory
 			WriteImplementation(vector.data(), vector.size() * sizeof(T));
 		}

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="Stream\SliceReader.test.cpp" />
     <ClCompile Include="Stream\FileWriter.test.cpp" />
     <ClCompile Include="Stream\MemoryStreamReader.test.cpp" />
+    <ClCompile Include="Stream\Writer.test.cpp" />
     <ClCompile Include="Tag.test.cpp" />
     <ClCompile Include="XFile.test.cpp" />
   </ItemGroup>

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -62,6 +62,9 @@
     <ClCompile Include="Stream\DynamicMemoryWriter.test.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
+    <ClCompile Include="Stream\Writer.test.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/test/Stream/Writer.test.cpp
+++ b/test/Stream/Writer.test.cpp
@@ -1,0 +1,32 @@
+#include "Stream/Writer.h"
+#include "Stream/DynamicMemoryWriter.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+// Note: Writer is an abstract class, so it can not be tested directly.
+// DynamicMemoryWriter will be used to test the template methods in Writer
+
+
+TEST(Writer, CanSerializeVectorOfTrivialStruct) {
+	struct TrivialStruct {
+		int field1;
+		int field2;
+
+		bool operator==(TrivialStruct other) const {
+			return (field1 == other.field1) && (field2 == other.field2);
+		}
+	};
+
+	// Test values
+	const std::vector<TrivialStruct> writeValue{{10, 1}, {20, 2}};
+	std::vector<TrivialStruct> readValue(writeValue.size());
+
+	// Write value
+	Stream::DynamicMemoryWriter writer;
+	EXPECT_NO_THROW(writer.Write(writeValue));
+
+	// Read value
+	auto reader = writer.GetReader();
+	EXPECT_NO_THROW(reader.Read(readValue));
+	EXPECT_EQ(writeValue, readValue);
+}


### PR DESCRIPTION
This fixes #276.

Trying to pass a vector of non-trivially-copyable types will now result in a compile time error.
