### PR TITLE
Allow OP2BmpLoader to return image, layer, frame, and animation counts for each Sprite

### DIFF
--- a/src/Sprite/OP2BmpLoader.cpp
+++ b/src/Sprite/OP2BmpLoader.cpp
@@ -56,3 +56,11 @@ std::unique_ptr<Stream::FileSliceReader> OP2BmpLoader::GetPixels(std::size_t sta
 {
 	return std::make_unique<Stream::FileSliceReader>(bmpReader.Slice(startingIndex, length));
 }
+
+std::size_t OP2BmpLoader::FrameCount(std::size_t animationIndex) const {
+	return artFile.animations[animationIndex].frames.size();
+}
+
+std::size_t OP2BmpLoader::LayerCount(std::size_t animationIndex, std::size_t frameIndex) const {
+	return artFile.animations[animationIndex].frames[frameIndex].layers.size();
+}

--- a/src/Sprite/OP2BmpLoader.h
+++ b/src/Sprite/OP2BmpLoader.h
@@ -14,6 +14,11 @@ public:
 
 	void ExtractImage(std::size_t index, const std::string& filenameOut);
 
+	inline std::size_t ImageCount() const { return artFile.imageMetas.size(); }
+	inline std::size_t AnimationCount() const { return artFile.animations.size(); }
+	std::size_t FrameCount(std::size_t animationIndex) const;
+	std::size_t LayerCount(std::size_t animationIndex, std::size_t frameIndex) const;
+
 private:
 	// Bmp loader for Outpost 2 specific BMP file
 	// Contains many images in pixels section with a default palette. 


### PR DESCRIPTION
Keep ArtFile encapsulated as Private so OP2BmpLoader consumer does not access it directly.