### PR TITLE
Fix signed/unsigned warning with Map version tags

### DIFF
--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -44,8 +44,8 @@ public:
 	void Write(const std::string& filename) const;
 	void Write(Stream::Writer& streamWriter) const;
 
-	inline void SetVersionTag(int32_t versionTag) { this->versionTag = versionTag; };
-	inline int32_t GetVersionTag() const { return versionTag; };
+	inline void SetVersionTag(uint32_t versionTag) { this->versionTag = versionTag; };
+	inline uint32_t GetVersionTag() const { return versionTag; };
 	inline bool IsSavedGame() const { return isSavedGame; };
 	inline uint32_t WidthInTiles() const { return widthInTiles; };
 	inline uint32_t HeightInTiles() const { return heightInTiles; };

--- a/src/Map/MapHeader.h
+++ b/src/Map/MapHeader.h
@@ -16,7 +16,7 @@ struct MapHeader
 	static const uint32_t CurrentMapVersion = 0x1011;
 
 	// The map's version tag must be >= MinMapVersion or Outpost 2 will abort loading the map.
-	int32_t versionTag;
+	uint32_t versionTag;
 
 	// True if file represents a saved game instead of a map file.
 	int32_t bSavedGame;


### PR DESCRIPTION
Consistently use unsigned version tag types.

The named constant versions are already defined as unsigned.
