### PR TITLE
Enable `/warnAsError` for the Windows MSVC CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build
       run: |
-        msbuild . /maxCpuCount
+        msbuild . /maxCpuCount /warnAsError
 
     - name: Test
       working-directory: ./test/


### PR DESCRIPTION
We should probably also eventually add `/property:RunCodeAnalysis=true`, though we'll need to clean up some warnings first.

Related:
- Issue #175
