### PR TITLE
Fix signed/unsigned warnings

### DIFF
--- a/test/Archive/ArchiveFile.test.cpp
+++ b/test/Archive/ArchiveFile.test.cpp
@@ -62,8 +62,8 @@ void TestEmptyArchive(Archive::ArchiveFile& archiveFile, const std::string& arch
 
 	EXPECT_EQ(archiveFilename, archiveFile.GetArchiveFilename());
 
-	EXPECT_EQ(0, archiveFile.GetCount());
-	EXPECT_GT(archiveFile.GetArchiveFileSize(), 0);
+	EXPECT_EQ(0u, archiveFile.GetCount());
+	EXPECT_GT(archiveFile.GetArchiveFileSize(), 0u);
 
 	XFile::DeletePath(extractDirectory);
 }

--- a/test/Archive/ArchiveFile.test.cpp
+++ b/test/Archive/ArchiveFile.test.cpp
@@ -63,7 +63,7 @@ void TestEmptyArchive(Archive::ArchiveFile& archiveFile, const std::string& arch
 	EXPECT_EQ(archiveFilename, archiveFile.GetArchiveFilename());
 
 	EXPECT_EQ(0u, archiveFile.GetCount());
-	EXPECT_GT(archiveFile.GetArchiveFileSize(), 0u);
+	EXPECT_LE(0u, archiveFile.GetArchiveFileSize());
 
 	XFile::DeletePath(extractDirectory);
 }

--- a/test/BitTwiddle.test.cpp
+++ b/test/BitTwiddle.test.cpp
@@ -24,16 +24,16 @@ TEST(BitTwiddle, IsPowerOf2) {
 }
 
 TEST(BitTwiddle, Log2OfPowerOf2) {
-	EXPECT_EQ(0, Log2OfPowerOf2(1));
-	EXPECT_EQ(1, Log2OfPowerOf2(2));
-	EXPECT_EQ(2, Log2OfPowerOf2(4));
-	EXPECT_EQ(3, Log2OfPowerOf2(8));
-	EXPECT_EQ(4, Log2OfPowerOf2(16));
-	EXPECT_EQ(5, Log2OfPowerOf2(32));
-	EXPECT_EQ(6, Log2OfPowerOf2(64));
-	EXPECT_EQ(7, Log2OfPowerOf2(128));
-	EXPECT_EQ(8, Log2OfPowerOf2(256));
-	EXPECT_EQ(9, Log2OfPowerOf2(512));
+	EXPECT_EQ(0u, Log2OfPowerOf2(1));
+	EXPECT_EQ(1u, Log2OfPowerOf2(2));
+	EXPECT_EQ(2u, Log2OfPowerOf2(4));
+	EXPECT_EQ(3u, Log2OfPowerOf2(8));
+	EXPECT_EQ(4u, Log2OfPowerOf2(16));
+	EXPECT_EQ(5u, Log2OfPowerOf2(32));
+	EXPECT_EQ(6u, Log2OfPowerOf2(64));
+	EXPECT_EQ(7u, Log2OfPowerOf2(128));
+	EXPECT_EQ(8u, Log2OfPowerOf2(256));
+	EXPECT_EQ(9u, Log2OfPowerOf2(512));
 
-	EXPECT_EQ(31, Log2OfPowerOf2(1 << 31));
+	EXPECT_EQ(31u, Log2OfPowerOf2(1 << 31));
 }

