### PR TITLE
Initialize the `alpha` field for mixed `Color` constants

### DIFF
--- a/src/Bitmap/Color.h
+++ b/src/Bitmap/Color.h
@@ -32,9 +32,9 @@ namespace OP2Utility
 		const Color Green{ 0, 255, 0, 0 };
 		const Color Blue{ 0, 0, 255, 0 };
 
-		const Color Yellow{ 255, 255, 0 };
-		const Color Cyan{ 0, 255, 255 };
-		const Color Magenta{ 255, 0, 255 };
+		const Color Yellow{ 255, 255, 0, 0 };
+		const Color Cyan{ 0, 255, 255, 0 };
+		const Color Magenta{ 255, 0, 255, 0 };
 
 		const Color TransparentBlack{ 0, 0, 0, 255 };
 		const Color TransparentWhite{ 255, 255, 255, 255 };


### PR DESCRIPTION
Fix Clang warning `-Wmissing-field-initializers`.

----

Another alternative might be to set a default value for the `alpha` field:
```cpp
uint8_t alpha{0};
```

I'm a bit tempted to go that direction, though the other `Color` constants had an explicit `alpha` value of `0`, so I went with precedent.

----

Related:
- Issue #175
