### PR TITLE
When over-writing an existing volume, prevent adding the volume to itself

### DIFF
--- a/src/Archive/VolFile.cpp
+++ b/src/Archive/VolFile.cpp
@@ -172,6 +172,12 @@ namespace Archive
 
 	void VolFile::WriteVolume(const std::string& filename, CreateVolumeInfo& volInfo)
 	{
+		for (const auto& path : volInfo.filesToPack) {
+			if (XFile::PathsAreEqual(filename, path)) {
+				throw std::runtime_error("Cannot include a volume being overwritten in new volume " + filename);
+			}
+		}
+
 		Stream::FileWriter volWriter(filename);
 
 		WriteHeader(volWriter, volInfo);


### PR DESCRIPTION
Causes the program to hang

This was discovered when testing OP2Archive. Basically, if you are over-writing a volume, and that volume is being added to the new volume, it will hang the program. I suspect this could be reproduced for a CLM. 

-Brett