--- a/test/Bitmap/ImageHeader.test.cpp
+++ b/test/Bitmap/ImageHeader.test.cpp
@@ -77,43 +77,43 @@ TEST(ImageHeader, VerifyValidBitCount)
 
 TEST(ImageHeader, CalculatePitch)
 {
-	EXPECT_EQ(4, ImageHeader::CalculatePitch(1, 1));
-	EXPECT_EQ(4, ImageHeader::CalculatePitch(1, 32));
-	EXPECT_EQ(8, ImageHeader::CalculatePitch(1, 33));
+	EXPECT_EQ(4u, ImageHeader::CalculatePitch(1, 1));
+	EXPECT_EQ(4u, ImageHeader::CalculatePitch(1, 32));
+	EXPECT_EQ(8u, ImageHeader::CalculatePitch(1, 33));
 
-	EXPECT_EQ(4, ImageHeader::CalculatePitch(4, 1));
-	EXPECT_EQ(4, ImageHeader::CalculatePitch(4, 8));
-	EXPECT_EQ(8, ImageHeader::CalculatePitch(4, 9));
+	EXPECT_EQ(4u, ImageHeader::CalculatePitch(4, 1));
+	EXPECT_EQ(4u, ImageHeader::CalculatePitch(4, 8));
+	EXPECT_EQ(8u, ImageHeader::CalculatePitch(4, 9));
 
-	EXPECT_EQ(4, ImageHeader::CalculatePitch(8, 1));
-	EXPECT_EQ(4, ImageHeader::CalculatePitch(8, 4));
-	EXPECT_EQ(8, ImageHeader::CalculatePitch(8, 5));
+	EXPECT_EQ(4u, ImageHeader::CalculatePitch(8, 1));
+	EXPECT_EQ(4u, ImageHeader::CalculatePitch(8, 4));
+	EXPECT_EQ(8u, ImageHeader::CalculatePitch(8, 5));
 
 	// Test non-static version of function
 	ImageHeader imageHeader;
 	imageHeader.bitCount = 1;
 	imageHeader.width = 1;
-	EXPECT_EQ(4, imageHeader.CalculatePitch());
+	EXPECT_EQ(4u, imageHeader.CalculatePitch());
 }
 
 TEST(ImageHeader, CalcByteWidth)
 {
-	EXPECT_EQ(1, ImageHeader::CalcPixelByteWidth(1, 1));
-	EXPECT_EQ(1, ImageHeader::CalcPixelByteWidth(1, 8));
-	EXPECT_EQ(2, ImageHeader::CalcPixelByteWidth(1, 9));
+	EXPECT_EQ(1u, ImageHeader::CalcPixelByteWidth(1, 1));
+	EXPECT_EQ(1u, ImageHeader::CalcPixelByteWidth(1, 8));
+	EXPECT_EQ(2u, ImageHeader::CalcPixelByteWidth(1, 9));
 
-	EXPECT_EQ(1, ImageHeader::CalcPixelByteWidth(4, 1));
-	EXPECT_EQ(1, ImageHeader::CalcPixelByteWidth(4, 2));
-	EXPECT_EQ(2, ImageHeader::CalcPixelByteWidth(4, 3));
+	EXPECT_EQ(1u, ImageHeader::CalcPixelByteWidth(4, 1));
+	EXPECT_EQ(1u, ImageHeader::CalcPixelByteWidth(4, 2));
+	EXPECT_EQ(2u, ImageHeader::CalcPixelByteWidth(4, 3));
 
-	EXPECT_EQ(1, ImageHeader::CalcPixelByteWidth(8, 1));
-	EXPECT_EQ(2, ImageHeader::CalcPixelByteWidth(8, 2));
+	EXPECT_EQ(1u, ImageHeader::CalcPixelByteWidth(8, 1));
+	EXPECT_EQ(2u, ImageHeader::CalcPixelByteWidth(8, 2));
 
 	// Test non-static version of function
 	ImageHeader imageHeader;
 	imageHeader.bitCount = 1;
 	imageHeader.width = 1;
-	EXPECT_EQ(1, imageHeader.CalcPixelByteWidth());
+	EXPECT_EQ(1u, imageHeader.CalcPixelByteWidth());
 }
 
 TEST(ImageHeader, Validate)

--- a/test/Map/MapHeader.test.cpp
+++ b/test/Map/MapHeader.test.cpp
@@ -24,9 +24,9 @@ protected:
 };
 
 TEST_F(MapHeader32TileSquare, WidthInTiles) {
-	EXPECT_EQ(32, mapHeader.WidthInTiles());
+	EXPECT_EQ(32u, mapHeader.WidthInTiles());
 }
 
 TEST_F(MapHeader32TileSquare, TileCount) {
-	EXPECT_EQ(32 * 32, mapHeader.TileCount());
+	EXPECT_EQ(32u * 32u, mapHeader.TileCount());
 }

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -28,7 +28,7 @@ TEST(ResourceManager, GetFilenames)
 	ResourceManager resourceManager("./data");
 	auto filenames = resourceManager.GetAllFilenamesOfType(".vol");
 
-	EXPECT_EQ(0, filenames.size());
+	EXPECT_EQ(0u, filenames.size());
 
