### PR TITLE
BitmapFile scan line orientation

### DIFF
--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -82,6 +82,11 @@ void BitmapFile::Validate() const
 	VerifyPixelSizeMatchesImageDimensionsWithPitch();
 }
 
+ScanLineOrientation BitmapFile::ScanLineOrientation() const
+{
+	return imageHeader.height < 0 ? ScanLineOrientation::TopDown : ScanLineOrientation::BottomUp;
+}
+
 void BitmapFile::SwapRedAndBlue()
 {
 	for (auto& color : palette) {

--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -82,7 +82,7 @@ void BitmapFile::Validate() const
 	VerifyPixelSizeMatchesImageDimensionsWithPitch();
 }
 
-ScanLineOrientation BitmapFile::ScanLineOrientation() const
+ScanLineOrientation BitmapFile::GetScanLineOrientation() const
 {
 	return imageHeader.height < 0 ? ScanLineOrientation::TopDown : ScanLineOrientation::BottomUp;
 }

--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -99,6 +99,22 @@ void BitmapFile::SwapRedAndBlue()
 	}
 }
 
+void BitmapFile::InvertScanLines()
+{
+	imageHeader.height *= -1;
+
+	std::vector<uint8_t> invertedPixels;
+
+	const auto pitch = imageHeader.CalculatePitch();
+	for (auto row = AbsoluteHeight(); row; --row)
+	{
+		auto iterator = invertedPixels.end();
+		invertedPixels.insert(iterator, pixels.begin() + (row - 1) * pitch, pixels.begin() + row * pitch);
+	}
+
+	pixels = std::move(invertedPixels);
+}
+
 bool operator==(const BitmapFile& lhs, const BitmapFile& rhs) {
 	return lhs.bmpHeader == rhs.bmpHeader && 
 		lhs.imageHeader == rhs.imageHeader && 

--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -2,12 +2,12 @@
 #include <stdexcept>
 #include <cmath>
 
-BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height)
+BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, int32_t height)
 {
 	BitmapFile bitmapFile;
 	bitmapFile.imageHeader = ImageHeader::Create(width, height, bitCount);
 	bitmapFile.palette.resize(bitmapFile.imageHeader.CalcMaxIndexedPaletteSize());
-	bitmapFile.pixels.resize(bitmapFile.imageHeader.CalculatePitch() * height);
+	bitmapFile.pixels.resize(bitmapFile.imageHeader.CalculatePitch() * std::abs(height));
 
 	const std::size_t pixelOffset = sizeof(BmpHeader) + sizeof(ImageHeader) + bitmapFile.palette.size() * sizeof(Color);
 	const std::size_t bitmapFileSize = pixelOffset + bitmapFile.pixels.size() * sizeof(uint8_t);
@@ -21,7 +21,7 @@ BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t
 	return bitmapFile;
 }
 
-BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, std::vector<Color> palette)
+BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, int32_t height, std::vector<Color> palette)
 {
 	if (palette.size() > std::size_t(1) << bitCount) {
 		throw std::runtime_error("Unable to create bitmap. Provided palette length is greater than provided bit count.");
@@ -33,7 +33,7 @@ BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t
 	return bitmapFile;
 }
 
-BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, std::vector<Color> palette, std::vector<uint8_t> pixels)
+BitmapFile BitmapFile::CreateIndexed(uint16_t bitCount, uint32_t width, int32_t height, std::vector<Color> palette, std::vector<uint8_t> pixels)
 {
 	auto bitmap = CreateIndexed(bitCount, width, height, palette);
 	bitmap.pixels = pixels;

--- a/src/Bitmap/BitmapFile.cpp
+++ b/src/Bitmap/BitmapFile.cpp
@@ -87,6 +87,11 @@ ScanLineOrientation BitmapFile::ScanLineOrientation() const
 	return imageHeader.height < 0 ? ScanLineOrientation::TopDown : ScanLineOrientation::BottomUp;
 }
 
