### PR TITLE
Fix SeekForward bug

### DIFF
--- a/src/Stream/SliceReader.h
+++ b/src/Stream/SliceReader.h
@@ -63,7 +63,7 @@ namespace OP2Utility::Stream
 
 
 		void SeekForward(uint64_t offset) override {
-			if (Position() + offset > startingOffset + sliceLength)
+			if (Position() + offset > sliceLength)
 			{
 				throw std::runtime_error(
 					"Seek forward by offset of " + std::to_string(offset) + " is beyond the bounds of the stream slice."

--- a/test/Stream/BidirectionalReader.test.h
+++ b/test/Stream/BidirectionalReader.test.h
@@ -13,10 +13,13 @@ template <class T>
 class SimpleBidirectionalReader : public testing::Test {
 protected:
 	// The ctor calls the factory function to create a reader implemented by T
-	SimpleBidirectionalReader() : reader(CreateBidirectionalReader<T>()) {}
+	SimpleBidirectionalReader() :
+		reader{CreateBidirectionalReader<T>()},
+		size{reader.Length()}
+	{}
 
 	T reader;
-	const unsigned int size = 5;
+	const uint64_t size;
 };
 
 TYPED_TEST_SUITE_P(SimpleBidirectionalReader);

--- a/test/Stream/SliceReader.test.cpp
+++ b/test/Stream/SliceReader.test.cpp
@@ -6,7 +6,7 @@ using namespace OP2Utility;
 template <>
 Stream::FileSliceReader CreateBidirectionalReader<Stream::FileSliceReader>() {
 	Stream::FileReader fileReader("Stream/data/SimpleStream.txt");
-	return fileReader.Slice(5);
+	return fileReader.Slice(1, 4);
 }
 
 INSTANTIATE_TYPED_TEST_SUITE_P(FileSliceReader, SimpleBidirectionalReader, Stream::FileSliceReader);


### PR DESCRIPTION
Related: #388

I updated the unit tests so they would actually catch the bug that was fixed in #388.

After pondering how to write a test for the current bug, I was not able to think of a way that could be easily inserted into existing unit test code. The comparison that leads to an exception basically goes the wrong way, where the old buggy code would not throw an exception when it should have. The only way to test the current code would be to check if it throws an exception when it should, however, not all stream classes that derive from `BidirectionalReader` will `throw` if you seek past the end. In particular, `FileReader` will not throw, so adding a `throw` check to the test will fail for that class.

I find the current stream tests somewhat hard to navigate and reason about. Maybe we should revisit the organization of that code at some point. I remember certain Google Test concepts were pretty new at that point, and we were still experimenting. Perhaps it would be clearer if we revisited the design now.
