### PR TITLE
Fix `ResourceManager` path bug

### DIFF
--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -160,16 +160,10 @@ std::vector<std::string> ResourceManager::GetArchiveFilenames()
 
 std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::string& fileExtension)
 {
-	auto directoryContents = XFile::GetFilenamesFromDirectory(resourceRootDir, fileExtension);
-	XFile::EraseNonFilenames(directoryContents);
-
-	return directoryContents;
+	return XFile::DirFilesWithExtension(resourceRootDir, fileExtension);
 }
 
 std::vector<std::string> ResourceManager::GetFilesFromDirectory(const std::regex& filenameRegex)
 {
-	auto directoryContents = XFile::GetFilenamesFromDirectory(resourceRootDir, filenameRegex);
-	XFile::EraseNonFilenames(directoryContents);
-
-	return directoryContents;
+	return XFile::DirFiles(resourceRootDir, filenameRegex);
 }

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -92,7 +92,7 @@ std::string XFile::AppendToFilename(const std::string& filename, const std::stri
 	return newPath.string();
 }
 
-std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& directory)
+std::vector<std::string> XFile::Dir(const std::string& directory)
 {
 	// Creating a path with an empty string will prevent the directory_iterator from finding files in the current relative path.
 	auto pathStr = directory.length() > 0 ? directory : "./";
@@ -106,7 +106,7 @@ std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& dir
 }
 
 template <typename SelectFunction>
-std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, SelectFunction selectFunction)
+std::vector<std::string> Dir(const std::string& directory, SelectFunction selectFunction)
 {
 	// Creating a path with an empty string will prevent the directory_iterator from finding files in the current relative path.
 	auto pathStr = directory.length() > 0 ? directory : "./";
@@ -122,9 +122,9 @@ std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory,
 	return filenames;
 }
 