+uint32_t BitmapFile::AbsoluteHeight() const
+{
+	return std::abs(imageHeader.height);
+}
+
 void BitmapFile::SwapRedAndBlue()
 {
 	for (auto& color : palette) {

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -55,7 +55,7 @@ public:
 
 	void Validate() const;
 
-	ScanLineOrientation ScanLineOrientation() const;
+	ScanLineOrientation GetScanLineOrientation() const;
 	uint32_t AbsoluteHeight() const;
 	void SwapRedAndBlue();
 	void InvertScanLines();

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -56,6 +56,7 @@ public:
 	void Validate() const;
 
 	ScanLineOrientation ScanLineOrientation() const;
+	uint32_t AbsoluteHeight() const;
 	void SwapRedAndBlue();
 
 private:

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -13,6 +13,12 @@ namespace Stream {
 	class BidirectionalReader;
 }
 
+enum class ScanLineOrientation
+{
+	TopDown,
+	BottomUp
+};
+
 // BitmapFile only supports indexed palette BMPs. 
 // Writing and reading bitmaps is restricted to the subset of 1, 2 and 8 bit BMPs.
 class BitmapFile
@@ -49,6 +55,7 @@ public:
 
 	void Validate() const;
 
+	ScanLineOrientation ScanLineOrientation() const;
 	void SwapRedAndBlue();
 
 private:

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -23,9 +23,9 @@ public:
 	std::vector<Color> palette;
 	std::vector<uint8_t> pixels;
 
-	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height);
-	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, std::vector<Color> palette);
-	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, uint32_t height, std::vector<Color> palette, std::vector<uint8_t> pixels);
+	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, int32_t height);
+	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, int32_t height, std::vector<Color> palette);
+	static BitmapFile CreateIndexed(uint16_t bitCount, uint32_t width, int32_t height, std::vector<Color> palette, std::vector<uint8_t> pixels);
 
 	// BMP Reader only supports indexed color palettes (1, 2, and 8 bit BMPs).
 	static BitmapFile ReadIndexed(const std::string& filename);

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -58,6 +58,7 @@ public:
 	ScanLineOrientation ScanLineOrientation() const;
 	uint32_t AbsoluteHeight() const;
 	void SwapRedAndBlue();
+	void InvertScanLines();
 
 private:
 	static void VerifyIndexedImageForSerialization(uint16_t bitCount);

