### PR TITLE
Fix weak vtable warnings

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="src\Stream\FileReader.cpp" />
     <ClCompile Include="src\Stream\FileWriter.cpp" />
     <ClCompile Include="src\Stream\ForwardReader.cpp" />
+    <ClCompile Include="src\Stream\ForwardWriter.cpp" />
     <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryReader.cpp" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryReader.cpp" />
+    <ClCompile Include="src\Stream\Reader.cpp" />
     <ClInclude Include="src\Sprite\Animation.h" />
     <ClInclude Include="src\Sprite\ArtFile.h" />
     <ClInclude Include="src\Sprite\ImageMeta.h" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="src\Sprite\PaletteHeader.cpp" />
     <ClCompile Include="src\Sprite\SectionHeader.cpp" />
     <ClCompile Include="src\Stream\BidirectionalReader.cpp" />
+    <ClCompile Include="src\Stream\BidirectionalWriter.cpp" />
     <ClCompile Include="src\Stream\FileReader.cpp" />
     <ClCompile Include="src\Stream\FileWriter.cpp" />
     <ClCompile Include="src\Stream\ForwardReader.cpp" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="src\Stream\MemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryReader.cpp" />
     <ClCompile Include="src\Stream\Reader.cpp" />
+    <ClCompile Include="src\Stream\Writer.cpp" />
     <ClInclude Include="src\Sprite\Animation.h" />
     <ClInclude Include="src\Sprite\ArtFile.h" />
     <ClInclude Include="src\Sprite\ImageMeta.h" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="src\Sprite\SpriteLoader.cpp" />
     <ClCompile Include="src\Sprite\PaletteHeader.cpp" />
     <ClCompile Include="src\Sprite\SectionHeader.cpp" />
+    <ClCompile Include="src\Stream\BidirectionalReader.cpp" />
     <ClCompile Include="src\Stream\FileReader.cpp" />
     <ClCompile Include="src\Stream\FileWriter.cpp" />
     <ClCompile Include="src\Stream\ForwardReader.cpp" />

--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -175,6 +175,7 @@
     <ClCompile Include="src\Sprite\SectionHeader.cpp" />
     <ClCompile Include="src\Stream\FileReader.cpp" />
     <ClCompile Include="src\Stream\FileWriter.cpp" />
+    <ClCompile Include="src\Stream\ForwardReader.cpp" />
     <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryWriter.cpp" />
     <ClCompile Include="src\Stream\MemoryReader.cpp" />

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -224,6 +224,9 @@
     <ClCompile Include="src\Stream\FileWriter.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stream\ForwardReader.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
     <ClCompile Include="src\Stream\MemoryReader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -218,6 +218,9 @@
     <ClCompile Include="src\Map\MapReader.cpp">
       <Filter>Map</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stream\BidirectionalReader.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
     <ClCompile Include="src\Stream\FileReader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -230,6 +230,9 @@
     <ClCompile Include="src\Stream\MemoryWriter.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stream\Reader.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
     <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp">
       <Filter>Stream</Filter>
     </ClCompile>

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -221,6 +221,9 @@
     <ClCompile Include="src\Stream\BidirectionalReader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stream\BidirectionalWriter.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
     <ClCompile Include="src\Stream\FileReader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -233,6 +233,9 @@
     <ClCompile Include="src\Stream\Reader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stream\Writer.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
     <ClCompile Include="src\Stream\DynamicMemoryWriter.cpp">
       <Filter>Stream</Filter>
     </ClCompile>

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -227,6 +227,9 @@
     <ClCompile Include="src\Stream\ForwardReader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stream\ForwardWriter.cpp">
+      <Filter>Stream</Filter>
+    </ClCompile>
     <ClCompile Include="src\Stream\MemoryReader.cpp">
       <Filter>Stream</Filter>
     </ClCompile>

--- a/src/Stream/BidirectionalReader.cpp
+++ b/src/Stream/BidirectionalReader.cpp
@@ -1,0 +1,7 @@
+#include "BidirectionalReader.h"
+
+
+namespace OP2Utility::Stream
+{
+	BidirectionalReader::~BidirectionalReader() = default;
+}

