### PR TITLE
Mark FileWriter Move Constructor as noexcept

### DIFF
--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -63,7 +63,7 @@ namespace Stream
 		}
 	}
 
-	FileWriter::FileWriter(FileWriter&& fileWriter) :
+	FileWriter::FileWriter(FileWriter&& fileWriter) noexcept :
 		filename(std::move(fileWriter.filename)),
 		file(std::move(fileWriter.file))
 	{

--- a/src/Stream/FileWriter.h
+++ b/src/Stream/FileWriter.h
@@ -27,7 +27,7 @@ namespace Stream
 		//   CanOpenNew
 		// If both flags are specified, no race condition can occur
 		FileWriter(const std::string& filename, OpenMode openMode = OpenMode::Default);
-		FileWriter(FileWriter&& fileWriter);
+		FileWriter(FileWriter&& fileWriter) noexcept;
 		~FileWriter() override;
 
 		// SeekableWriter methods


### PR DESCRIPTION
Resolves the warning below:

Warning	C26439	This kind of function may not throw. Declare it 'noexcept' (f.6).	OP2Utility	\OP2UTILITY\SRC\STREAM\FILEWRITER.CPP	66	

New warning as of VS2019's toolset.