### PR TITLE
Update TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ matrix:
   include:
     - os: linux
       dist: bionic
-      env: CXX=g++-6 CC=gcc-6
+      env: CXX=g++-7 CC=gcc-7
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-6
-            - google-mock
+            - g++-7
+            - googletest
     - os: linux
       dist: bionic
       env: CXX=clang++-6.0 CC=clang-6.0
@@ -23,7 +23,7 @@ matrix:
           packages:
             - clang-6.0
             - libstdc++-6-dev
-            - google-mock
+            - googletest
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,13 @@
 
 language: cpp
-matrix:
-  include:
-    - os: linux
-      dist: bionic
-      env: CXX=g++ CC=gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - googletest
-    - os: linux
-      dist: bionic
-      env: CXX=clang++ CC=clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - googletest
+os: linux
+dist: bionic
+compiler:
+  - gcc
+  - clang
+
+before_install:
+  - sudo apt-get install -y googletest
 
 script:
   # Use -k to continue after errors, ensuring full build log with all errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 script:
   # Use -k to continue after errors, ensuring full build log with all errors
   - make -k
-  - make gmock
+  - make gtest
   - make check
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,21 @@ matrix:
   include:
     - os: linux
       dist: bionic
-      env: CXX=g++-7 CC=gcc-7
+      env: CXX=g++ CC=gcc
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
             - googletest
     - os: linux
       dist: bionic
-      env: CXX=clang++-6.0 CC=clang-6.0
+      env: CXX=clang++ CC=clang
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
           packages:
-            - clang-6.0
-            - libstdc++-6-dev
             - googletest
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 
 language: generic
-sudo: false
 matrix:
   include:
     - os: linux
+      dist: bionic
       env: CXX=g++-6 CC=gcc-6
       addons:
         apt:
@@ -13,6 +13,7 @@ matrix:
             - g++-6
             - google-mock
     - os: linux
+      dist: bionic
       env: CXX=clang++-6.0 CC=clang-6.0
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 
-language: generic
+language: cpp
 matrix:
   include:
     - os: linux

--- a/makefile
+++ b/makefile
@@ -58,6 +58,7 @@ clean-all:
 GTESTSRCDIR := /usr/src/googletest/
 GTESTINCDIR := /usr/src/googletest/googletest/include/
 GTESTBUILDDIR := $(BUILDDIR)/gtest/
+GTESTLOCALLIBDIR := $(GTESTBUILDDIR)googlemock/
 GTESTLIBDIR := /usr/lib/
 
 .PHONY: gtest gtest-install gtest-clean
@@ -78,7 +79,7 @@ TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I$(GTESTINCDIR)
-TESTLDFLAGS := -L./ -L$(GTESTBUILDDIR) -L$(GTESTBUILDDIR)/gtest/
+TESTLDFLAGS := -L./ -L$(GTESTLOCALLIBDIR) -L$(GTESTLOCALLIBDIR)/gtest/
 TESTLIBS := -lOP2Utility -lgtest -lgtest_main -lpthread -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 


### PR DESCRIPTION
Wonderful news: TravisCI finally updated their Ubuntu images, giving stock access to Ubuntu 18.04. Additionally, they have a C++ language variant of the base Ubuntu image, which comes pre-installed with both GCC and Clang. This should improve both compile speed and maintenance issues.
