### PR TITLE
Add explicit `override` for `virtual` destructors

### DIFF
--- a/src/Archive/ClmFile.h
+++ b/src/Archive/ClmFile.h
@@ -17,7 +17,7 @@ namespace OP2Utility::Archive
 	{
 	public:
 		ClmFile(const std::string& filename);
-		virtual ~ClmFile();
+		~ClmFile() override;
 
 		std::string GetName(std::size_t index) override;
 		uint32_t GetSize(std::size_t index) override;

--- a/src/Archive/VolFile.h
+++ b/src/Archive/VolFile.h
@@ -18,7 +18,7 @@ namespace OP2Utility::Archive
 	{
 	public:
 		VolFile(const std::string& filename);
-		~VolFile();
+		~VolFile() override;
 
 		// Internal file status
 		//std::size_t GetIndex(const std::string& name) override;


### PR DESCRIPTION
Fixes Clang warning `-Winconsistent-missing-destructor-override`.

----

Related:
- Issue #406
