### PR TITLE
Fix move warning within FileWriter

### DIFF
--- a/src/Stream/FileWriter.cpp
+++ b/src/Stream/FileWriter.cpp
@@ -64,7 +64,7 @@ namespace Stream
 	}
 
 	FileWriter::FileWriter(FileWriter&& fileWriter) noexcept :
-		filename(std::move(fileWriter.filename)),
+		filename(fileWriter.filename),
 		file(std::move(fileWriter.file))
 	{
 	}


### PR DESCRIPTION
I think the warning is telling me that the move isn't happening anyways because the source is labeled const? Not so sure about this one.

Warning	C26478	Don't use std::move on constant variables. (es.56).	OP2Utility	\OP2UTILITY\SRC\STREAM\FILEWRITER.CPP	67

https://docs.microsoft.com/en-us/visualstudio/code-quality/c26478