### PR TITLE
Update `makefile` so `all` target includes unit tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,6 @@
 
+.DEFAULT_GOAL := op2utility
+
 SRCDIR := src
 BUILDDIR := .build
 INTDIR := $(BUILDDIR)/obj

--- a/makefile
+++ b/makefile
@@ -20,7 +20,10 @@ OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 FOLDERS := $(sort $(dir $(SRCS)))
 
 .PHONY: all
-all: $(OUTPUT)
+all: op2utility
+
+.PHONY: op2utility
+op2utility: $(OUTPUT)
 
 $(OUTPUT): $(OBJS)
 	@mkdir -p ${@D}

--- a/makefile
+++ b/makefile
@@ -19,6 +19,7 @@ SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 FOLDERS := $(sort $(dir $(SRCS)))
 
+.PHONY: all
 all: $(OUTPUT)
 
 $(OUTPUT): $(OBJS)

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := op2utility
 
 .PHONY: all
-all: op2utility
+all: op2utility test
 
 SRCDIR := src
 BUILDDIR := .build

--- a/makefile
+++ b/makefile
@@ -1,6 +1,9 @@
 
 .DEFAULT_GOAL := op2utility
 
+.PHONY: all
+all: op2utility
+
 SRCDIR := src
 BUILDDIR := .build
 INTDIR := $(BUILDDIR)/obj
@@ -20,9 +23,6 @@ POSTCOMPILE = @mv -f $(INTDIR)/$*.Td $(INTDIR)/$*.d && touch $@
 SRCS := $(shell find $(SRCDIR) -name '*.cpp')
 OBJS := $(patsubst $(SRCDIR)/%.cpp,$(INTDIR)/%.o,$(SRCS))
 FOLDERS := $(sort $(dir $(SRCS)))
-
-.PHONY: all
-all: op2utility
 
 .PHONY: op2utility
 op2utility: $(OUTPUT)


### PR DESCRIPTION
Add `op2utility` target to `makefile`, set as the `.DEFAULT_GOAL`, and update the `all` target to depend on `test` too.

For other projects, normally `make all` is expected to build the unit tests too, whereas `make` would just build the static library project.

----

Note that `make show-warnings` uses the target `all`, so this means we'll also see warnings for the unit test project now.

----

Noticed this while doing some work on the unit test project.

Related:
- PR #416
- Issue #414
- Issue #175
