### PR TITLE
Tileset validation type inconsistencies

### DIFF
--- a/src/Sprite/TilesetCommon.cpp
+++ b/src/Sprite/TilesetCommon.cpp
@@ -15,6 +15,6 @@ namespace Tileset
 
 	std::string formatReadErrorMessage(std::string propertyName, std::string value, std::string expectedValue)
 	{
-		return "Tileset property " + propertyName + " reads. Expected a value of " + expectedValue + ".";
+		return "Tileset property " + propertyName + " reads " + value + ". Expected value of " + expectedValue + ".";
 	}
 }

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -119,10 +119,10 @@ namespace Tileset
 	{
 		constexpr int32_t DefaultPixelWidth = 32;
 		constexpr uint32_t DefaultPixelHeightMultiple = DefaultPixelWidth;
-		constexpr uint32_t DefaultBitDepth = 8;
+		constexpr uint16_t DefaultBitCount = 8;
 
-		if (tileset.imageHeader.bitCount != DefaultBitDepth) {
-			throwReadError("Bit Depth", tileset.imageHeader.bitCount, DefaultBitDepth);
+		if (tileset.imageHeader.bitCount != DefaultBitCount) {
+			throwReadError("Bit Depth", tileset.imageHeader.bitCount, DefaultBitCount);
 		}
 
 		if (tileset.imageHeader.width != DefaultPixelWidth) {

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -117,7 +117,7 @@ namespace Tileset
 
 	void ValidateTileset(const BitmapFile& tileset)
 	{
-		constexpr uint32_t DefaultPixelWidth = 32;
+		constexpr int32_t DefaultPixelWidth = 32;
 		constexpr uint32_t DefaultPixelHeightMultiple = DefaultPixelWidth;
 		constexpr uint32_t DefaultBitDepth = 8;
 


### PR DESCRIPTION
This fixes several issues with error messaging for tilesets mentioned in issue #348. 

Pending discussion in #348, can actually implement a templated solution for tileset read error messaging.

Part of the problems were because I was straight up not reporting the value parameter, which I should have caught earlier.