### PR TITLE
Fix deprecated copy warnings

### DIFF
--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -22,6 +22,9 @@ namespace OP2Utility::Stream
 		// This method is similar to Read, except it does not raise an exception if the buffer can not be filled
 		virtual std::size_t ReadPartial(void* buffer, std::size_t size) noexcept = 0;
 
+		constexpr Reader() = default;
+		constexpr Reader(const Reader& other) = default;
+
 		virtual ~Reader() = default;
 
 		// Helper methods, which depend only on the above interface

--- a/src/Tag.h
+++ b/src/Tag.h
@@ -35,6 +35,8 @@ namespace OP2Utility
 		// Allow construction from other Tag objects
 		constexpr Tag(const Tag& other) = default;
 
+		constexpr Tag& operator=(const Tag& other) = default;
+
 		// Equality and inequality comparable
 		bool operator ==(const Tag rhs) const {
 			return text == rhs.text;


### PR DESCRIPTION
Fixes the Clang warnings:
- `-Wdeprecated-copy`
- `-Wdeprecated-copy-with-dtor`

----

Related:
- Issue #406
