### PR TITLE
Fix MSVC Code Analysis warnings - Uninitialized variables

### DIFF
--- a/src/Archive/VolFile.cpp
+++ b/src/Archive/VolFile.cpp
@@ -409,7 +409,12 @@ namespace OP2Utility::Archive
 		m_Count = packedFileCount;
 	}
 
-	VolFile::SectionHeader::SectionHeader() {}
+	VolFile::SectionHeader::SectionHeader() :
+		tag{},
+		length{},
+		padding{}
+	{}
+
 	VolFile::SectionHeader::SectionHeader(Tag tag, uint32_t length, VolPadding padding)
 		: tag(tag), length(length), padding(padding) {}
 }

--- a/src/Archive/VolFile.h
+++ b/src/Archive/VolFile.h
@@ -80,10 +80,10 @@ namespace OP2Utility::Archive
 			std::vector<std::unique_ptr<Stream::BidirectionalReader>> fileStreamReaders;
 			std::vector<std::string> filesToPack;
 			std::vector<std::string> names;
-			uint32_t stringTableLength;
-			uint32_t indexTableLength;
-			uint32_t paddedStringTableLength;
-			uint32_t paddedIndexTableLength;
+			uint32_t stringTableLength{};
+			uint32_t indexTableLength{};
+			uint32_t paddedStringTableLength{};
+			uint32_t paddedIndexTableLength{};
 
 			std::size_t fileCount() const
 			{

--- a/src/Bitmap/BitmapFile.h
+++ b/src/Bitmap/BitmapFile.h
@@ -26,8 +26,8 @@ namespace OP2Utility
 	class BitmapFile
 	{
 	public:
-		BmpHeader bmpHeader;
-		ImageHeader imageHeader;
+		BmpHeader bmpHeader{};
+		ImageHeader imageHeader{};
 		std::vector<Color> palette;
 		std::vector<uint8_t> pixels;
 

--- a/src/Map/Map.cpp
+++ b/src/Map/Map.cpp
@@ -7,6 +7,7 @@
 namespace OP2Utility
 {
 	Map::Map() :
+		clipRect{},
 		versionTag(MapHeader::MinMapVersion),
 		isSavedGame(false),
 		widthInTiles(0),

--- a/src/Map/SavedGameUnits.h
+++ b/src/Map/SavedGameUnits.h
@@ -34,8 +34,8 @@ namespace OP2Utility
 		std::vector<uint32_t> objects2;
 		uint32_t nextUnitIndex{}; //Type UnitID
 		uint32_t prevUnitIndex{}; //Type UnitID
-		std::array<UnitRecord, 2047> units; // Was 1023 before patch
-		std::array<uint32_t, 2048> freeUnits;
+		std::array<UnitRecord, 2047> units{}; // Was 1023 before patch
+		std::array<uint32_t, 2048> freeUnits{};
 
 		void CheckSizeOfUnit() const;
 	};

--- a/src/Map/SavedGameUnits.h
+++ b/src/Map/SavedGameUnits.h
@@ -23,17 +23,17 @@ namespace OP2Utility
 	// Second section of saved game specifc data (not included in .map files)
 	struct SavedGameUnits
 	{
-		uint32_t unitCount;
-		uint32_t lastUsedUnitIndex;
-		uint32_t nextFreeUnitSlotIndex;
-		uint32_t firstFreeUnitSlotIndex;
-		uint32_t sizeOfUnit;
-		uint32_t objectCount1;
-		uint32_t objectCount2;
+		uint32_t unitCount{};
+		uint32_t lastUsedUnitIndex{};
+		uint32_t nextFreeUnitSlotIndex{};
+		uint32_t firstFreeUnitSlotIndex{};
+		uint32_t sizeOfUnit{};
+		uint32_t objectCount1{};
+		uint32_t objectCount2{};
 		std::vector<ObjectType1> objects1;
 		std::vector<uint32_t> objects2;
-		uint32_t nextUnitIndex; //Type UnitID
-		uint32_t prevUnitIndex; //Type UnitID
+		uint32_t nextUnitIndex{}; //Type UnitID
+		uint32_t prevUnitIndex{}; //Type UnitID
 		std::array<UnitRecord, 2047> units; // Was 1023 before patch
 		std::array<uint32_t, 2048> freeUnits;
 

--- a/src/Map/TileGroup.h
+++ b/src/Map/TileGroup.h
@@ -12,10 +12,10 @@ namespace OP2Utility
 		std::string name;
 
 		// Width of tile group in tiles
-		uint32_t tileWidth;
+		uint32_t tileWidth{};
 
 		// Height of tile group in tiles
-		uint32_t tileHeight;
+		uint32_t tileHeight{};
 
 		// Tiles used in TileGroup listed in 1D (all of row 0 tiles first, then row 1, etc).
 		std::vector<uint32_t> mappingIndices;

--- a/src/Map/TilesetSource.h
+++ b/src/Map/TilesetSource.h
@@ -16,7 +16,7 @@ namespace OP2Utility
 		std::string tilesetFilename;
 
 		// Number of Tiles in set (represented on BMP).
-		uint32_t numTiles;
+		uint32_t numTiles{};
 
 
 		bool operator==(const TilesetSource& rhs) const {

--- a/src/Sprite/Animation.h
+++ b/src/Sprite/Animation.h
@@ -48,10 +48,10 @@ namespace OP2Utility
 
 		static_assert(16 == sizeof(UnknownContainer), "Animation::UnknownContainer is an unexpected size");
 
-		uint32_t unknown;
-		Rect selectionRect; // pixels
-		Point32 pixelDisplacement; // Reverse direction from an offset, origin is center of tile
-		uint32_t unknown2; //(0x3C CC/DIRT/Garage/Std. Lab construction/dock, 0x0D spider walking)
+		uint32_t unknown{};
+		Rect selectionRect{}; // pixels
+		Point32 pixelDisplacement{}; // Reverse direction from an offset, origin is center of tile
+		uint32_t unknown2{}; //(0x3C CC/DIRT/Garage/Std. Lab construction/dock, 0x0D spider walking)
 
 		std::vector<Frame> frames;
 

--- a/src/Sprite/Animation.h
+++ b/src/Sprite/Animation.h
@@ -27,13 +27,13 @@ namespace OP2Utility
 
 			static_assert(8 == sizeof(Layer), "Animation::Frame::Layer is an unexpected size");
 
-			LayerMetadata layerMetadata;
-			LayerMetadata unknownBitfield;
+			LayerMetadata layerMetadata{};
+			LayerMetadata unknownBitfield{};
 
-			uint8_t optional1;
-			uint8_t optional2;
-			uint8_t optional3;
-			uint8_t optional4;
+			uint8_t optional1{};
+			uint8_t optional2{};
+			uint8_t optional3{};
+			uint8_t optional4{};
 
 			// Maximum count of items in container is 128
 			std::vector<Layer> layers;

--- a/src/Sprite/ArtFile.h
+++ b/src/Sprite/ArtFile.h
@@ -30,7 +30,7 @@ namespace OP2Utility
 		std::vector<Palette8Bit> palettes;
 		std::vector<ImageMeta> imageMetas;
 		std::vector<Animation> animations;
-		uint32_t unknownAnimationCount;
+		uint32_t unknownAnimationCount{};
 
 		static ArtFile Read(std::string filename);
 		static ArtFile Read(Stream::Reader& reader);

--- a/src/Sprite/SectionHeader.cpp
+++ b/src/Sprite/SectionHeader.cpp
@@ -3,7 +3,7 @@
 
 namespace OP2Utility
 {
-	SectionHeader::SectionHeader() : length(0) {}
+	SectionHeader::SectionHeader() : tag{}, length(0) {}
 	SectionHeader::SectionHeader(Tag tag, uint32_t length) : tag(tag), length(length) {}
 
 	void SectionHeader::Validate(Tag tagName) const

--- a/src/Sprite/TilesetHeaders.h
+++ b/src/Sprite/TilesetHeaders.h
@@ -10,11 +10,11 @@ namespace OP2Utility::Tileset
 	struct TilesetHeader
 	{
 		SectionHeader sectionHead;
-		uint32_t tagCount;
-		uint32_t pixelWidth;
-		uint32_t pixelHeight; // Assume height is always positive, unlike standard Windows Bitmap Format
-		uint32_t bitDepth;
-		uint32_t flags;
+		uint32_t tagCount{};
+		uint32_t pixelWidth{};
+		uint32_t pixelHeight{}; // Assume height is always positive, unlike standard Windows Bitmap Format
+		uint32_t bitDepth{};
+		uint32_t flags{};
 
 		constexpr static auto DefaultTagHead = MakeTag("head");
 		constexpr static uint32_t DefaultSectionSize = 0x14;

--- a/src/Sprite/TilesetHeaders.h
+++ b/src/Sprite/TilesetHeaders.h
@@ -33,7 +33,7 @@ namespace OP2Utility::Tileset
 	{
 		SectionHeader ppal;
 		SectionHeader head;
-		uint32_t tagCount;
+		uint32_t tagCount{};
 
 		constexpr static auto DefaultTagPpal = MakeTag("PPAL");
 		constexpr static uint32_t DefaultPpalSectionSize = 1048;


### PR DESCRIPTION
Fixes warnings for potential uninitialized data, though I wonder if we could do a bit better than the changes here. For `class` types I think I prefer using the constructor init-list to initialize fields. Though for `struct` types, where all fields are `public`, and no constructor exists, it's pretty easy to declare an instance and not initialize fields unless they are given a default initializer in the `struct` definition.

Related:
- Issue #175
- PR #424
