### PR TITLE
Use `<filesystem>` feature detect

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ OBJDIR := $(BUILDDIR)/obj
 DEPDIR := $(BUILDDIR)/deps
 OUTPUT := libOP2Utility.a
 
-CXXFLAGS := -std=c++14 -g -Wall -Wno-unknown-pragmas
+CXXFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td
 

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -2,7 +2,7 @@
 #include "StringHelper.h"
 #include <cstddef>
 
-#ifdef _WIN32
+#ifdef __cpp_lib_filesystem
 #include <filesystem>
 namespace fs = std::filesystem;
 #else


### PR DESCRIPTION
Try to detect feature directly, rather than infer it through a platform detect. This should work better with different versions of a compiler on the same platform.