### PR TITLE
Update Docker image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,25 +13,17 @@
 
 FROM ubuntu:20.04
 
-# Install CircleCI tools needed for primary containers
+# Install Development tools, Google Test library, and tools for primary CircleCI container
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    cmake \
+    libgtest-dev \
     git \
     ssh \
     tar \
     gzip \
     ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-
-# Install gcc and clang compilers
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    clang \
-  && rm -rf /var/lib/apt/lists/*
-
-# Install Google Test (source package and build dependencies)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake \
-    libgtest-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Compile and install Google Test

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -11,7 +11,7 @@
 # Validate .circleci/config.yml file with:
 #   circleci config validate
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Install CircleCI tools needed for primary containers
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG gtestBuildDir=/tmp/gtest/
 RUN mkdir -p ${gtestBuildDir} && \
   cd ${gtestBuildDir} && \
-  cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/gtest/ && \
+  cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gtest/ && \
   make -C ${gtestBuildDir} && \
   cp ${gtestBuildDir}lib*.a /usr/lib && \
   rm -rf ${gtestBuildDir}

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -26,12 +26,3 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     gzip \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
-
-# Compile and install Google Test
-ARG gtestBuildDir=/tmp/gtest/
-RUN mkdir -p ${gtestBuildDir} && \
-  cd ${gtestBuildDir} && \
-  cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gtest/ && \
-  make -C ${gtestBuildDir} && \
-  cp ${gtestBuildDir}lib*.a /usr/lib && \
-  rm -rf ${gtestBuildDir}

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -14,7 +14,7 @@
 FROM ubuntu:20.04
 
 # Install Development tools, Google Test library, and tools for primary CircleCI container
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     clang \
     cmake \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     clang \
     cmake \
     libgtest-dev \
+    libgmock-dev \
     git \
     ssh \
     tar \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,10 +1,10 @@
 # For building on CircleCI with Google Test
 
 # Build from the root project folder with:
-#   docker build .circleci/ --tag outpostuniverse/circleci-gcc-clang-googletest
+#   docker build .circleci/ --tag outpostuniverse/op2utility:1.1
 # Push image to DockerHub with:
 #   docker login
-#   docker push outpostuniverse/circleci-gcc-clang-googletest
+#   docker push outpostuniverse/op2utility
 
 # Run locally using the CircleCI command line interface:
 #   circleci build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2
 jobs:
   gcc:
     docker:
-      - image: outpostuniverse/circleci-gcc-clang-googletest
+      - image: outpostuniverse/op2utility:1.1
     steps:
       - checkout
       - run: make -k CXX=g++
       - run: make check CXX=g++
   clang:
     docker:
-      - image: outpostuniverse/circleci-gcc-clang-googletest
+      - image: outpostuniverse/op2utility:1.1
     steps:
       - checkout
       - run: make -k CXX=clang++


### PR DESCRIPTION
Update the Docker image for CircleCI builds.
- Change base image to Ubuntu 20.04
- Update Google Test to v1.10.0

The change allows deprecation warnings to be seen for the newer version of Google Test.

The update also reveals some path handling changes related to the `<filesystem>` header. (Edit: See #340, and #341).
