### PR TITLE
Allow detecting & reporting when v4 or v5 bitmap image headers are encountered

### DIFF
--- a/src/Bitmap/ImageHeader.cpp
+++ b/src/Bitmap/ImageHeader.cpp
@@ -1,4 +1,5 @@
 #include "ImageHeader.h"
+#include "../StringUtility.h"
 #include <string>
 #include <stdexcept>
 #include <algorithm>
@@ -90,7 +91,15 @@ namespace OP2Utility
 	void ImageHeader::Validate() const
 	{
 		if (headerSize != sizeof(ImageHeader)) {
-			throw std::runtime_error("Image Header size must be equal to " + std::to_string(sizeof(ImageHeader)));
+			if (headerSize == sizeof(ImageHeaderV4)) {
+				throw std::runtime_error("Image Header size indicates header version 4. Only version 1 is supported.");
+			}
+			
+			if (headerSize == sizeof(ImageHeaderV5)) {
+				throw std::runtime_error("Image header size indicates header version 5. Only version 1 is supported.");
+			}
+
+			throw std::runtime_error("Unknown image header size of " + StringUtility::StringFrom(headerSize) + " detected. Header size must be equal to " + std::to_string(sizeof(ImageHeader)));
 		}
 
 		if (planes != DefaultPlanes) {

--- a/src/Bitmap/ImageHeader.h
+++ b/src/Bitmap/ImageHeader.h
@@ -59,6 +59,43 @@ namespace OP2Utility
 
 	static_assert(40 == sizeof(ImageHeader), "ImageHeader is an unexpected size");
 
+	struct ImageHeaderV4 {
+		ImageHeader imageHeader;
+		uint32_t redMask;
+		uint32_t greenMask;
+		uint32_t blueMask;
+		uint32_t alphaMask;
+		uint32_t colorSpaceType;
+		int32_t redEndpointX;
+		int32_t redEndpointY;
+		int32_t redEndpointZ;
+		int32_t greenEndpointX;
+		int32_t greenEndpointY;
+		int32_t greenEndpointZ;
+		int32_t blueEndpointX;
+		int32_t blueEndpointY;
+		int32_t blueEndpointZ;
+		uint32_t gammaRed;
+		uint32_t gammaGreen;
+		uint32_t gammaBlue;
+	};
+
+	static_assert(108 == sizeof(ImageHeaderV4), "ImageHeaderV4 is an unexpected size");
+
+	struct ImageHeaderV5 {
+		ImageHeaderV4 imageHeader;
+		uint32_t gamutMatchingIntent;
+		// Offset in bytes from the beginning of the image header to the start of the profile data
+		uint32_t profileDataOffset;
+		// Size in bytes of embedded profile data
+		uint32_t profileDataSize;
+		// Reservered member should always be set to zero.
+		uint32_t reserved;
+	};
+
+	static_assert(124 == sizeof(ImageHeaderV5), "ImageHeaderV5 is an unexpected size");
+
+
 #pragma pack(pop)
 
 	bool operator==(const ImageHeader& lhs, const ImageHeader& rhs);


### PR DESCRIPTION
I was trying to import a bitmap the other day, and OP2Utility reported the header size was incorrect. This was confusing because the bitmap was well formed. Turned out I was trying to load a bitmap saved using the v5 header format. This should provide a better error experience, especially for someone who does not understand how to inspect the size property of a bitmap using a hex editor...