### PR TITLE
Cleanup stream read method guards

### DIFF
--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -82,25 +82,5 @@ namespace Stream
 			container.resize(containerSize);
 			Read(container);
 		}
-
-		// Size prefixed string data types
-		// Ex: Read<uint32_t>(string); // Read 32-bit string length, allocate space, then read string data
-		template<typename SizeType, typename CharT, typename Traits, typename Allocator>
-		void Read(std::basic_string<CharT, Traits, Allocator>& string) {
-			SizeType stringSize;
-			Read(stringSize);
-			// This check is trivially false for unsigned SizeType
-			if (stringSize < 0) {
-				throw std::runtime_error("String's size may not be a negative number");
-			}
-			// This check may be trivially false when SizeType is too small to overflow string size for CharT types
-			if (stringSize > string.max_size()) {
-				throw std::runtime_error("String's size is too big to fit in memory");
-			}
-
-			string.clear();
-			string.resize(stringSize);
-			Read(string);
-		}
 	};
 }

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -54,6 +54,15 @@ namespace Stream
 			ReadImplementation(container.data(), container.size() * sizeof(typename T::value_type));
 		}
 
+		// String data types
+		// Reads into entire length of passed string. Call string.resize(stringSize) before
+		// passing string into this function to ensure proper string size is read
+		template<typename CharT, typename Traits, typename Allocator>
+		void Read(std::basic_string<CharT, Traits, Allocator>& string) {
+			// Size calculation can't possibly overflow since the string size necessarily fits in memory
+			Read(&string[0], string.size() * sizeof(CharT));
+		}
+
 		// Size prefixed vector data types
 		// Ex: Read<uint32_t>(vector); // Read 32-bit vector size, allocate space, then read vector data
 		template<typename SizeType, typename T, typename A>
@@ -71,15 +80,6 @@ namespace Stream
 			vector.clear();
 			vector.resize(vectorSize);
 			Read(vector);
-		}
-
-		// String data types
-		// Reads into entire length of passed string. Call string.resize(stringSize) before
-		// passing string into this function to ensure proper string size is read
-		template<typename CharT, typename Traits, typename Allocator>
-		void Read(std::basic_string<CharT, Traits, Allocator>& string) {
-			// Size calculation can't possibly overflow since the string size necessarily fits in memory
-			Read(&string[0], string.size() * sizeof(CharT));
 		}
 
 		// Size prefixed string data types

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -40,14 +40,18 @@ namespace Stream
 			ReadImplementation(&object, sizeof(object));
 		}
 
-		// Vector data types
-		// Reads into entire length of passed vector. Call vector.resize(vectorSize) before
-		// passing vector into this function to ensure proper vector size is read
-		template<typename T, typename A>
+		// Non-trivial contiguous container of trivially copyable data types
+		// Reads into entire length of passed container. Call container.resize(size) before
+		// passing container into this function to ensure proper container size is read
+		template<typename T>
 		inline
-		void Read(std::vector<T, A>& vector) {
-			// Size calculation can't possibly overflow since the vector size necessarily fits in memory
-			ReadImplementation(vector.data(), vector.size() * sizeof(T));
+		std::enable_if_t<
+			!std::is_trivially_copyable<T>::value &&
+			std::is_trivially_copyable<typename T::value_type>::value
+		>
+		Read(T& container) {
+			// Size calculation can't possibly overflow since the container size necessarily fits in memory
+			ReadImplementation(container.data(), container.size() * sizeof(typename T::value_type));
 		}
 
 		// Size prefixed vector data types

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -64,23 +64,23 @@ namespace Stream
 			Read(&string[0], string.size() * sizeof(CharT));
 		}
 
-		// Size prefixed vector data types
+		// Size prefixed container data types
 		// Ex: Read<uint32_t>(vector); // Read 32-bit vector size, allocate space, then read vector data
-		template<typename SizeType, typename T, typename A>
-		void Read(std::vector<T, A>& vector) {
-			SizeType vectorSize;
-			Read(vectorSize);
+		template<typename SizeType, typename T>
+		void Read(T& container) {
+			SizeType containerSize;
+			Read(containerSize);
 			// This check is trivially false for unsigned SizeType
-			if (vectorSize < 0) {
-				throw std::runtime_error("Vector's size may not be a negative number");
+			if (containerSize < 0) {
+				throw std::runtime_error("Container's size may not be a negative number");
 			}
-			// This check may be trivially false when SizeType is much smaller than max vector size
-			if (vectorSize > vector.max_size()) {
-				throw std::runtime_error("Vector's size is too big to fit in memory");
+			// This check may be trivially false when SizeType is much smaller than max container size
+			if (containerSize > container.max_size()) {
+				throw std::runtime_error("Container's size is too big to fit in memory");
 			}
-			vector.clear();
-			vector.resize(vectorSize);
-			Read(vector);
+			container.clear();
+			container.resize(containerSize);
+			Read(container);
 		}
 
 		// Size prefixed string data types

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -34,7 +34,9 @@ namespace Stream
 
 		// Trivially copyable data types
 		template<typename T>
-		inline std::enable_if_t<std::is_trivially_copyable<T>::value> Read(T& object) {
+		inline
+		std::enable_if_t<std::is_trivially_copyable<T>::value>
+		Read(T& object) {
 			ReadImplementation(&object, sizeof(object));
 		}
 
@@ -42,7 +44,8 @@ namespace Stream
 		// Reads into entire length of passed vector. Call vector.resize(vectorSize) before
 		// passing vector into this function to ensure proper vector size is read
 		template<typename T, typename A>
-		inline void Read(std::vector<T, A>& vector) {
+		inline
+		void Read(std::vector<T, A>& vector) {
 			// Size calculation can't possibly overflow since the vector size necessarily fits in memory
 			ReadImplementation(vector.data(), vector.size() * sizeof(T));
 		}

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -57,6 +57,7 @@ namespace Stream
 		// String data types
 		// Reads into entire length of passed string. Call string.resize(stringSize) before
 		// passing string into this function to ensure proper string size is read
+		// Note: C++17 added a non-const overload of `string.data()`, needed to collapse this with the above
 		template<typename CharT, typename Traits, typename Allocator>
 		void Read(std::basic_string<CharT, Traits, Allocator>& string) {
 			// Size calculation can't possibly overflow since the string size necessarily fits in memory


### PR DESCRIPTION
This is the read update corresponding to PR #287. Tagging Issue #278 as related. Tagging PR #281 as related for simplifying the template parameters.

There was one slight difference to the write case. I didn't collapse one of the string read methods into the generalized container form, since the `string.data()` method didn't have a non-const overload until C++17. Reference:
https://en.cppreference.com/w/cpp/string/basic_string/data

The current Linux flags are set for C++14. I'm uncertain if there are blocking issues with the Windows project, particularly regarding the Google Test unit test project. If it's fine to update to C++17, then we can collapse those two methods into one.
