### PR TITLE
Allow initializing OP2BmpLoader using a stream

### DIFF
--- a/src/Sprite/OP2BmpLoader.cpp
+++ b/src/Sprite/OP2BmpLoader.cpp
@@ -8,6 +8,9 @@
 OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::string artFilename) :
 	bmpReader(bmpFilename), artFile(ArtFile::Read(artFilename)) { }
 
+OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, Stream::BidirectionalReader& artFileStream) :
+	bmpReader(bmpFilename), artFile(ArtFile::Read(artFileStream)) { }
+
 void OP2BmpLoader::ExtractImage(std::size_t index, const std::string& filenameOut) 
 {
 	artFile.VerifyImageIndexInBounds(index);

--- a/src/Sprite/OP2BmpLoader.cpp
+++ b/src/Sprite/OP2BmpLoader.cpp
@@ -58,9 +58,9 @@ std::unique_ptr<Stream::FileSliceReader> OP2BmpLoader::GetPixels(std::size_t sta
 }
 
 std::size_t OP2BmpLoader::FrameCount(std::size_t animationIndex) const {
-	return artFile.animations[animationIndex].frames.size();
+	return artFile->animations[animationIndex].frames.size();
 }
 
 std::size_t OP2BmpLoader::LayerCount(std::size_t animationIndex, std::size_t frameIndex) const {
-	return artFile.animations[animationIndex].frames[frameIndex].layers.size();
+	return artFile->animations[animationIndex].frames[frameIndex].layers.size();
 }

--- a/src/Sprite/OP2BmpLoader.cpp
+++ b/src/Sprite/OP2BmpLoader.cpp
@@ -8,7 +8,7 @@
 OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::string artFilename) :
 	bmpReader(bmpFilename), artFile(ArtFile::Read(artFilename)) { }
 
-OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, Stream::BidirectionalReader& artFileStream) :
+OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, Stream::Reader& artFileStream) :
 	bmpReader(bmpFilename), artFile(ArtFile::Read(artFileStream)) { }
 
 void OP2BmpLoader::ExtractImage(std::size_t index, const std::string& filenameOut) 

--- a/src/Sprite/OP2BmpLoader.cpp
+++ b/src/Sprite/OP2BmpLoader.cpp
@@ -5,17 +5,14 @@
 #include <algorithm>
 #include <limits>
 
-OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::string artFilename) :
-	bmpReader(bmpFilename), artFile(ArtFile::Read(artFilename)) { }
-
-OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, Stream::Reader& artFileStream) :
-	bmpReader(bmpFilename), artFile(ArtFile::Read(artFileStream)) { }
+OP2BmpLoader::OP2BmpLoader(std::string bmpFilename, std::shared_ptr<ArtFile> artFile) :
+	bmpReader(bmpFilename), artFile(artFile) { }
 
 void OP2BmpLoader::ExtractImage(std::size_t index, const std::string& filenameOut) 
 {
-	artFile.VerifyImageIndexInBounds(index);
+	artFile->VerifyImageIndexInBounds(index);
 
-	ImageMeta& imageMeta = artFile.imageMetas[index];
+	ImageMeta& imageMeta = artFile->imageMetas[index];
 
 	std::vector<Color> palette = GetPalette(imageMeta);
 
@@ -47,10 +44,10 @@ std::vector<Color> OP2BmpLoader::GetPalette(const ImageMeta& imageMeta)
 	}
 	else
 	{
-		palette.resize(artFile.palettes[imageMeta.paletteIndex].size());
+		palette.resize(artFile->palettes[imageMeta.paletteIndex].size());
 	}
 
-	std::copy(artFile.palettes[imageMeta.paletteIndex].begin(), artFile.palettes[imageMeta.paletteIndex].end(), palette.begin());
+	std::copy(artFile->palettes[imageMeta.paletteIndex].begin(), artFile->palettes[imageMeta.paletteIndex].end(), palette.begin());
 
 	return palette;
 }

--- a/src/Sprite/OP2BmpLoader.h
+++ b/src/Sprite/OP2BmpLoader.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ArtFile.h"
-#include "../Stream/Reader.h"
 #include "../Stream/SliceReader.h"
 #include <memory>
 #include <string>
@@ -11,8 +10,7 @@
 class OP2BmpLoader
 {
 public:
-	OP2BmpLoader(std::string bmpFilename, std::string artFilename);
-	OP2BmpLoader(std::string bmpFilename, Stream::Reader& artFileStream);
+	OP2BmpLoader(std::string bmpFilename, std::shared_ptr<ArtFile> artFile);
 
 	void ExtractImage(std::size_t index, const std::string& filenameOut);
 
@@ -21,7 +19,7 @@ private:
 	// Contains many images in pixels section with a default palette. 
 	// Actual palette data and range of pixels to form each image is contained in the .prt file.
 	Stream::FileReader bmpReader;
-	ArtFile artFile;
+	std::shared_ptr<ArtFile> artFile;
 
 	std::vector<Color> GetPalette(const ImageMeta& imageMeta);
 	std::unique_ptr<Stream::FileSliceReader> GetPixels(std::size_t startingIndex, std::size_t length);

--- a/src/Sprite/OP2BmpLoader.h
+++ b/src/Sprite/OP2BmpLoader.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ArtFile.h"
-#include "../Stream/BidirectionalReader.h"
+#include "../Stream/Reader.h"
 #include "../Stream/SliceReader.h"
 #include <memory>
 #include <string>
@@ -12,7 +12,7 @@ class OP2BmpLoader
 {
 public:
 	OP2BmpLoader(std::string bmpFilename, std::string artFilename);
-	OP2BmpLoader(std::string bmpFilename, Stream::BidirectionalReader& artFileStream);
+	OP2BmpLoader(std::string bmpFilename, Stream::Reader& artFileStream);
 
 	void ExtractImage(std::size_t index, const std::string& filenameOut);
 

--- a/src/Sprite/OP2BmpLoader.h
+++ b/src/Sprite/OP2BmpLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ArtFile.h"
+#include "../Stream/BidirectionalReader.h"
 #include "../Stream/SliceReader.h"
 #include <memory>
 #include <string>
@@ -11,6 +12,7 @@ class OP2BmpLoader
 {
 public:
 	OP2BmpLoader(std::string bmpFilename, std::string artFilename);
+	OP2BmpLoader(std::string bmpFilename, Stream::BidirectionalReader& artFileStream);
 
 	void ExtractImage(std::size_t index, const std::string& filenameOut);
 

--- a/src/Sprite/OP2BmpLoader.h
+++ b/src/Sprite/OP2BmpLoader.h
@@ -14,8 +14,8 @@ public:
 
 	void ExtractImage(std::size_t index, const std::string& filenameOut);
 
-	inline std::size_t ImageCount() const { return artFile.imageMetas.size(); }
-	inline std::size_t AnimationCount() const { return artFile.animations.size(); }
+	inline std::size_t ImageCount() const { return artFile->imageMetas.size(); }
+	inline std::size_t AnimationCount() const { return artFile->animations.size(); }
 	std::size_t FrameCount(std::size_t animationIndex) const;
 	std::size_t LayerCount(std::size_t animationIndex, std::size_t frameIndex) const;
 


### PR DESCRIPTION
This allows loading ArtFile without first extracting it from the vol file.

I struggled to right a meaningful unit test if we don't want to keep a copy of an actual ArtFile in memory or within the repository.