### PR TITLE
Wrap local function in unnamed namespace

### DIFF
--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -9,6 +9,8 @@
 
 using namespace OP2Utility;
 
+namespace
+{
 void WriteAndReadBitmapSub(uint16_t bitCount, int32_t width, int32_t height)
 {
 	Stream::DynamicMemoryWriter writer;
@@ -20,6 +22,8 @@ void WriteAndReadBitmapSub(uint16_t bitCount, int32_t width, int32_t height)
 	EXPECT_NO_THROW(bitmapFile2 = BitmapFile::ReadIndexed(writer.GetReader()));
 	EXPECT_EQ(bitmapFile, bitmapFile2);
 }
+}
+
 
 TEST(BitmapFile, RoundTripWriteAndRead)
 {

--- a/test/Bitmap/BitmapFile.test.cpp
+++ b/test/Bitmap/BitmapFile.test.cpp
@@ -11,17 +11,17 @@ using namespace OP2Utility;
 
 namespace
 {
-void WriteAndReadBitmapSub(uint16_t bitCount, int32_t width, int32_t height)
-{
-	Stream::DynamicMemoryWriter writer;
+	void WriteAndReadBitmapSub(uint16_t bitCount, int32_t width, int32_t height)
+	{
+		Stream::DynamicMemoryWriter writer;
 
-	BitmapFile bitmapFile = BitmapFile::CreateIndexed(bitCount, width, height);
-	BitmapFile bitmapFile2;
+		BitmapFile bitmapFile = BitmapFile::CreateIndexed(bitCount, width, height);
+		BitmapFile bitmapFile2;
 
-	EXPECT_NO_THROW(bitmapFile.WriteIndexed(writer));
-	EXPECT_NO_THROW(bitmapFile2 = BitmapFile::ReadIndexed(writer.GetReader()));
-	EXPECT_EQ(bitmapFile, bitmapFile2);
-}
+		EXPECT_NO_THROW(bitmapFile.WriteIndexed(writer));
+		EXPECT_NO_THROW(bitmapFile2 = BitmapFile::ReadIndexed(writer.GetReader()));
+		EXPECT_EQ(bitmapFile, bitmapFile2);
+	}
 }
 
 


### PR DESCRIPTION
Fix Clang warning `-Wmissing-prototypes`.

Related:
- Issue #175