--- a/src/Sprite/TilesetHeaders.cpp
+++ b/src/Sprite/TilesetHeaders.cpp
@@ -3,13 +3,13 @@
 
 namespace Tileset
 {
-	TilesetHeader TilesetHeader::Create(std::int32_t heightInTiles)
+	TilesetHeader TilesetHeader::Create(uint32_t heightInTiles)
 	{
 		return TilesetHeader{
 			SectionHeader(DefaultTagHead, DefaultSectionSize),
 			DefaultTagCount,
 			DefaultPixelWidth,
-			heightInTiles * static_cast<int32_t>(DefaultPixelHeightMultiple),
+			heightInTiles * DefaultPixelHeightMultiple,
 			DefaultBitDepth,
 			DefaultFlags
 		};

--- a/src/Sprite/TilesetHeaders.h
+++ b/src/Sprite/TilesetHeaders.h
@@ -12,7 +12,7 @@ namespace Tileset
 		SectionHeader sectionHead;
 		uint32_t tagCount;
 		uint32_t pixelWidth;
-		int32_t pixelHeight;
+		uint32_t pixelHeight; // Assume height is always positive, unlike standard Windows Bitmap Format
 		uint32_t bitDepth;
 		uint32_t flags;
 
@@ -24,7 +24,7 @@ namespace Tileset
 		constexpr static uint32_t DefaultBitDepth = 8;
 		constexpr static uint32_t DefaultFlags = 8; // Unsure meaning of Flags
 
-		static TilesetHeader Create(std::int32_t heightInTiles);
+		static TilesetHeader Create(std::uint32_t heightInTiles);
 
 		void Validate() const;
 	};

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -96,7 +96,7 @@ namespace Tileset
 		ValidateTileset(tileset);
 
 		// OP2 Custom Tileset assumes a positive height and TopDown Scan Line (Contradicts Windows Bitmap File Format)
-		if (tileset.ScanLineOrientation() == ScanLineOrientation::BottomUp) {
+		if (tileset.GetScanLineOrientation() == ScanLineOrientation::BottomUp) {
 			tileset.InvertScanLines();
 		}
 		auto absoluteHeight = tileset.AbsoluteHeight();

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -91,7 +91,7 @@ namespace Tileset
 		return bitmapFile;
 	}
 
-	void WriteCustomTileset(Stream::Writer& writer, const BitmapFile& tileset)
+	void WriteCustomTileset(Stream::Writer& writer, BitmapFile tileset)
 	{
 		ValidateTileset(tileset);
 
@@ -101,8 +101,7 @@ namespace Tileset
 		PpalHeader ppalHeader = PpalHeader::Create();
 		
 		SectionHeader paletteHeader{ DefaultTagData, DefaultPaletteHeaderSize };
-		auto palette = tileset.palette;
-		SwapPaletteRedAndBlue(palette);
+		SwapPaletteRedAndBlue(tileset.palette);
 
 		SectionHeader pixelHeader{ DefaultTagData, CalculatePixelHeaderLength(tilesetHeader.pixelHeight) };
 
@@ -110,7 +109,7 @@ namespace Tileset
 		writer.Write(tilesetHeader);
 		writer.Write(ppalHeader);
 		writer.Write(paletteHeader);
-		writer.Write(palette);
+		writer.Write(tileset.palette);
 		writer.Write(pixelHeader);
 		writer.Write(tileset.pixels);
 	}

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -75,7 +75,7 @@ namespace Tileset
 		reader.Read(paletteHeader);
 		ValidatePaletteHeader(paletteHeader);
 
-		auto bitmapFile = BitmapFile::CreateIndexed(tilesetHeader.bitDepth, tilesetHeader.pixelWidth, tilesetHeader.pixelHeight);
+		auto bitmapFile = BitmapFile::CreateIndexed(tilesetHeader.bitDepth, tilesetHeader.pixelWidth, tilesetHeader.pixelHeight * -1);
 		reader.Read(bitmapFile.palette);
 
 		SectionHeader pixelHeader;

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -11,9 +11,9 @@ namespace Tileset
 {
 	void ValidateFileSignatureHeader(const SectionHeader& fileSignatureHeader);
 	void ValidatePaletteHeader(const SectionHeader& paletteHeader);
-	void ValidatePixelHeader(const SectionHeader& pixelHeader, int32_t height);
+	void ValidatePixelHeader(const SectionHeader& pixelHeader, uint32_t height);
 	uint32_t CalculatePbmpSectionSize(uint32_t pixelLength);
-	uint32_t CalculatePixelHeaderLength(int32_t height);
+	uint32_t CalculatePixelHeaderLength(uint32_t height);
 	void SwapPaletteRedAndBlue(std::vector<Color>& palette);
 
 
@@ -160,7 +160,7 @@ namespace Tileset
 		}
 	}
 
