### PR TITLE
Allow clearing content of Stream::DynamicMemoryWriter

### DIFF
--- a/src/Stream/DynamicMemoryWriter.cpp
+++ b/src/Stream/DynamicMemoryWriter.cpp
@@ -56,4 +56,10 @@ namespace Stream
 	MemoryReader DynamicMemoryWriter::GetReader() {
 		return MemoryReader(streamBuffer.data(), streamBuffer.size());
 	}
+
+	// Clear all currently set memory
+	void DynamicMemoryWriter::Clear() {
+		SeekBeginning();
+		streamBuffer.clear();
+	}
 }

--- a/src/Stream/DynamicMemoryWriter.h
+++ b/src/Stream/DynamicMemoryWriter.h
@@ -41,6 +41,9 @@ namespace Stream
 		// Get read access to the written data
 		MemoryReader GetReader();
 
+		// Clear set memory and reset stream position to 0
+		void Clear();
+
 	protected:
 		void WriteImplementation(const void* buffer, std::size_t size) override;
 

--- a/test/Bitmap/IndexedBmpWriter.test.cpp
+++ b/test/Bitmap/IndexedBmpWriter.test.cpp
@@ -1,5 +1,6 @@
 #include "../src/Bitmap/Color.h"
 #include "../src/Bitmap/BitmapFile.h"
+#include "../src/Stream/DynamicMemoryWriter.h"
 #include "XFile.h"
 #include <gtest/gtest.h>
 #include <string>
@@ -10,12 +11,11 @@ TEST(BitmapFile, InvalidBitCountThrows)
 {
 	const std::vector<Color> palette(8);
 	const std::vector<uint8_t> pixels(4, 0);
-	const std::string filename = "Sprite/data/MonochromeTest.bmp";
+	Stream::DynamicMemoryWriter writer;
 
-	EXPECT_THROW(BitmapFile::CreateIndexed(3, 1, 1, palette, pixels).WriteIndexed(filename), std::runtime_error);
-	EXPECT_THROW(BitmapFile::CreateIndexed(32, 1, 1, palette, pixels).WriteIndexed(filename), std::runtime_error);
-
-	XFile::DeletePath(filename);
+	EXPECT_THROW(BitmapFile::CreateIndexed(3, 1, 1, palette, pixels).WriteIndexed(writer), std::runtime_error);
+	writer.Clear();
+	EXPECT_THROW(BitmapFile::CreateIndexed(32, 1, 1, palette, pixels).WriteIndexed(writer), std::runtime_error);
 }
 
 TEST(BitmapFile, TooManyPaletteEntriesThrows)


### PR DESCRIPTION
Example use in BmpWriter.Test provided.

@DanRStevens I think there may be some inconsistency in ability to Seek forwards and backwards in the Stream::DynamicMemoryReader. I didn't fully review if this is a real problem since I am targeting this branch as a precursor to Issue #367. 