### PR TITLE
Provide function to validate a tileset

### DIFF
--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -1,6 +1,7 @@
 #include "TilesetLoader.h"
+#include "../Bitmap/BitmapFile.h"
 #include "../Stream/BidirectionalReader.h"
-
+#include <stdexcept>
 
 namespace TilesetLoader
 {
@@ -11,5 +12,23 @@ namespace TilesetLoader
 		reader.SeekBackward(sizeof(tag));
 
 		return tag == TagFileSignature;
+	}
+
+	void ValidateTileset(const BitmapFile& tileset)
+	{
+		if (tileset.imageHeader.bitCount != 8)
+		{
+			throw std::runtime_error("Tileset palette must be an 8 bit indexed bitmap");
+		}
+
+		if (tileset.imageHeader.width != 32)
+		{
+			throw std::runtime_error("Tileset width must be exactly 32 pixels");
+		}
+
+		if (std::abs(tileset.imageHeader.height) % 32)
+		{
+			throw std::runtime_error("Tileset height must be a multiple of 32 pixels");
+		}
 	}
 }

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -26,7 +26,7 @@ namespace TilesetLoader
 			throw std::runtime_error("Tileset width must be exactly 32 pixels");
 		}
 
-		if (std::abs(tileset.imageHeader.height) % 32)
+		if (tileset.imageHeader.height % 32 != 0)
 		{
 			throw std::runtime_error("Tileset height must be a multiple of 32 pixels");
 		}

--- a/src/Sprite/TilesetLoader.h
+++ b/src/Sprite/TilesetLoader.h
@@ -2,6 +2,8 @@
 
 #include "../Tag.h"
 
+class BitmapFile;
+
 namespace Stream {
 	class BidirectionalReader;
 }
@@ -12,4 +14,8 @@ namespace TilesetLoader
 	constexpr Tag TagFileSignature = MakeTag("PBMP");
 
 	bool PeekIsCustomTileset(Stream::BidirectionalReader& reader);
+
+	// Throw runtime error if provided bitmap does not meet specific tileset requirements
+	// Assumes provided tileset is already properly formed to standard bitmap file format
+	void ValidateTileset(const BitmapFile& tileset);
 }

--- a/test/Sprite/TilesetLoader.test.cpp
+++ b/test/Sprite/TilesetLoader.test.cpp
@@ -1,4 +1,5 @@
 #include "../../src/Sprite/TilesetLoader.h"
+#include "../../src/Bitmap/BitmapFile.h"
 #include "../../src/Stream/MemoryReader.h"
 #include "../../src/Tag.h"
 #include <gtest/gtest.h>
@@ -15,4 +16,18 @@ TEST(TilesetLoader, PeekIsCustomTileset)
 	Stream::MemoryReader reader2(&wrongFileSignature, sizeof(wrongFileSignature));
 	EXPECT_FALSE(TilesetLoader::PeekIsCustomTileset(reader2));
 	EXPECT_EQ(0u, reader2.Position());
+}
+
+TEST(TilesetLoader, ValidateTileset)
+{
+	EXPECT_NO_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(8, 32, 32)));
+
+	// Improper bit depth
+	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(1, 32, 32)), std::runtime_error);
+
+	// Improper width
+	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(1, 64, 32)), std::runtime_error);
+
+	// Improper Height
+	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(1, 32, 70)), std::runtime_error);
 }


### PR DESCRIPTION
Function will be applied after a tileset is loaded into memory and if in custom format preconditioned into a standard bitmap