-	void ValidatePixelHeader(const SectionHeader& pixelHeader, int32_t height)
+	void ValidatePixelHeader(const SectionHeader& pixelHeader, uint32_t height)
 	{
 		if (pixelHeader.tag != DefaultTagData) {
 			throwReadError("Pixel Header Tag", pixelHeader.tag, DefaultTagData);
@@ -182,7 +182,7 @@ namespace Tileset
 			16;
 	}
 
-	uint32_t CalculatePixelHeaderLength(int32_t height)
+	uint32_t CalculatePixelHeaderLength(uint32_t height)
 	{
 		// Because tilesets are have a bitDepth of 8 and are always 32 pixels wide, 
 		// can assume a padding of 0 bytes on each scan line.

--- a/src/Sprite/TilesetLoader.h
+++ b/src/Sprite/TilesetLoader.h
@@ -30,7 +30,7 @@ namespace Tileset
 
 	// Write tileset in Outpost 2's custom bitmap format.
 	// To write tileset in standard bitmap format, use BitmapFile::WriteIndexed
-	void WriteCustomTileset(Stream::Writer& writer, const BitmapFile& tileset);
+	void WriteCustomTileset(Stream::Writer& writer, BitmapFile tileset);
 
 	// Throw runtime error if provided bitmap does not meet specific tileset requirements
 	// Assumes provided tileset is already properly formed to standard bitmap file format

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -99,6 +99,18 @@ TEST(BitmapFile, ScanLineOrientation)
 	}
 }
 
+TEST(BitmapFile, AbsoluteHeight)
+{
+	{ // Test Positive Height
+		auto bitmap = BitmapFile::CreateIndexed(1, 32, 32);
+		EXPECT_EQ(32, bitmap.AbsoluteHeight());
+	}
+	{ // Test Negative Height
+		auto bitmap = BitmapFile::CreateIndexed(1, 32, -32);
+		EXPECT_EQ(32, bitmap.AbsoluteHeight());
+	}
+}
+
 TEST(BitmapFile, SwapRedAndBlue)
 {
 	auto bitmapFile = BitmapFile::CreateIndexed(8, 2, 2, { DiscreteColor::Red });

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -91,11 +91,11 @@ TEST(BitmapFile, ScanLineOrientation)
 {
 	{ // Test Negative Height
 		auto bitmap = BitmapFile::CreateIndexed(1, 32, -32);
-		EXPECT_EQ(ScanLineOrientation::TopDown, bitmap.ScanLineOrientation());
+		EXPECT_EQ(ScanLineOrientation::TopDown, bitmap.GetScanLineOrientation());
 	}
 	{ // Test Positive Height
 		auto bitmap = BitmapFile::CreateIndexed(1, 32, 32);
-		EXPECT_EQ(ScanLineOrientation::BottomUp, bitmap.ScanLineOrientation());
+		EXPECT_EQ(ScanLineOrientation::BottomUp, bitmap.GetScanLineOrientation());
 	}
 }
 
@@ -134,12 +134,12 @@ TEST(BitmapFile, InvertScanLines)
 	auto bitmap = BitmapFile::CreateIndexed(8, 8, 2, { /* Empty Palette */ }, pixels);
 	bitmap.InvertScanLines();
 
-	EXPECT_EQ(ScanLineOrientation::TopDown, bitmap.ScanLineOrientation());
+	EXPECT_EQ(ScanLineOrientation::TopDown, bitmap.GetScanLineOrientation());
 	EXPECT_EQ(invertedPixels, bitmap.pixels);
 
 	bitmap.InvertScanLines();
 
-	EXPECT_EQ(ScanLineOrientation::BottomUp, bitmap.ScanLineOrientation());
+	EXPECT_EQ(ScanLineOrientation::BottomUp, bitmap.GetScanLineOrientation());
 	EXPECT_EQ(pixels, bitmap.pixels);
 }
 

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -119,6 +119,30 @@ TEST(BitmapFile, SwapRedAndBlue)
 	EXPECT_EQ(DiscreteColor::Blue, bitmapFile.palette[0]);
 }
 