-std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& directory, const std::string& extension)
+std::vector<std::string> XFile::DirWithExtension(const std::string& directory, const std::string& extension)
 {
-	return ::GetFilenamesFromDirectory(
+	return ::Dir(
 		directory,
 		[&extension](const std::string& filename) {
 			return fs::path(filename).extension().string() == extension;
@@ -132,9 +132,9 @@ std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& dir
 	);
 }
 
-std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& directory, const std::regex& filenameRegex)
+std::vector<std::string> XFile::Dir(const std::string& directory, const std::regex& filenameRegex)
 {
-	return ::GetFilenamesFromDirectory(
+	return ::Dir(
 		directory,
 		[&filenameRegex](const std::string& filename) {
 			return std::regex_search(filename, filenameRegex);
@@ -144,7 +144,7 @@ std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& dir
 
 std::vector<std::string> XFile::DirFilesWithExtension(const std::string& directory, const std::string& extension)
 {
-	return ::GetFilenamesFromDirectory(
+	return ::Dir(
 		directory,
 		[&extension](const std::string& filename) {
 			return (fs::path(filename).extension().string() == extension) && IsFile(filename);
@@ -154,7 +154,7 @@ std::vector<std::string> XFile::DirFilesWithExtension(const std::string& directo
 
 std::vector<std::string> XFile::DirFiles(const std::string& directory, const std::regex& filenameRegex)
 {
-	return ::GetFilenamesFromDirectory(
+	return ::Dir(
 		directory,
 		[&filenameRegex](const std::string& filename) {
 			return std::regex_search(filename, filenameRegex) && IsFile(filename);

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -142,6 +142,16 @@ std::vector<std::string> XFile::DirWithExtension(const std::string& directory, c
 	);
 }
 
+std::vector<std::string> XFile::DirFiles(const std::string& directory)
+{
+	return ::Dir(
+		directory,
+		[](const std::string& filename) {
+			return IsFile(filename);
+		}
+	);
+}
+
 std::vector<std::string> XFile::DirFiles(const std::string& directory, const std::regex& filenameRegex)
 {
 	return ::Dir(

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -122,16 +122,6 @@ std::vector<std::string> Dir(const std::string& directory, SelectFunction select
 	return filenames;
 }
 
-std::vector<std::string> XFile::DirWithExtension(const std::string& directory, const std::string& extension)
-{
-	return ::Dir(
-		directory,
-		[&extension](const std::string& filename) {
-			return fs::path(filename).extension().string() == extension;
-		}
-	);
-}
-
 std::vector<std::string> XFile::Dir(const std::string& directory, const std::regex& filenameRegex)
 {
 	return ::Dir(
@@ -142,12 +132,12 @@ std::vector<std::string> XFile::Dir(const std::string& directory, const std::reg
 	);
 }
 
-std::vector<std::string> XFile::DirFilesWithExtension(const std::string& directory, const std::string& extension)
+std::vector<std::string> XFile::DirWithExtension(const std::string& directory, const std::string& extension)
 {
 	return ::Dir(
 		directory,
 		[&extension](const std::string& filename) {
-			return (fs::path(filename).extension().string() == extension) && IsFile(filename);
+			return fs::path(filename).extension().string() == extension;
 		}
 	);
 }
@@ -158,6 +148,16 @@ std::vector<std::string> XFile::DirFiles(const std::string& directory, const std
 		directory,
 		[&filenameRegex](const std::string& filename) {
 			return std::regex_search(filename, filenameRegex) && IsFile(filename);
+		}
+	);
+}
+
+std::vector<std::string> XFile::DirFilesWithExtension(const std::string& directory, const std::string& extension)
+{
+	return ::Dir(
+		directory,
+		[&extension](const std::string& filename) {
+			return (fs::path(filename).extension().string() == extension) && IsFile(filename);
 		}
 	);
 }

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -142,6 +142,16 @@ std::vector<std::string> XFile::GetFilenamesFromDirectory(const std::string& dir
 	);
 }
 
+std::vector<std::string> XFile::DirFilesWithExtension(const std::string& directory, const std::string& extension)
+{
+	return ::GetFilenamesFromDirectory(
+		directory,
+		[&extension](const std::string& filename) {
+			return (fs::path(filename).extension().string() == extension) && IsFile(filename);
+		}
+	);
+}
+
 void XFile::EraseNonFilenames(std::vector<std::string>& directoryContents)
 {
 	directoryContents.erase(

--- a/src/XFile.cpp
+++ b/src/XFile.cpp
@@ -152,6 +152,16 @@ std::vector<std::string> XFile::DirFilesWithExtension(const std::string& directo
 	);
 }
 
+std::vector<std::string> XFile::DirFiles(const std::string& directory, const std::regex& filenameRegex)
+{
+	return ::GetFilenamesFromDirectory(
+		directory,
+		[&filenameRegex](const std::string& filename) {
+			return std::regex_search(filename, filenameRegex) && IsFile(filename);
+		}
+	);
+}
+
 void XFile::EraseNonFilenames(std::vector<std::string>& directoryContents)
 {
 	directoryContents.erase(

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -34,6 +34,9 @@ namespace XFile
 	// Extension includes the dot (.) prefix
 	std::vector<std::string> DirFilesWithExtension(const std::string& directory, const std::string& extension);
 
+	// Non-recursive search that returns files from a directory (but not subfolders)
+	std::vector<std::string> DirFiles(const std::string& directory, const std::regex& filenameRegex);
+
 	// Erase all paths that are not represent filenames (such as subdirectories)
 	void EraseNonFilenames(std::vector<std::string>& directoryContents);
 

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -30,6 +30,10 @@ namespace XFile
 	// Non-recursive search that returns entire directory contents (not just filenames)
 	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, const std::regex& filenameRegex);
 
+	// Non-recursive search that returns files from a directory (but not subfolders)
+	// Extension includes the dot (.) prefix
+	std::vector<std::string> DirFilesWithExtension(const std::string& directory, const std::string& extension);
+
 	// Erase all paths that are not represent filenames (such as subdirectories)
 	void EraseNonFilenames(std::vector<std::string>& directoryContents);
 

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -31,6 +31,9 @@ namespace XFile
 	std::vector<std::string> DirWithExtension(const std::string& directory, const std::string& extension);
 
 	// Non-recursive search that returns files from a directory (but not subfolders)
+	std::vector<std::string> DirFiles(const std::string& directory);
+
+	// Non-recursive search that returns files from a directory (but not subfolders)
 	std::vector<std::string> DirFiles(const std::string& directory, const std::regex& filenameRegex);
 
 	// Non-recursive search that returns files from a directory (but not subfolders)

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -21,14 +21,14 @@ namespace XFile
 	bool IsFile(const std::string& path);
 
 	// Non-recursive search that returns entire directory contents (not just filenames)
-	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory);
+	std::vector<std::string> Dir(const std::string& directory);
 	
 	// Non-recursive search that returns entire directory contents (not just filenames)
 	// Extension includes the dot (.) prefix
-	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, const std::string& extension);
+	std::vector<std::string> DirWithExtension(const std::string& directory, const std::string& extension);
 	
 	// Non-recursive search that returns entire directory contents (not just filenames)
-	std::vector<std::string> GetFilenamesFromDirectory(const std::string& directory, const std::regex& filenameRegex);
+	std::vector<std::string> Dir(const std::string& directory, const std::regex& filenameRegex);
 
 	// Non-recursive search that returns files from a directory (but not subfolders)
 	// Extension includes the dot (.) prefix

--- a/src/XFile.h
+++ b/src/XFile.h
@@ -22,20 +22,20 @@ namespace XFile
 
 	// Non-recursive search that returns entire directory contents (not just filenames)
 	std::vector<std::string> Dir(const std::string& directory);
-	
+
+	// Non-recursive search that returns entire directory contents (not just filenames)
+	std::vector<std::string> Dir(const std::string& directory, const std::regex& filenameRegex);
+
 	// Non-recursive search that returns entire directory contents (not just filenames)
 	// Extension includes the dot (.) prefix
 	std::vector<std::string> DirWithExtension(const std::string& directory, const std::string& extension);
-	
-	// Non-recursive search that returns entire directory contents (not just filenames)
-	std::vector<std::string> Dir(const std::string& directory, const std::regex& filenameRegex);
+
+	// Non-recursive search that returns files from a directory (but not subfolders)
+	std::vector<std::string> DirFiles(const std::string& directory, const std::regex& filenameRegex);
 
 	// Non-recursive search that returns files from a directory (but not subfolders)
 	// Extension includes the dot (.) prefix
 	std::vector<std::string> DirFilesWithExtension(const std::string& directory, const std::string& extension);
-
-	// Non-recursive search that returns files from a directory (but not subfolders)
-	std::vector<std::string> DirFiles(const std::string& directory, const std::regex& filenameRegex);
 
 	// Erase all paths that are not represent filenames (such as subdirectories)
 	void EraseNonFilenames(std::vector<std::string>& directoryContents);

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -1,4 +1,6 @@
 #include "../src/ResourceManager.h"
+#include "../src/Archive/VolFile.h"
+#include "../src/XFile.h"
 #include <gtest/gtest.h>
 #include <stdexcept>
 
@@ -20,6 +22,13 @@ TEST(ResourceManager, GetResourceStream_RefuseAbsolutePath) {
 #endif
 	EXPECT_THROW(resourceManager.GetResourceStream("/Archive.vol"), std::runtime_error);
 	EXPECT_THROW(resourceManager.GetResourceStream("/PathTo/Archive.vol"), std::runtime_error);
+}
+
+TEST(ResourceManager, GetResourceStreamExistingFileUnpacked)
+{
+	ResourceManager resourceManager("./data");
+	// Opening an existing file should result in a valid stream
+	EXPECT_NE(nullptr, resourceManager.GetResourceStream("Empty.txt"));
 }
 
 TEST(ResourceManager, GetFilenames)

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -41,3 +41,14 @@ TEST(ResourceManager, GetFilenames)
 
 	EXPECT_EQ(0u, resourceManager.GetAllFilenames("Directory.vol").size());
 }
+
+TEST(ResourceManager, GetArchiveFilenames)
+{
+	const std::string archiveName("./data/Test.vol");
+	Archive::VolFile::CreateArchive(archiveName, {});
+
+	ResourceManager resourceManager("./data");
+	EXPECT_EQ(std::vector<std::string>{archiveName}, resourceManager.GetArchiveFilenames());
+
+	XFile::DeletePath(archiveName);
+}

--- a/test/ResourceManager.test.cpp
+++ b/test/ResourceManager.test.cpp
@@ -47,8 +47,13 @@ TEST(ResourceManager, GetArchiveFilenames)
 	const std::string archiveName("./data/Test.vol");
 	Archive::VolFile::CreateArchive(archiveName, {});
 
-	ResourceManager resourceManager("./data");
-	EXPECT_EQ(std::vector<std::string>{archiveName}, resourceManager.GetArchiveFilenames());
+	// Scope block to ensures ResourceManager is destructed after use
+	// This ensures the VOL file is closed before attempting to delete it
+	// This is needed for Windows filesystem semantics
+	{
+		ResourceManager resourceManager("./data");
+		EXPECT_EQ(std::vector<std::string>{archiveName}, resourceManager.GetArchiveFilenames());
+	}
 
 	XFile::DeletePath(archiveName);
 }

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -120,3 +120,10 @@ TEST(XFileGetFilenamesFromDirectory, ExplicitCurrentDirectory) {
 	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
+
+TEST(XFileDirFilesWithExtension, DataPath) {
+	// Files are found
+	EXPECT_THAT(XFile::DirFilesWithExtension("data/", ".txt"), testing::Contains(testing::EndsWith("Empty.txt")));
+	// Directories are skipped
+	EXPECT_THAT(XFile::DirFilesWithExtension("data/", ".vol"), Not(testing::Contains(testing::EndsWith("Directory.vol"))));
+}

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -131,6 +131,13 @@ TEST(XFileDirFilesWithExtension, DataPath) {
 	EXPECT_THAT(XFile::DirFilesWithExtension("data/", ".vol"), Not(testing::Contains(testing::EndsWith("Directory.vol"))));
 }
 
+TEST(XFileDirFiles, NoFilter) {
+	// Files are found
+	EXPECT_THAT(XFile::DirFiles("data/"), testing::Contains(testing::EndsWith("Empty.txt")));
+	// Directories are skipped
+	EXPECT_THAT(XFile::DirFiles("data/"), Not(testing::Contains(testing::EndsWith("Directory.vol"))));
+}
+
 TEST(XFileDirFiles, DataPath) {
 	// Files are found
 	EXPECT_THAT(XFile::DirFiles("data/", std::regex(".txt")), testing::Contains(testing::EndsWith("Empty.txt")));

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -127,3 +127,10 @@ TEST(XFileDirFilesWithExtension, DataPath) {
 	// Directories are skipped
 	EXPECT_THAT(XFile::DirFilesWithExtension("data/", ".vol"), Not(testing::Contains(testing::EndsWith("Directory.vol"))));
 }
+
+TEST(XFileDirFiles, DataPath) {
+	// Files are found
+	EXPECT_THAT(XFile::DirFiles("data/", std::regex(".txt")), testing::Contains(testing::EndsWith("Empty.txt")));
+	// Directories are skipped
+	EXPECT_THAT(XFile::DirFiles("data/", std::regex(".vol")), Not(testing::Contains(testing::EndsWith("Directory.vol"))));
+}

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -109,15 +109,18 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 }
 
 
-TEST(XFileGetFilenamesFromDirectory, EmptyPath) {
+TEST(XFileGetFilenamesFromDirectory, NoFilter) {
 	EXPECT_THAT(XFile::GetFilenamesFromDirectory(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 
-TEST(XFileGetFilenamesFromDirectory, ExplicitCurrentDirectory) {
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+TEST(XFileGetFilenamesFromDirectory, ExtensionFilter) {
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+}
+
+TEST(XFileGetFilenamesFromDirectory, RegexFilter) {
+	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 

--- a/test/XFile.test.cpp
+++ b/test/XFile.test.cpp
@@ -109,19 +109,19 @@ TEST(XFileGetDirectory, WindowsAbsolutePathToDirectory) {
 }
 
 
-TEST(XFileGetFilenamesFromDirectory, NoFilter) {
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+TEST(XFileDir, NoFilter) {
+	EXPECT_THAT(XFile::Dir(""), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::Dir("./"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 
-TEST(XFileGetFilenamesFromDirectory, ExtensionFilter) {
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+TEST(XFileDirWithExtension, ExtensionFilter) {
+	EXPECT_THAT(XFile::DirWithExtension("", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::DirWithExtension("./", ".vcxproj"), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 
-TEST(XFileGetFilenamesFromDirectory, RegexFilter) {
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
-	EXPECT_THAT(XFile::GetFilenamesFromDirectory("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+TEST(XFileDir, RegexFilter) {
+	EXPECT_THAT(XFile::Dir("", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
+	EXPECT_THAT(XFile::Dir("./", std::regex(".*[.]vcxproj")), testing::Contains(testing::EndsWith("OP2UtilityTest.vcxproj")));
 }
 
 TEST(XFileDirFilesWithExtension, DataPath) {


### PR DESCRIPTION
This is based on PR #323. ~~Review may be easier if we first merge the parent branch, and then rebase this branch on master.~~ Edit: Rebase complete.

This fixes #321. Provided wrapper methods may not exactly match those suggested in the issue. We may want to decide if more should be added, or if some should be removed.

This fixes #324. As I hadn't really made a definite decision on the final name, I went with the original I had suggested. I'd still be open to using an alternate name. Mostly I did this rename because it flowed naturally with the updates to the other issue above.
