### PR TITLE
Add `Id` attributes to `Project` nodes in Solution file

### DIFF
--- a/OP2Utility.slnx
+++ b/OP2Utility.slnx
@@ -3,6 +3,6 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
-  <Project Path="OP2Utility.vcxproj" />
-  <Project Path="test/OP2UtilityTest.vcxproj" />
+  <Project Path="OP2Utility.vcxproj" Id="980d53d9-f9e2-4682-9307-1303c9e42313" />
+  <Project Path="test/OP2UtilityTest.vcxproj" Id="e4517bf0-202c-41b0-85f8-fbe2e8a76f51" />
 </Solution>


### PR DESCRIPTION
It seems Visual Studio doesn't initially add the `Id` attributes when converting to `.slnx` format. The `Id` attributes are added sometime later, perhaps during the build.

Related:
- PR #415
- Issue #414