+TEST(BitmapFile, InvertScanLines)
+{
+	const std::vector<uint8_t> pixels{
+		1, 1, 1, 1, 1, 1, 1, 1,
+		0, 0, 0, 0, 0, 0, 0, 0
+	};
+
+	const std::vector<uint8_t> invertedPixels{
+		0, 0, 0, 0, 0, 0, 0, 0,
+		1, 1, 1, 1, 1, 1, 1, 1
+	};
+
+	auto bitmap = BitmapFile::CreateIndexed(8, 8, 2, { /* Empty Palette */ }, pixels);
+	bitmap.InvertScanLines();
+
+	EXPECT_EQ(ScanLineOrientation::TopDown, bitmap.ScanLineOrientation());
+	EXPECT_EQ(invertedPixels, bitmap.pixels);
+
+	bitmap.InvertScanLines();
+
+	EXPECT_EQ(ScanLineOrientation::BottomUp, bitmap.ScanLineOrientation());
+	EXPECT_EQ(pixels, bitmap.pixels);
+}
+
 TEST(BitmapFile, Equality)
 {
 	BitmapFile bitmapFile1 = BitmapFile::CreateIndexed(1, 1, 1);	

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -87,6 +87,18 @@ TEST(BitmapFile, CreateWithPalette)
 	EXPECT_THROW(bitmapFile = BitmapFile::CreateIndexed(1, 2, 2, palette), std::runtime_error);
 }
 
+TEST(BitmapFile, ScanLineOrientation)
+{
+	{ // Test Negative Height
+		auto bitmap = BitmapFile::CreateIndexed(1, 32, -32);
+		EXPECT_EQ(ScanLineOrientation::TopDown, bitmap.ScanLineOrientation());
+	}
+	{ // Test Positive Height
+		auto bitmap = BitmapFile::CreateIndexed(1, 32, 32);
+		EXPECT_EQ(ScanLineOrientation::BottomUp, bitmap.ScanLineOrientation());
+	}
+}
+
 TEST(BitmapFile, SwapRedAndBlue)
 {
 	auto bitmapFile = BitmapFile::CreateIndexed(8, 2, 2, { DiscreteColor::Red });

--- a/test/Sprite/TilesetLoader.test.cpp
+++ b/test/Sprite/TilesetLoader.test.cpp
@@ -24,7 +24,7 @@ TEST(TilesetLoader, WriteCustomTileset)
 {
 	Stream::DynamicMemoryWriter writer;
 
-	auto tileset1 = BitmapFile::CreateIndexed(8, 32, 32, { DiscreteColor::Red});
+	auto tileset1 = BitmapFile::CreateIndexed(8, 32, -32, { DiscreteColor::Red});
 	Tileset::WriteCustomTileset(writer, tileset1);
 
 	// Read just written tileset to ensure it was well formed

--- a/test/Sprite/TilesetLoader.test.cpp
+++ b/test/Sprite/TilesetLoader.test.cpp
@@ -13,7 +13,7 @@ TEST(TilesetLoader, PeekIsCustomTileset)
 	Stream::MemoryReader reader1(&Tileset::TagFileSignature, sizeof(Tileset::TagFileSignature));
 	EXPECT_TRUE(Tileset::PeekIsCustomTileset(reader1));
 	EXPECT_EQ(0u, reader1.Position());
-	
+
 	const Tag wrongFileSignature("TEST");
 	Stream::MemoryReader reader2(&wrongFileSignature, sizeof(wrongFileSignature));
 	EXPECT_FALSE(Tileset::PeekIsCustomTileset(reader2));
@@ -48,7 +48,7 @@ TEST(TilesetLoader, ReadTileset)
 	auto tileset = BitmapFile::CreateIndexed(8, 32, 32, { DiscreteColor::Red });
 	Stream::DynamicMemoryWriter writer;
 	tileset.WriteIndexed(writer);
-	
+
 	auto newTileset = Tileset::ReadTileset(writer.GetReader());
 
 	EXPECT_EQ(tileset, newTileset);


### PR DESCRIPTION
Most of the intermediate commits in this changeset break the tileset unit tests due to the original tests not taking into account proper Windows bitmap file scan line orientation.