### PR TITLE
Write files in new directories

### DIFF
--- a/src/Archive/ArchiveFile.cpp
+++ b/src/Archive/ArchiveFile.cpp
@@ -18,7 +18,7 @@ namespace Archive
 	{
 		for (std::size_t i = 0; i < GetCount(); ++i)
 		{
-			ExtractFile(i, XFile::ReplaceFilename(destDirectory, GetName(i)));
+			ExtractFile(i, XFile::Append(destDirectory, GetName(i)));
 		}
 	}
 

--- a/src/Archive/ArchiveFile.h
+++ b/src/Archive/ArchiveFile.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "../Stream/BidirectionalReader.h"
 #include <string>
 #include <memory>
 #include <cstdint>
 #include <cstddef>
-#include "../Stream/BidirectionalReader.h"
 
 namespace Archive
 {

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -40,7 +40,7 @@ namespace Stream
 	{
 		// Create directory if it does not exist. ofstream will fail if directory does not exist.
 		auto directory = XFile::GetDirectory(filename);
-		if (!XFile::PathExists(directory)) {
+		if (directory != "" && !XFile::PathExists(directory)) {
 			XFile::NewDirectory(directory);
 		}
 

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -40,7 +40,7 @@ namespace Stream
 	{
 		// Create directory if it does not exist. ofstream will fail if directory does not exist.
 		auto directory = XFile::GetDirectory(filename);
-		if (directory != "" && !XFile::PathExists(directory)) {
+		if (!directory.empty() && !XFile::PathExists(directory)) {
 			XFile::NewDirectory(directory);
 		}
 

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -42,7 +42,7 @@ namespace Stream
 		auto directory = XFile::GetDirectory(filename);
 		if (!directory.empty() && !XFile::PathExists(directory)) 
 		{
-			if (openMode != OpenMode::CanOpenNew) {
+			if (openMode & OpenMode::CanOpenNew) {
 				throw std::runtime_error("The directory does not exist. The write command was restricted from creating new files or directories.");
 			}
 

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -1,4 +1,5 @@
 #include "FileWriter.h"
+#include "../XFile.h"
 #include <stdexcept>
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
@@ -35,9 +36,16 @@ namespace Stream
 
 
 	FileWriter::FileWriter(const std::string& filename, OpenMode openMode) :
-		filename(filename),
-		file(filename, TranslateFlags(filename, openMode))
+		filename(filename)
 	{
+		// Create directory if it does not exist. ofstream will fail if directory does not exist.
+		auto directory = XFile::GetDirectory(filename);
+		if (!XFile::PathExists(directory)) {
+			XFile::NewDirectory(directory);
+		}
+
+		file = std::ofstream(filename, TranslateFlags(filename, openMode));
+
 		if (!file.is_open()) {
 			throw std::runtime_error("File could not be opened. Filename: " + filename);
 		}

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -40,7 +40,12 @@ namespace Stream
 	{
 		// Create directory if it does not exist. ofstream will fail if directory does not exist.
 		auto directory = XFile::GetDirectory(filename);
-		if (!directory.empty() && !XFile::PathExists(directory)) {
+		if (!directory.empty() && !XFile::PathExists(directory)) 
+		{
+			if (openMode != OpenMode::CanOpenNew) {
+				throw std::runtime_error("The directory does not exist. The write command was restricted from creating new files or directories.");
+			}
+
 			XFile::NewDirectory(directory);
 		}
 

--- a/test/Stream/FileWriter.test.cpp
+++ b/test/Stream/FileWriter.test.cpp
@@ -65,3 +65,13 @@ TEST(FileWriter, MoveConstructible) {
 	// Cleanup temporary file
 	XFile::DeletePath(filename);
 }
+
+TEST(FileWriter, DirectoryDoesNotExist) {
+	EXPECT_NO_THROW(Stream::FileWriter writer("../NewDirectory/TestFile.temp"));
+	EXPECT_NO_THROW(Stream::FileWriter writer("./NewDirectory/TestFile.temp"));
+	EXPECT_NO_THROW(Stream::FileWriter writer("NewDirectory/TestFile.temp"));
+
+	EXPECT_NO_THROW(Stream::FileWriter writer("..\\NewDirectory\\TestFile.temp"));
+	EXPECT_NO_THROW(Stream::FileWriter writer(".\\NewDirectory\\TestFile.temp"));
+	EXPECT_NO_THROW(Stream::FileWriter writer("NewDirectory\\TestFile.temp"));
+}

--- a/test/Stream/FileWriter.test.cpp
+++ b/test/Stream/FileWriter.test.cpp
@@ -1,6 +1,7 @@
 #include "Stream/FileWriter.h"
 #include "XFile.h"
 #include <gtest/gtest.h>
+#include <string>
 
 void WriteToNewDirectory(const std::string& path);
 
@@ -76,6 +77,11 @@ TEST(FileWriter, DirectoryDoesNotExist) {
 // Will delete the path after testing creation
 void WriteToNewDirectory(const std::string& path)
 {
+	// New directory should not be created when writer cannot create new files
+	EXPECT_THROW(Stream::FileWriter writer(path, Stream::FileWriter::OpenMode::CanOpenExisting), std::runtime_error);
+	EXPECT_FALSE(XFile::PathExists(path));
+
 	EXPECT_NO_THROW(Stream::FileWriter writer(path));
+
 	XFile::DeletePath(path);
 }

--- a/test/Stream/FileWriter.test.cpp
+++ b/test/Stream/FileWriter.test.cpp
@@ -2,6 +2,7 @@
 #include "XFile.h"
 #include <gtest/gtest.h>
 
+void WriteToNewDirectory(const std::string& path);
 
 TEST(FileWriterOpenMode, BadFlagCombinations) {
 	using OpenMode = Stream::FileWriter::OpenMode;
@@ -67,11 +68,14 @@ TEST(FileWriter, MoveConstructible) {
 }
 
 TEST(FileWriter, DirectoryDoesNotExist) {
-	EXPECT_NO_THROW(Stream::FileWriter writer("../NewDirectory/TestFile.temp"));
-	EXPECT_NO_THROW(Stream::FileWriter writer("./NewDirectory/TestFile.temp"));
-	EXPECT_NO_THROW(Stream::FileWriter writer("NewDirectory/TestFile.temp"));
+	WriteToNewDirectory("../NewDirectory/TestFile.temp");
+	WriteToNewDirectory("./NewDirectory/TestFile.temp");
+	WriteToNewDirectory("NewDirectory/TestFile.temp");
+}
 
-	EXPECT_NO_THROW(Stream::FileWriter writer("..\\NewDirectory\\TestFile.temp"));
-	EXPECT_NO_THROW(Stream::FileWriter writer(".\\NewDirectory\\TestFile.temp"));
-	EXPECT_NO_THROW(Stream::FileWriter writer("NewDirectory\\TestFile.temp"));
+// Will delete the path after testing creation
+void WriteToNewDirectory(const std::string& path)
+{
+	EXPECT_NO_THROW(Stream::FileWriter writer(path));
+	XFile::DeletePath(path);
 }


### PR DESCRIPTION
I think there is an issue with XFile::GetDirectory

It returns the filename without the extension in some cases instead of the directory.