### PR TITLE
Fix Google Test macro deprecation warning

### DIFF
--- a/test/Stream/BidirectionalReader.test.h
+++ b/test/Stream/BidirectionalReader.test.h
@@ -18,7 +18,7 @@ protected:
 	const unsigned int size = 5;
 };
 
-TYPED_TEST_CASE_P(SimpleSeekableReader);
+TYPED_TEST_SUITE_P(SimpleSeekableReader);
 
 TYPED_TEST_P(SimpleSeekableReader, SeekRelativeOutOfBoundsBeginningPreservesPosition) {
 	auto position = this->seekableReader.Position();
@@ -41,7 +41,7 @@ TYPED_TEST_P(SimpleSeekableReader, StreamSizeMatchesInitialization) {
 	EXPECT_EQ(this->size, this->seekableReader.Length());
 }
 
-REGISTER_TYPED_TEST_CASE_P(SimpleSeekableReader,
+REGISTER_TYPED_TEST_SUITE_P(SimpleSeekableReader,
 	SeekRelativeOutOfBoundsBeginningPreservesPosition,
 	StreamPositionUpdatesOnRead,
 	StreamSizeMatchesInitialization

--- a/test/Stream/FileReader.test.cpp
+++ b/test/Stream/FileReader.test.cpp
@@ -7,7 +7,7 @@ Stream::FileReader CreateSeekableReader<Stream::FileReader>() {
 	return Stream::FileReader("Stream/data/SimpleStream.txt");
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(FileReader, SimpleSeekableReader, Stream::FileReader);
+INSTANTIATE_TYPED_TEST_SUITE_P(FileReader, SimpleSeekableReader, Stream::FileReader);
 
 
 TEST(FileReaderTest, AccessNonexistingFile) {

--- a/test/Stream/MemoryStreamReader.test.cpp
+++ b/test/Stream/MemoryStreamReader.test.cpp
@@ -12,7 +12,7 @@ Stream::MemoryReader CreateReader<Stream::MemoryReader>() {
 	return Stream::MemoryReader(buffer.data(), buffer.size() * sizeof(char));
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(BasicMemoryReader, BasicReaderTests, Stream::MemoryReader);
+INSTANTIATE_TYPED_TEST_SUITE_P(BasicMemoryReader, BasicReaderTests, Stream::MemoryReader);
 
 
 template <>
@@ -21,7 +21,7 @@ Stream::MemoryReader CreateSeekableReader<Stream::MemoryReader>() {
 	return Stream::MemoryReader(buffer.data(), buffer.size() * sizeof(char));
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(MemoryReader, SimpleSeekableReader, Stream::MemoryReader);
+INSTANTIATE_TYPED_TEST_SUITE_P(MemoryReader, SimpleSeekableReader, Stream::MemoryReader);
 
 
 // Simple test

--- a/test/Stream/Reader.test.h
+++ b/test/Stream/Reader.test.h
@@ -16,7 +16,7 @@ protected:
 	T stream;
 };
 
-TYPED_TEST_CASE_P(BasicReaderTests);
+TYPED_TEST_SUITE_P(BasicReaderTests);
 
 TYPED_TEST_P(BasicReaderTests, CanReadZeroBytesToNull) {
 	ASSERT_NO_THROW(this->stream.Read(nullptr, 0));
@@ -26,7 +26,7 @@ TYPED_TEST_P(BasicReaderTests, CanReadPartialZeroBytesToNull) {
 	EXPECT_EQ(0u, this->stream.ReadPartial(nullptr, 0));
 }
 
-REGISTER_TYPED_TEST_CASE_P(BasicReaderTests,
+REGISTER_TYPED_TEST_SUITE_P(BasicReaderTests,
 	CanReadZeroBytesToNull,
 	CanReadPartialZeroBytesToNull
 );

--- a/test/Stream/SliceReader.test.cpp
+++ b/test/Stream/SliceReader.test.cpp
@@ -7,7 +7,7 @@ Stream::FileSliceReader CreateSeekableReader<Stream::FileSliceReader>() {
 	return fileReader.Slice(5);
 }
 
-INSTANTIATE_TYPED_TEST_CASE_P(FileSliceReader, SimpleSeekableReader, Stream::FileSliceReader);
+INSTANTIATE_TYPED_TEST_SUITE_P(FileSliceReader, SimpleSeekableReader, Stream::FileSliceReader);
 
 
 TEST(FileSliceReader, SliceIsBoundsChecked) {


### PR DESCRIPTION
Need to use TEST_SUITE macros instead of TEST_CASE macros.
- `TYPED_TEST_SUITE_P`
- `REGISTER_TYPED_TEST_SUITE_P`
- `INSTANTIATE_TYPED_TEST_SUITE_P`

Closes #338
