### PR TITLE
Remove extra semicolons

### DIFF
--- a/src/Archive/ClmFile.cpp
+++ b/src/Archive/ClmFile.cpp
@@ -302,7 +302,7 @@ namespace OP2Utility::Archive
 
 	bool ClmFile::ClmHeader::CheckFileVersion() const {
 		return fileVersion == standardFileVersion;
-	};
+	}
 
 	bool ClmFile::ClmHeader::CheckUnknown() const {
 		return unknown == standardUnknown;

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -84,7 +84,7 @@ TEST(BitmapFile, VerifyPixelSizeMatchesImageDimensionsWithPitch)
 	EXPECT_THROW(BitmapFile::VerifyPixelSizeMatchesImageDimensionsWithPitch(1, 1, 1, 1), std::runtime_error);
 
 	// Test non-static version of function
-	BitmapFile bitmapFile = BitmapFile::CreateIndexed(1, 1, 1);;
+	BitmapFile bitmapFile = BitmapFile::CreateIndexed(1, 1, 1);
 	EXPECT_NO_THROW(bitmapFile.VerifyPixelSizeMatchesImageDimensionsWithPitch());
 	bitmapFile.pixels.resize(1, 0);
 	EXPECT_THROW(bitmapFile.VerifyPixelSizeMatchesImageDimensionsWithPitch(), std::runtime_error);

--- a/test/Stream/Writer.test.cpp
+++ b/test/Stream/Writer.test.cpp
@@ -39,7 +39,7 @@ TEST(Writer, CanSerializeVectorOfTrivialStruct) {
 
 TEST(Writer, CanSerializeNonTrivialType) {
 	struct NonTrivialStruct {
-		virtual void virtualFunction() {};
+		virtual void virtualFunction() {}
 
 		void Write(Stream::Writer& writer) {
 			writer.Write(testInteger);


### PR DESCRIPTION
Remove extra semicolons to fix Clang warnings from `-Wextra-semi` and `-Wextra-semi-stmt`.

Related:
- Issue #175
