### PR TITLE
Add a GetLavaPossible helper function to Map

### DIFF
--- a/src/Map/Map.cpp
+++ b/src/Map/Map.cpp
@@ -25,6 +25,10 @@ bool Map::GetLavaPossible(std::size_t x, std::size_t y) const
 	return tiles[GetTileIndex(x, y)].bLavaPossible;
 }
 
+void Map::SetLavaPossible(bool lavaPossible, std::size_t x, std::size_t y)
+{
+	tiles[GetTileIndex(x, y)].bLavaPossible = lavaPossible;
+}
 
 std::size_t Map::GetTilesetIndex(std::size_t x, std::size_t y) const
 {

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -84,6 +84,7 @@ public:
 	std::size_t GetTileMappingIndex(std::size_t x, std::size_t y) const;
 	CellType GetCellType(std::size_t x, std::size_t y) const;
 	bool GetLavaPossible(std::size_t x, std::size_t y) const;
+	void SetLavaPossible(bool lavaPossible, std::size_t x, std::size_t y);
 	std::size_t GetTilesetIndex(std::size_t x, std::size_t y) const;
 	std::size_t GetImageIndex(std::size_t x, std::size_t y) const;
 

--- a/test/Map/Map.test.cpp
+++ b/test/Map/Map.test.cpp
@@ -20,3 +20,14 @@ TEST(Map, TrimTilesetSources) {
 		map.tilesetSources
 	);
 }
+
+TEST(Map, LavaPossible) {
+	Map map;
+	map.tiles.push_back(Tile());
+
+	EXPECT_NO_THROW(map.SetLavaPossible(true, 0, 0));
+	EXPECT_TRUE(map.GetLavaPossible(0, 0));
+
+	EXPECT_NO_THROW(map.SetLavaPossible(false, 0, 0));
+	EXPECT_FALSE(map.GetLavaPossible(0, 0));
+}


### PR DESCRIPTION
I was going to add support for checking if valid x and y coordinates are given, but that creates a pretty significant chain reaction of code updates and maybe should be in a different branch. 

Also, I think we need to document the function Map::GetTileIndex better (for my own sake and anyone else who isn't great at bit twiddling).