### PR TITLE
Add rvalue read maps

### DIFF
--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -35,6 +35,8 @@ public:
 
 	static Map ReadMap(std::string filename);
 	static Map ReadMap(Stream::Reader& mapStream);
+	static Map ReadMap(Stream::Reader&& mapStream);
+
 	static Map ReadSavedGame(std::string filename);
 	static Map ReadSavedGame(Stream::BidirectionalReader& savedGameStream);
 

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -39,6 +39,7 @@ public:
 
 	static Map ReadSavedGame(std::string filename);
 	static Map ReadSavedGame(Stream::BidirectionalReader& savedGameStream);
+	static Map ReadSavedGame(Stream::BidirectionalReader&& savedGameStream);
 
 	void Write(const std::string& filename) const;
 	void Write(Stream::Writer& streamWriter) const;

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -56,6 +56,12 @@ Map Map::ReadSavedGame(Stream::BidirectionalReader& savedGameStream)
 	return map;
 }
 
+// Read saved game from an rvalue stream (unnamed temporary)
+Map Map::ReadSavedGame(Stream::BidirectionalReader&& savedGameStream) {
+	// Delegate to lvalue overload
+	return ReadSavedGame(savedGameStream);
+}
+
 
 // == Private methods ==
 

--- a/src/Map/MapReader.cpp
+++ b/src/Map/MapReader.cpp
@@ -27,6 +27,12 @@ Map Map::ReadMap(Stream::Reader& mapStream)
 	return map;
 }
 
+// Read map from an rvalue stream (unnamed temporary)
+Map Map::ReadMap(Stream::Reader&& mapStream) {
+	// Delegate to lvalue overload
+	return ReadMap(mapStream);
+}
+
 Map Map::ReadSavedGame(std::string filename)
 {
 	Stream::FileReader savedGameStream(filename);

--- a/test/Map/MapReader.test.cpp
+++ b/test/Map/MapReader.test.cpp
@@ -1,4 +1,5 @@
 #include "Map/Map.h"
+#include "Stream/DynamicMemoryWriter.h"
 #include <gtest/gtest.h>
 #include <string>
 
@@ -14,4 +15,18 @@ TEST(MapReader, MissingFile) {
 TEST(MapReader, EmptyFile) {
 	EXPECT_THROW(Map::ReadMap("Map/data/EmptyMap.map"), std::runtime_error);
 	EXPECT_THROW(Map::ReadSavedGame("Map/data/EmptySave.OP2"), std::runtime_error);
+}
+
+TEST(MapReader, ReadMap) {
+	// Simple valid source to load from
+	Stream::DynamicMemoryWriter writer;
+	Map map;
+	map.Write(writer);
+
+	// Read from stream as lvalue
+	auto reader = writer.GetReader();
+	EXPECT_NO_THROW(auto mapFile = Map::ReadMap(reader));
+
+	// Read from stream as rvalue (unnamed temporary object)
+	EXPECT_NO_THROW(auto mapFile = Map::ReadMap(writer.GetReader()));
 }

--- a/test/Map/MapReader.test.cpp
+++ b/test/Map/MapReader.test.cpp
@@ -20,8 +20,7 @@ TEST(MapReader, EmptyFile) {
 TEST(MapReader, ReadMap) {
 	// Simple valid source to load from
 	Stream::DynamicMemoryWriter writer;
-	Map map;
-	map.Write(writer);
+	Map().Write(writer);
 
 	// Read from stream as lvalue
 	auto reader = writer.GetReader();

--- a/test/Map/MapReader.test.cpp
+++ b/test/Map/MapReader.test.cpp
@@ -29,4 +29,7 @@ TEST(MapReader, ReadMap) {
 
 	// Read from stream as rvalue (unnamed temporary object)
 	EXPECT_NO_THROW(auto mapFile = Map::ReadMap(writer.GetReader()));
+	
+	// Throw error if attempting to read a saved game from a map
+	EXPECT_THROW(auto savedGame = Map::ReadSavedGame(writer.GetReader()), std::runtime_error);
 }


### PR DESCRIPTION
The branch name is incorrect. It is for Reading maps/saved games, not writing.

We don't have a default way to create a saved game, so it isn't really tested yet. I think this is okay since we don't actually support fully reading/writing saved games.

Inspired by @DanRStevens work on Rvalue in a different branch.

-Brett