### PR TITLE
When attempting to create a file with the same name as a directory, F…

### DIFF
--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -38,6 +38,10 @@ namespace Stream
 	FileWriter::FileWriter(const std::string& filename, OpenMode openMode) :
 		filename(filename)
 	{
+		if (XFile::IsDirectory(filename) && XFile::PathExists(filename)) {
+			throw std::runtime_error("Requested filename already exists as a directory.");
+		}
+
 		// Create directory if it does not exist. ofstream will fail if directory does not exist.
 		auto directory = XFile::GetDirectory(filename);
 		if (!directory.empty() && !XFile::PathExists(directory)) 

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -38,6 +38,10 @@ namespace Stream
 	FileWriter::FileWriter(const std::string& filename, OpenMode openMode) :
 		filename(filename)
 	{
+		if (filename.empty()) {
+			throw std::runtime_error("Empty filename provided.");
+		}
+
 		if (XFile::IsDirectory(filename) && XFile::PathExists(filename)) {
 			throw std::runtime_error("Requested filename already exists as a directory.");
 		}

--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -42,7 +42,7 @@ namespace Stream
 			throw std::runtime_error("Empty filename provided.");
 		}
 
-		if (XFile::IsDirectory(filename) && XFile::PathExists(filename)) {
+		if (XFile::IsDirectory(filename)) {
 			throw std::runtime_error("Requested filename already exists as a directory.");
 		}
 

--- a/test/Stream/FileWriter.test.cpp
+++ b/test/Stream/FileWriter.test.cpp
@@ -73,8 +73,9 @@ TEST(FileWriter, MoveConstructible) {
 	XFile::DeletePath(filename);
 }
 
-TEST(FileWriter, EmptyFilename) {
+TEST(FileWriter, InvalidFilename) {
 	EXPECT_THROW(Stream::FileWriter fileWriter(""), std::runtime_error);
+	EXPECT_THROW(Stream::FileWriter fileWriter("data"), std::runtime_error);
 }
 
 TEST(FileWriter, DirectoryDoesNotExist) {

--- a/test/Stream/FileWriter.test.cpp
+++ b/test/Stream/FileWriter.test.cpp
@@ -73,6 +73,10 @@ TEST(FileWriter, MoveConstructible) {
 	XFile::DeletePath(filename);
 }
 
+TEST(FileWriter, EmptyFilename) {
+	EXPECT_THROW(Stream::FileWriter fileWriter(""), std::runtime_error);
+}
+
 TEST(FileWriter, DirectoryDoesNotExist) {
 	WriteToNewDirectory("../NewDirectory/TestFile.temp");
 	WriteToNewDirectory("./NewDirectory/TestFile.temp");


### PR DESCRIPTION
…ileWriter can present a more specific error.

This one does not have to be merged if it is controversial, but it seemed easier to just demonstrate in code than write an issue.

I was confused for a while because earlier I had created a test.vol directory for testing purposes. The code kept telling me the file already existed even though I was passing the overwrite flag. Took me a while to diagnose.