### PR TITLE
Pass palette on bitmap creation

### DIFF
--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -21,14 +21,14 @@ BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t
 	return bitmapFile;
 }
 
-BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette)
+BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, std::vector<Color> palette)
 {
 	if (palette.size() > std::size_t(1) << bitCount) {
 		throw std::runtime_error("Unable to create bitmap. Provided palette length is greater than provided bit count.");
 	}
 
 	auto bitmapFile = BitmapFile::CreateIndexed(bitCount, width, height);
-	std::copy(palette.begin(), palette.end(), bitmapFile.palette.begin());
+	std::move(palette.begin(), palette.end(), bitmapFile.palette.begin());
 
 	return bitmapFile;
 }

--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 #include <cmath>
 
-BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height)
+BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height)
 {
 	BitmapFile bitmapFile;
 	bitmapFile.imageHeader = ImageHeader::Create(width, height, bitCount);
@@ -21,13 +21,13 @@ BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, u
 	return bitmapFile;
 }
 
-BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette)
+BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette)
 {
 	if (palette.size() > std::size_t(1) << bitCount) {
 		throw std::runtime_error("Unable to create bitmap. Provided palette length is greater than provided bit count.");
 	}
 
-	auto bitmapFile = BitmapFile::CreateDefaultIndexed(bitCount, width, height);
+	auto bitmapFile = BitmapFile::CreateIndexed(bitCount, width, height);
 	std::copy(palette.begin(), palette.end(), bitmapFile.palette.begin());
 
 	return bitmapFile;

--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -2,12 +2,11 @@
 #include <stdexcept>
 #include <cmath>
 
-BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height, Color initialColor)
+BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height)
 {
 	BitmapFile bitmapFile;
 	bitmapFile.imageHeader = ImageHeader::Create(width, height, bitCount);
 	bitmapFile.palette.resize(bitmapFile.imageHeader.CalcMaxIndexedPaletteSize());
-	bitmapFile.palette[0] = initialColor;
 	bitmapFile.pixels.resize(bitmapFile.imageHeader.CalculatePitch() * height);
 
 	const std::size_t pixelOffset = sizeof(BmpHeader) + sizeof(ImageHeader) + bitmapFile.palette.size() * sizeof(Color);
@@ -18,6 +17,18 @@ BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, u
 	}
 
 	bitmapFile.bmpHeader = BmpHeader::Create(static_cast<uint32_t>(bitmapFileSize), static_cast<uint32_t>(pixelOffset));
+
+	return bitmapFile;
+}
+
+BitmapFile BitmapFile::CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette)
+{
+	if (palette.size() > std::size_t(1) << bitCount) {
+		throw std::runtime_error("Unable to create bitmap. Provided palette length is greater than provided bit count.");
+	}
+
+	auto bitmapFile = BitmapFile::CreateDefaultIndexed(bitCount, width, height);
+	std::copy(palette.begin(), palette.end(), bitmapFile.palette.begin());
 
 	return bitmapFile;
 }

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -24,7 +24,7 @@ public:
 	std::vector<uint8_t> pixels;
 
 	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height);
-	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette);
+	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, std::vector<Color> palette);
 
 	// BMP Reader only supports indexed color palettes (1, 2, and 8 bit BMPs).
 	static BitmapFile ReadIndexed(const std::string& filename);

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -23,8 +23,8 @@ public:
 	std::vector<Color> palette;
 	std::vector<uint8_t> pixels;
 
-	// @param initialColor will set the first palette entry to the provided color
-	static BitmapFile CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height, Color initialColor = DiscreteColor::Black);
+	static BitmapFile CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height);
+	static BitmapFile CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette);
 
 	// BMP Reader only supports indexed color palettes (1, 2, and 8 bit BMPs).
 	static BitmapFile ReadIndexed(const std::string& filename);

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -23,8 +23,8 @@ public:
 	std::vector<Color> palette;
 	std::vector<uint8_t> pixels;
 