-	EXPECT_EQ(0, resourceManager.GetAllFilenames("Directory.vol").size());
+	EXPECT_EQ(0u, resourceManager.GetAllFilenames("Directory.vol").size());
 }

--- a/test/Stream/BidirectionalReader.test.h
+++ b/test/Stream/BidirectionalReader.test.h
@@ -31,10 +31,10 @@ TYPED_TEST_P(SimpleSeekableReader, SeekRelativeOutOfBoundsBeginningPreservesPosi
 TYPED_TEST_P(SimpleSeekableReader, StreamPositionUpdatesOnRead) {
 	char destinationBuffer;
 
-	EXPECT_EQ(0, this->seekableReader.Position());
+	EXPECT_EQ(0u, this->seekableReader.Position());
 
 	this->seekableReader.Read(destinationBuffer);
-	EXPECT_EQ(1, this->seekableReader.Position());
+	EXPECT_EQ(1u, this->seekableReader.Position());
 }
 
 TYPED_TEST_P(SimpleSeekableReader, StreamSizeMatchesInitialization) {

--- a/test/Stream/DynamicMemoryWriter.test.cpp
+++ b/test/Stream/DynamicMemoryWriter.test.cpp
@@ -9,19 +9,19 @@ TEST(DynamicMemoryWriter, LengthAutoExpands) {
 	Stream::DynamicMemoryWriter writer;
 
 	// Initially stream has 0 length
-	EXPECT_EQ(0, writer.Length());
+	EXPECT_EQ(0u, writer.Length());
 
 	// Length grows as data is added
 	EXPECT_NO_THROW(writer.Write(data));
-	EXPECT_EQ(4, writer.Length());
+	EXPECT_EQ(4u, writer.Length());
 
 	// Seeking forward past the end expands the stream
 	EXPECT_NO_THROW(writer.SeekForward(1));
-	EXPECT_EQ(5, writer.Length());
+	EXPECT_EQ(5u, writer.Length());
 
 	// Additional data is added after the expansion gap
 	EXPECT_NO_THROW(writer.Write(data));
-	EXPECT_EQ(9, writer.Length());
+	EXPECT_EQ(9u, writer.Length());
 }
 
 TEST(DynamicMemoryWriter, ReadsBackStoredData) {

--- a/test/Stream/FileReader.test.cpp
+++ b/test/Stream/FileReader.test.cpp
@@ -18,8 +18,8 @@ TEST(FileReaderTest, ZeroSizeStreamHasSafeOperations) {
 	Stream::FileReader stream("Stream/data/EmptyFile.txt");
 
 	// Length and position
-	EXPECT_EQ(0, stream.Length());
-	EXPECT_EQ(0, stream.Position());
+	EXPECT_EQ(0u, stream.Length());
+	EXPECT_EQ(0u, stream.Position());
 
 	// Seek to current position (should not cause error)
 	ASSERT_NO_THROW(stream.Seek(0));
@@ -28,7 +28,7 @@ TEST(FileReaderTest, ZeroSizeStreamHasSafeOperations) {
 
 	// Read 0 bytes
 	ASSERT_NO_THROW(stream.Read(nullptr, 0));
-	EXPECT_EQ(0, stream.ReadPartial(nullptr, 0));
+	EXPECT_EQ(0u, stream.ReadPartial(nullptr, 0));
 }
 
 
@@ -46,5 +46,5 @@ TEST_F(SimpleFileReader, SeekRelativeOutOfBoundsBeginningPreservesPosition) {
 }
 
 TEST_F(SimpleFileReader, StreamSizeMatchesInitialization) {
-	EXPECT_EQ(stream.Length(), 5);
+	EXPECT_EQ(stream.Length(), 5u);
 }

--- a/test/Stream/FileReader.test.cpp
+++ b/test/Stream/FileReader.test.cpp
@@ -46,5 +46,5 @@ TEST_F(SimpleFileReader, SeekRelativeOutOfBoundsBeginningPreservesPosition) {
 }
 
 TEST_F(SimpleFileReader, StreamSizeMatchesInitialization) {
-	EXPECT_EQ(stream.Length(), 5u);
+	EXPECT_EQ(5u, stream.Length());
 }

--- a/test/Stream/MemoryStreamReader.test.cpp
+++ b/test/Stream/MemoryStreamReader.test.cpp
@@ -28,8 +28,8 @@ TEST(MemoryStreamReaderTest, ZeroSizeStreamHasSafeOperations) {
 	Stream::MemoryReader stream(nullptr, 0);
 	
 	// Length and position
-	EXPECT_EQ(0, stream.Length());
-	EXPECT_EQ(0, stream.Position());
+	EXPECT_EQ(0u, stream.Length());
+	EXPECT_EQ(0u, stream.Position());
 	
 	// Seek to current position (should not cause error)
 	ASSERT_NO_THROW(stream.Seek(0));
@@ -38,7 +38,7 @@ TEST(MemoryStreamReaderTest, ZeroSizeStreamHasSafeOperations) {
 	
 	// Read 0 bytes
 	ASSERT_NO_THROW(stream.Read(nullptr, 0));
-	EXPECT_EQ(0, stream.ReadPartial(nullptr, 0));
+	EXPECT_EQ(0u, stream.ReadPartial(nullptr, 0));
 }
 
 
@@ -54,8 +54,8 @@ protected:
 
 TEST_F(EmptyMemoryStreamReader, ZeroSizeStreamHasSafeOperations) {
 	// Length and position
-	EXPECT_EQ(0, stream.Length());
-	EXPECT_EQ(0, stream.Position());
+	EXPECT_EQ(0u, stream.Length());
+	EXPECT_EQ(0u, stream.Position());
 
 	// Seek to current position (should not cause error)
 	ASSERT_NO_THROW(stream.Seek(0));
@@ -64,7 +64,7 @@ TEST_F(EmptyMemoryStreamReader, ZeroSizeStreamHasSafeOperations) {
 
 	// Read 0 bytes
 	ASSERT_NO_THROW(stream.Read(nullptr, 0));
-	EXPECT_EQ(0, stream.ReadPartial(nullptr, 0));
+	EXPECT_EQ(0u, stream.ReadPartial(nullptr, 0));
 }
 
 

--- a/test/Stream/Reader.test.h
+++ b/test/Stream/Reader.test.h
@@ -23,7 +23,7 @@ TYPED_TEST_P(BasicReaderTests, CanReadZeroBytesToNull) {
 }
 
 TYPED_TEST_P(BasicReaderTests, CanReadPartialZeroBytesToNull) {
-	EXPECT_EQ(0, this->stream.ReadPartial(nullptr, 0));
+	EXPECT_EQ(0u, this->stream.ReadPartial(nullptr, 0));
 }
 
 REGISTER_TYPED_TEST_CASE_P(BasicReaderTests,

--- a/test/Tag.test.cpp
+++ b/test/Tag.test.cpp
@@ -6,20 +6,20 @@
 
 TEST(Tag, RemoveLastElement) {
 	// Note: Empty string (size 0) omitted, since variables may always take at least 1 byte
-	EXPECT_EQ(1, sizeof(RemoveLastElement("A")));
-	EXPECT_EQ(4, sizeof(RemoveLastElement("volh")));
-	EXPECT_EQ(11, sizeof(RemoveLastElement("some string")));
+	EXPECT_EQ(1u, sizeof(RemoveLastElement("A")));
+	EXPECT_EQ(4u, sizeof(RemoveLastElement("volh")));
+	EXPECT_EQ(11u, sizeof(RemoveLastElement("some string")));
 
 	// Wide string literals and unicode string literals
-	EXPECT_EQ(4, RemoveLastElement(L"wide").size());
-	EXPECT_EQ(5, RemoveLastElement(u8"UTF-8").size());
-	EXPECT_EQ(6, RemoveLastElement(u"UTF-16").size());
-	EXPECT_EQ(6, RemoveLastElement(U"UTF-32").size());
+	EXPECT_EQ(4u, RemoveLastElement(L"wide").size());
+	EXPECT_EQ(5u, RemoveLastElement(u8"UTF-8").size());
+	EXPECT_EQ(6u, RemoveLastElement(u"UTF-16").size());
+	EXPECT_EQ(6u, RemoveLastElement(U"UTF-32").size());
 }
 
 TEST(Tag, Properties) {
 	// Proper size
-	EXPECT_EQ(4, sizeof(Tag));
+	EXPECT_EQ(4u, sizeof(Tag));
 
 	// Tags can be memcopied
 	EXPECT_TRUE(std::is_trivially_copyable<Tag>::value);


### PR DESCRIPTION
This fixes the signed/unsigned warnings from issue #314, seen on Linux with GCC.
