### PR TITLE
Cleanup stream method guards

### DIFF
--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -64,14 +64,6 @@ namespace Stream
 			Write(vector);
 		}
 
-		// String data types
-		// Does not write null terminator unless specifically included in string
-		template<typename CharT, typename Traits, typename Allocator>
-		void Write(const std::basic_string<CharT, Traits, Allocator>& string) {
-			// Size calculation can't possibly overflow since the string size necessarily fits in memory
-			Write(&string[0], string.size() * sizeof(CharT));
-		}
-
 		// Size prefixed string data types
 		// Ex: Write<uint32_t>(string); // Write 32-bit string length followed by string data
 		// Does not write null terminator unless specifically included in string

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -37,17 +37,16 @@ namespace Stream
 			WriteImplementation(&object, sizeof(object));
 		}
 
-		// Vector of trivially copyable data types
+		// Non-trivial contiguous container of trivially copyable data types
 		template<typename T>
 		inline
 		std::enable_if_t<
 			!std::is_trivially_copyable<T>::value &&
-			std::is_same<T, std::vector<typename T::value_type, typename T::allocator_type>>::value &&
 			std::is_trivially_copyable<typename T::value_type>::value
 		>
-		Write(const T& vector) {
-			// Size calculation can't possibly overflow since the vector size necessarily fits in memory
-			WriteImplementation(vector.data(), vector.size() * sizeof(typename T::value_type));
+		Write(const T& container) {
+			// Size calculation can't possibly overflow since the container size necessarily fits in memory
+			WriteImplementation(container.data(), container.size() * sizeof(typename T::value_type));
 		}
 
 		// Size prefixed vector data types

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -49,21 +49,21 @@ namespace Stream
 			WriteImplementation(container.data(), container.size() * sizeof(typename T::value_type));
 		}
 
-		// Size prefixed vector data types
+		// Size prefixed container data types
 		// Ex: Write<uint32_t>(vector); // Write 32-bit vector size followed by vector data
 		template<typename SizeType, typename T>
 		std::enable_if_t<
-			std::is_same<T, std::vector<typename T::value_type, typename T::allocator_type>>::value
+			true
 		>
-		Write(const T& vector) {
-			auto vectorSize = vector.size();
-			// This check is trivially false if SizeType is larger than max vector size
-			if (vectorSize > std::numeric_limits<SizeType>::max()) {
-				throw std::runtime_error("Vector too large to save size field");
+		Write(const T& container) {
+			auto containerSize = container.size();
+			// This check is trivially false if SizeType is larger than max container size
+			if (containerSize > std::numeric_limits<SizeType>::max()) {
+				throw std::runtime_error("Container too large to save size field");
 			}
 			// Cast can't overflow due to check above
-			Write(static_cast<SizeType>(vectorSize));
-			Write(vector);
+			Write(static_cast<SizeType>(containerSize));
+			Write(container);
 		}
 
 		// Size prefixed string data types

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -37,13 +37,17 @@ namespace Stream
 			WriteImplementation(&object, sizeof(object));
 		}
 
-		// Vector of trvially copyable data types
-		template<typename T, typename A>
+		// Vector of trivially copyable data types
+		template<typename T>
 		inline
-		std::enable_if_t<std::is_trivially_copyable<T>::value>
-		Write(const std::vector<T, A>& vector) {
+		std::enable_if_t<
+			!std::is_trivially_copyable<T>::value &&
+			std::is_same<T, std::vector<typename T::value_type, typename T::allocator_type>>::value &&
+			std::is_trivially_copyable<typename T::value_type>::value
+		>
+		Write(const T& vector) {
 			// Size calculation can't possibly overflow since the vector size necessarily fits in memory
-			WriteImplementation(vector.data(), vector.size() * sizeof(T));
+			WriteImplementation(vector.data(), vector.size() * sizeof(typename T::value_type));
 		}
 
 		// Size prefixed vector data types

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -61,9 +61,8 @@ namespace Stream
 			if (vectorSize > std::numeric_limits<SizeType>::max()) {
 				throw std::runtime_error("Vector too large to save size field");
 			}
-			// This can't overflow due to check above
-			auto typedSize = static_cast<SizeType>(vectorSize);
-			Write(typedSize);
+			// Cast can't overflow due to check above
+			Write(static_cast<SizeType>(vectorSize));
 			Write(vector);
 		}
 

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -66,21 +66,6 @@ namespace Stream
 			Write(container);
 		}
 
-		// Size prefixed string data types
-		// Ex: Write<uint32_t>(string); // Write 32-bit string length followed by string data
-		// Does not write null terminator unless specifically included in string
-		template<typename SizeType, typename CharT, typename Traits, typename Allocator>
-		void Write(const std::basic_string<CharT, Traits, Allocator>& string) {
-			auto stringSize = string.size();
-			// This check is trivially false if SizeType is larger than max string size
-			if (stringSize > std::numeric_limits<SizeType>::max()) {
-				throw std::runtime_error("String's size is too large to write in provided size field");
-			}
-			// This can't overflow due to check above
-			Write(static_cast<SizeType>(stringSize));
-			Write(string);
-		}
-
 		// Copy a Reader to a Writer
 		static const std::size_t DefaultCopyChunkSize = 0x00020000;
 		template<std::size_t BufferSize = DefaultCopyChunkSize>

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -51,8 +51,11 @@ namespace Stream
 
 		// Size prefixed vector data types
 		// Ex: Write<uint32_t>(vector); // Write 32-bit vector size followed by vector data
-		template<typename SizeType, typename T, typename A>
-		void Write(const std::vector<T, A>& vector) {
+		template<typename SizeType, typename T>
+		std::enable_if_t<
+			std::is_same<T, std::vector<typename T::value_type, typename T::allocator_type>>::value
+		>
+		Write(const T& vector) {
 			auto vectorSize = vector.size();
 			// This check is trivially false if SizeType is larger than max vector size
 			if (vectorSize > std::numeric_limits<SizeType>::max()) {


### PR DESCRIPTION
Updates for Write stream method guards.

This consolidates the `std::vector` and `std::string` variants of the write methods into unified container write methods. The differences were little more than variable names, and the overload type.

This relates to Issue #278. This simplifies template parameters, which may help PR #281.

Corresponding updates should be made to the Read stream method guards. (Added in PR #288).

The existing unit tests helped with the development of this. Particularly after I changed the meaning of a template `T` parameter, but forgot to update a corresponding `sizeof(T)`. Nevertheless, I find myself thinking a few additional unit tests might be good, which runs through various categories of types, doing a quick round trip serialization on them.