-	static BitmapFile CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height);
-	static BitmapFile CreateDefaultIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette);
+	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height);
+	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, const std::vector<Color>& palette);
 
 	// BMP Reader only supports indexed color palettes (1, 2, and 8 bit BMPs).
 	static BitmapFile ReadIndexed(const std::string& filename);

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -7,7 +7,7 @@ void WriteAndReadBitmapSub(uint16_t bitCount, int32_t width, int32_t height)
 {
 	const std::string filename("Sprite/data/BitmapTest.bmp");
 
-	BitmapFile bitmapFile = BitmapFile::CreateDefaultIndexed(bitCount, width, height);
+	BitmapFile bitmapFile = BitmapFile::CreateIndexed(bitCount, width, height);
 	BitmapFile bitmapFile2;
 
 	EXPECT_NO_THROW(BitmapFile::WriteIndexed(filename, bitmapFile));
@@ -54,7 +54,7 @@ TEST(BitmapFile, VerifyIndexedPaletteSizeDoesNotExceedBitCount)
 	EXPECT_THROW(BitmapFile::VerifyIndexedPaletteSizeDoesNotExceedBitCount(1, 3), std::runtime_error);
 
 	// Test non-static version of function
-	BitmapFile bitmapFile = BitmapFile::CreateDefaultIndexed(1, 1, 1);
+	BitmapFile bitmapFile = BitmapFile::CreateIndexed(1, 1, 1);
 	EXPECT_NO_THROW(bitmapFile.VerifyIndexedPaletteSizeDoesNotExceedBitCount());
 	bitmapFile.palette.resize(3);
 	EXPECT_THROW(bitmapFile.VerifyIndexedPaletteSizeDoesNotExceedBitCount(), std::runtime_error);
@@ -66,7 +66,7 @@ TEST(BitmapFile, VerifyPixelSizeMatchesImageDimensionsWithPitch)
 	EXPECT_THROW(BitmapFile::VerifyPixelSizeMatchesImageDimensionsWithPitch(1, 1, 1, 1), std::runtime_error);
 
 	// Test non-static version of function
-	BitmapFile bitmapFile = BitmapFile::CreateDefaultIndexed(1, 1, 1);;
+	BitmapFile bitmapFile = BitmapFile::CreateIndexed(1, 1, 1);;
 	EXPECT_NO_THROW(bitmapFile.VerifyPixelSizeMatchesImageDimensionsWithPitch());
 	bitmapFile.pixels.resize(1, 0);
 	EXPECT_THROW(bitmapFile.VerifyPixelSizeMatchesImageDimensionsWithPitch(), std::runtime_error);
@@ -74,7 +74,7 @@ TEST(BitmapFile, VerifyPixelSizeMatchesImageDimensionsWithPitch)
 
 TEST(BitmapFile, CreateWithPalette)
 {
-	auto bitmapFile = BitmapFile::CreateDefaultIndexed(8, 2, 2, { DiscreteColor::Green });
+	auto bitmapFile = BitmapFile::CreateIndexed(8, 2, 2, { DiscreteColor::Green });
 
 	ASSERT_EQ(DiscreteColor::Green, bitmapFile.palette[0]);
 
@@ -85,12 +85,12 @@ TEST(BitmapFile, CreateWithPalette)
 
 	// Proivde palette with more indices than bit count supports
 	std::vector<Color> palette{ DiscreteColor::Green, DiscreteColor::Red, DiscreteColor::Blue };
-	EXPECT_THROW(bitmapFile = BitmapFile::CreateDefaultIndexed(1, 2, 2, palette), std::runtime_error);
+	EXPECT_THROW(bitmapFile = BitmapFile::CreateIndexed(1, 2, 2, palette), std::runtime_error);
 }
 
 TEST(BitmapFile, SwapRedAndBlue)
 {
-	auto bitmapFile = BitmapFile::CreateDefaultIndexed(8, 2, 2, { DiscreteColor::Red });
+	auto bitmapFile = BitmapFile::CreateIndexed(8, 2, 2, { DiscreteColor::Red });
 
 	bitmapFile.SwapRedAndBlue();
 	EXPECT_EQ(DiscreteColor::Blue, bitmapFile.palette[0]);
@@ -98,7 +98,7 @@ TEST(BitmapFile, SwapRedAndBlue)
 
 TEST(BitmapFile, Equality)
 {
-	BitmapFile bitmapFile1 = BitmapFile::CreateDefaultIndexed(1, 1, 1);	
+	BitmapFile bitmapFile1 = BitmapFile::CreateIndexed(1, 1, 1);	
 	auto bitmapFile2 = bitmapFile1;
 
 	EXPECT_TRUE(bitmapFile1 == bitmapFile2);

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -72,9 +72,9 @@ TEST(BitmapFile, VerifyPixelSizeMatchesImageDimensionsWithPitch)
 	EXPECT_THROW(bitmapFile.VerifyPixelSizeMatchesImageDimensionsWithPitch(), std::runtime_error);
 }
 
-TEST(BitmapFile, InitialColor)
+TEST(BitmapFile, CreateWithPalette)
 {
-	auto bitmapFile = BitmapFile::CreateDefaultIndexed(8, 2, 2, DiscreteColor::Green);
+	auto bitmapFile = BitmapFile::CreateDefaultIndexed(8, 2, 2, { DiscreteColor::Green });
 
 	ASSERT_EQ(DiscreteColor::Green, bitmapFile.palette[0]);
 
@@ -82,11 +82,15 @@ TEST(BitmapFile, InitialColor)
 	for (const auto& pixel : bitmapFile.pixels) {
 		ASSERT_EQ(0u, pixel);
 	}
+
+	// Proivde palette with more indices than bit count supports
+	std::vector<Color> palette{ DiscreteColor::Green, DiscreteColor::Red, DiscreteColor::Blue };
+	EXPECT_THROW(bitmapFile = BitmapFile::CreateDefaultIndexed(1, 2, 2, palette), std::runtime_error);
 }
 
 TEST(BitmapFile, SwapRedAndBlue)
 {
-	auto bitmapFile = BitmapFile::CreateDefaultIndexed(8, 2, 2, DiscreteColor::Red);
+	auto bitmapFile = BitmapFile::CreateDefaultIndexed(8, 2, 2, { DiscreteColor::Red });
 
 	bitmapFile.SwapRedAndBlue();
 	EXPECT_EQ(DiscreteColor::Blue, bitmapFile.palette[0]);

--- a/test/Sprite/TilesetLoader.test.cpp
+++ b/test/Sprite/TilesetLoader.test.cpp
@@ -20,14 +20,14 @@ TEST(TilesetLoader, PeekIsCustomTileset)
 
 TEST(TilesetLoader, ValidateTileset)
 {
-	EXPECT_NO_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(8, 32, 32)));
+	EXPECT_NO_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateIndexed(8, 32, 32)));
 
 	// Improper bit depth
-	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(1, 32, 32)), std::runtime_error);
+	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateIndexed(1, 32, 32)), std::runtime_error);
 
 	// Improper width
-	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(1, 64, 32)), std::runtime_error);
+	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateIndexed(1, 64, 32)), std::runtime_error);
 
 	// Improper Height
-	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateDefaultIndexed(1, 32, 70)), std::runtime_error);
+	EXPECT_THROW(TilesetLoader::ValidateTileset(BitmapFile::CreateIndexed(1, 32, 70)), std::runtime_error);
 }


### PR DESCRIPTION
From recommendation in PR#362.

While looking at the naming scheme, I decided having the word Default in `BitmapFile::CreateDefaultIndexed` didn't add any value, so removed it.