### PR TITLE
Remove dedundant declaration from source file

### DIFF
--- a/src/Sprite/ArtFile.cpp
+++ b/src/Sprite/ArtFile.cpp
@@ -3,9 +3,6 @@
 
 namespace OP2Utility
 {
-	constexpr Tag ArtFile::TagPalette;
-
-
 	void ArtFile::VerifyImageIndexInBounds(std::size_t index)
 	{
 		if (index > imageMetas.size()) {


### PR DESCRIPTION
It's basically a forward declare, but in a source file rather than a header file, and for a `constexpr` value, which needs a definition to be `constexpr`.

Fixes clang warning `-Wdeprecated-redundant-constexpr-static-def`.

----

Related:
- Issue #406
