### PR TITLE
Remove `using namespace` from headers

### DIFF
--- a/test/Stream/BidirectionalReader.test.h
+++ b/test/Stream/BidirectionalReader.test.h
@@ -5,8 +5,6 @@
 #include <gtest/gtest.h>
 
 
-using namespace OP2Utility;
-
 template <class T>
 T CreateBidirectionalReader();
 

--- a/test/Stream/Reader.test.h
+++ b/test/Stream/Reader.test.h
@@ -5,8 +5,6 @@
 #include <gtest/gtest.h>
 
 
-using namespace OP2Utility;
-
 template <class T>
 T CreateReader();
 


### PR DESCRIPTION
Fix Clang warning `-Wheader-hygiene`.

Related:
- Issue #175
