### PR TITLE
Fix syntax error in TilesetLoader.cpp

### DIFF
--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -178,7 +178,7 @@ namespace Tileset
 		return sizeof(Tag) + // PBMP Header
 			sizeof(TilesetHeader) +
 			sizeof(PpalHeader) +
-			sizeof(Tag) + DefaultPaletteHeaderSize, //Palette and Header
+			sizeof(Tag) + DefaultPaletteHeaderSize + //Palette and Header
 			sizeof(Tag) + CalculatePixelHeaderLength(pixelLength) - //Pixels and Header
 			16;
 	}


### PR DESCRIPTION
Caught by gcc and clang