### PR TITLE
Remove reference to Visual Studio 2017

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -18,7 +18,7 @@ Main features:
  - Indexed Bitmap manipulation (experimental)
 
 The library can be compiled and used on both Windows and Linux. Both x86 (32-bit) and x64 architectures are fully supported. Partial unit test coverage is made using [Google Test](https://github.com/google/googletest). Supported compilers:
- - Visual Studio 2017
+ - Visual Studio
  - GCC
  - Clang
 


### PR DESCRIPTION
I think the goal is to remain relevant on a couple of rolling versions of Visual Studio that support C++17 feature sets instead of calling out only one version. Although I am currently testing against VS2019.