### PR TITLE
Prevent resource manager from returning directories

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -4,7 +4,6 @@
 #include "Stream/BidirectionalReader.h"
 #include "XFile.h"
 #include <algorithm>
-#include <regex>
 
 using namespace Archive;
 
@@ -63,7 +62,7 @@ std::vector<std::string> ResourceManager::GetAllFilenames(const std::string& fil
 {
 	std::regex filenameRegex(filenameRegexStr, std::regex_constants::icase);
 
-	std::vector<std::string> filenames = XFile::GetFilenamesFromDirectory(resourceRootDir, filenameRegex);
+	auto filenames = GetFilesFromDirectory(filenameRegex);
 
 	if (!accessArchives) {
 		return filenames;
@@ -163,8 +162,21 @@ std::vector<std::string> ResourceManager::GetArchiveFilenames()
 std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::string& fileExtension)
 {
 	auto directoryContents = XFile::GetFilenamesFromDirectory(resourceRootDir, fileExtension);
+	EraseNonFilenames(directoryContents);
 
-	// Reject non-filenames
+	return directoryContents;
+}
+
+std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::regex& filenameRegex)
+{
+	auto directoryContents = XFile::GetFilenamesFromDirectory(resourceRootDir, filenameRegex);
+	EraseNonFilenames(directoryContents);
+
+	return directoryContents;
+}
+
+void ResourceManager::EraseNonFilenames(std::vector<std::string>& directoryContents)
+{
 	directoryContents.erase(
 		std::remove_if(
 			directoryContents.begin(),
@@ -173,6 +185,4 @@ std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::strin
 		),
 		directoryContents.end()
 	);
-
-	return directoryContents;
 }

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -3,7 +3,6 @@
 #include "Archive/ClmFile.h"
 #include "Stream/BidirectionalReader.h"
 #include "XFile.h"
-#include <algorithm>
 
 using namespace Archive;
 
@@ -162,7 +161,7 @@ std::vector<std::string> ResourceManager::GetArchiveFilenames()
 std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::string& fileExtension)
 {
 	auto directoryContents = XFile::GetFilenamesFromDirectory(resourceRootDir, fileExtension);
-	EraseNonFilenames(directoryContents);
+	XFile::EraseNonFilenames(directoryContents);
 
 	return directoryContents;
 }
@@ -170,19 +169,7 @@ std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::strin
 std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::regex& filenameRegex)
 {
 	auto directoryContents = XFile::GetFilenamesFromDirectory(resourceRootDir, filenameRegex);
-	EraseNonFilenames(directoryContents);
+	XFile::EraseNonFilenames(directoryContents);
 
 	return directoryContents;
-}
-
-void ResourceManager::EraseNonFilenames(std::vector<std::string>& directoryContents)
-{
-	directoryContents.erase(
-		std::remove_if(
-			directoryContents.begin(),
-			directoryContents.end(),
-			[](std::string path) { return !XFile::IsFile(path); }
-		),
-		directoryContents.end()
-	);
 }

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <regex>
 #include <cstddef>
 
 namespace Stream {
@@ -35,4 +36,6 @@ private:
 	bool IsDuplicateFilename(std::vector<std::string>& currentFilenames, std::string filenameToCheck);
 	// Returns only files from the directory
 	std::vector<std::string> GetFilesFromDirectory(const std::string& fileExtension);
+	std::vector<std::string> GetFilesFromDirectory(const std::regex& filenameRegex);
+	void EraseNonFilenames(std::vector<std::string>& directoryContents);
 };

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -37,5 +37,4 @@ private:
 	// Returns only files from the directory
 	std::vector<std::string> GetFilesFromDirectory(const std::string& fileExtension);
 	std::vector<std::string> GetFilesFromDirectory(const std::regex& filenameRegex);
-	void EraseNonFilenames(std::vector<std::string>& directoryContents);
 };

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -1,6 +1,7 @@
 #include "XFile.h"
 #include "StringHelper.h"
 #include <cstddef>
+#include <algorithm>
 
 #ifdef __cpp_lib_filesystem
 #include <filesystem>
@@ -136,6 +137,18 @@ std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& dir
 	}
 
 	return filenames;
+}
+
+void XFile::EraseNonFilenames(std::vector<std::string>& directoryContents)
+{
+	directoryContents.erase(
+		std::remove_if(
+			directoryContents.begin(),
+			directoryContents.end(),
+			[](std::string path) { return !XFile::IsFile(path); }
+		),
+		directoryContents.end()
+	);
 }
 
 bool XFile::IsRootPath(const std::string& pathStr)

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -30,6 +30,9 @@ namespace XFile
 	// Non-recursive search that returns entire directory contents (not just filenames)
 	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, const std::regex& filenameRegex);
 
+	// Erase all paths that are not represent filenames (such as subdirectories)
+	void EraseNonFilenames(std::vector<std::string>& directoryContents);
+
 	std::string ChangeFileExtension(const std::string& filename, const std::string& newExtension);
 
 	void NewDirectory(const std::string& newPath);

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -30,7 +30,5 @@ TEST(ResourceManager, GetFilenames)
 
 	EXPECT_EQ(0, filenames.size());
 
-	filenames = resourceManager.GetAllFilenames("Directory.vol");
-
-	EXPECT_EQ(0, filenames.size());
+	EXPECT_EQ(0, resourceManager.GetAllFilenames("Directory.vol").size());
 }

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -21,3 +21,16 @@ TEST(ResourceManager, GetResourceStream_RefuseAbsolutePath) {
 	EXPECT_THROW(resourceManager.GetResourceStream("/Archive.vol"), std::runtime_error);
 	EXPECT_THROW(resourceManager.GetResourceStream("/PathTo/Archive.vol"), std::runtime_error);
 }
+
+TEST(ResourceManager, GetFilenames)
+{
+	// Ensure Directory.vol is not returned
+	ResourceManager resourceManager("./data");
+	auto filenames = resourceManager.GetAllFilenamesOfType(".vol");
+
+	EXPECT_EQ(0, filenames.size());
+
+	filenames = resourceManager.GetAllFilenames("Directory.vol");
+
+	EXPECT_EQ(0, filenames.size());
+}


### PR DESCRIPTION
This prevents returning directories from the resource manager. I'm ok with the results. 

We had discussed returning directories from the ResourceManager. I have to check if directory contents are filenames or not before returning results from ResourceManager. Otherwise it would invalidate all the filenames returned from the archives.

I we want that functionality currently, perhaps two sets of functions:
 - ResourceManager::GetFilenames
 - ResourceManager::GetSubdirectories

I don't think we can use something like GetDirectoryContents because the user wouldn't know if the returned items were directories or files contained in an archive. I guess they could run IsDirectory and IsFilename and anything remaining has to be from an archive, but that seems strange.

I'm fine with this code as is unless there is a desire to solve the issue at this juncture.

Thanks,
-Brett