--- a/src/Stream/BidirectionalReader.h
+++ b/src/Stream/BidirectionalReader.h
@@ -7,6 +7,8 @@ namespace OP2Utility::Stream
 {
 	class BidirectionalReader : public ForwardReader {
 	public:
+		~BidirectionalReader() override;
+
 		void Peek(void* buffer, std::size_t size) {
 			ReadImplementation(buffer, size);
 			SeekBackward(size);

--- a/src/Stream/BidirectionalWriter.cpp
+++ b/src/Stream/BidirectionalWriter.cpp
@@ -1,0 +1,7 @@
+#include "BidirectionalWriter.h"
+
+
+namespace OP2Utility::Stream
+{
+	BidirectionalWriter::~BidirectionalWriter() = default;
+}

--- a/src/Stream/BidirectionalWriter.h
+++ b/src/Stream/BidirectionalWriter.h
@@ -7,6 +7,8 @@ namespace OP2Utility::Stream
 {
 	class BidirectionalWriter : public ForwardWriter {
 	public:
+		~BidirectionalWriter() override;
+
 		// Seek backward by a relative amount, given as offset from current position
 		virtual void SeekBackward(uint64_t offset) = 0;
 

--- a/src/Stream/ForwardReader.cpp
+++ b/src/Stream/ForwardReader.cpp
@@ -1,0 +1,7 @@
+#include "ForwardReader.h"
+
+
+namespace OP2Utility::Stream
+{
+	ForwardReader::~ForwardReader() = default;
+}

--- a/src/Stream/ForwardReader.h
+++ b/src/Stream/ForwardReader.h
@@ -7,6 +7,8 @@ namespace OP2Utility::Stream
 {
 	class ForwardReader : public Reader {
 	public:
+		~ForwardReader() override;
+
 		// Get the size of the stream
 		virtual uint64_t Length() = 0;
 

--- a/src/Stream/ForwardWriter.cpp
+++ b/src/Stream/ForwardWriter.cpp
@@ -1,0 +1,7 @@
+#include "ForwardWriter.h"
+
+
+namespace OP2Utility::Stream
+{
+	ForwardWriter::~ForwardWriter() = default;
+}

--- a/src/Stream/ForwardWriter.h
+++ b/src/Stream/ForwardWriter.h
@@ -8,6 +8,8 @@ namespace OP2Utility::Stream
 	class ForwardWriter : public Writer
 	{
 	public:
+		~ForwardWriter() override;
+
 		// Get the size of the stream
 		virtual uint64_t Length() = 0;
 

--- a/src/Stream/Reader.cpp
+++ b/src/Stream/Reader.cpp
@@ -3,6 +3,9 @@
 
 namespace OP2Utility::Stream
 {
+	Reader::~Reader() = default;
+
+
 	std::string Reader::ReadNullTerminatedString(std::size_t maxCount)
 	{
 		std::string str;

--- a/src/Stream/Reader.cpp
+++ b/src/Stream/Reader.cpp
@@ -1,0 +1,23 @@
+#include "Reader.h"
+
+
+namespace OP2Utility::Stream
+{
+	std::string Reader::ReadNullTerminatedString(std::size_t maxCount)
+	{
+		std::string str;
+
+		char c;
+		for (std::size_t i = 0; i < maxCount; ++i)
+		{
+			Read(c);
+			if (c == '\0') {
+				break;
+			}
+
+			str.push_back(c);
+		}
+
+		return str;
+	}
+}

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -91,22 +91,6 @@ namespace OP2Utility::Stream
 		// Read characters into a string until a null terminator is encountered
 		// Does not include the null terminator in the returned string
 		// Use maxCount to restrict the size of the returned string
-		std::string ReadNullTerminatedString(std::size_t maxCount = SIZE_MAX)
-		{
-			std::string str;
-
-			char c;
-			for (std::size_t i = 0; i < maxCount; ++i)
-			{
-				Read(c);
-				if (c == '\0') {
-					break;
-				}
-
-				str.push_back(c);
-			}
-
-			return str;
-		}
+		std::string ReadNullTerminatedString(std::size_t maxCount = SIZE_MAX);
 	};
 }

--- a/src/Stream/Reader.h
+++ b/src/Stream/Reader.h
@@ -25,7 +25,7 @@ namespace OP2Utility::Stream
 		constexpr Reader() = default;
 		constexpr Reader(const Reader& other) = default;
 
-		virtual ~Reader() = default;
+		virtual ~Reader();
 
 		// Helper methods, which depend only on the above interface
 		// ====

--- a/src/Stream/Writer.cpp
+++ b/src/Stream/Writer.cpp
@@ -1,0 +1,7 @@
+#include "Writer.h"
+
+
+namespace OP2Utility::Stream
+{
+	Writer::~Writer() = default;
+}

--- a/src/Stream/Writer.h
+++ b/src/Stream/Writer.h
@@ -20,7 +20,7 @@ namespace OP2Utility::Stream
 		virtual void WriteImplementation(const void* buffer, std::size_t size) = 0;
 
 	public:
-		virtual ~Writer() = default;
+		virtual ~Writer();
 
 		void Write(const void* buffer, std::size_t size) {
 			WriteImplementation(buffer, size);


### PR DESCRIPTION
Fix Clang warnings for flag `-Wweak-vtables`.

These fixes are for the main library, not the unit test project. The GoogleTest library itself emits a few of these warnings.

I'm a little on the fence about adding implementation files for what should be pure interface classes. I figure I'll go with it for now, since it's sometimes handy to have an implementation file available to add a method, and many of these classes do have non-virtual helper methods.

----

Related:
- Issue #406
