### PR TITLE
Fix Clang warnings `-Wimplicit-int-conversion`

### DIFF
--- a/src/Archive/HuffLZ.cpp
+++ b/src/Archive/HuffLZ.cpp
@@ -197,7 +197,7 @@ namespace OP2Utility::Archive
 	// Performs a tree lookup guided by the bitstream to find the next code
 	unsigned short HuffLZ::GetNextCode()
 	{
-		int nodeIndex;
+		unsigned short nodeIndex;
 		bool bBit;
 
 		// Use bitstream to find a terminal node

--- a/src/Archive/HuffLZ.cpp
+++ b/src/Archive/HuffLZ.cpp
@@ -195,7 +195,7 @@ namespace OP2Utility::Archive
 
 
 	// Performs a tree lookup guided by the bitstream to find the next code
-	int HuffLZ::GetNextCode()
+	unsigned short HuffLZ::GetNextCode()
 	{
 		int nodeIndex;
 		bool bBit;

--- a/src/Archive/HuffLZ.h
+++ b/src/Archive/HuffLZ.h
@@ -22,7 +22,7 @@ namespace OP2Utility::Archive
 		void FillDecompressBuffer();				// Decompress until buffer is near full
 		std::size_t CopyAvailableData(char *buff, std::size_t size);// Copies already decompressed data
 		bool DecompressCode();	// Decompresses a code and returns false at end of stream
-		int GetNextCode();
+		unsigned short GetNextCode();
 		unsigned int GetRepeatOffset();
 		void WriteCharToBuffer(char c);
 

--- a/src/Sprite/TilesetLoader.cpp
+++ b/src/Sprite/TilesetLoader.cpp
@@ -74,7 +74,12 @@ namespace OP2Utility::Tileset
 		reader.Read(paletteHeader);
 		ValidatePaletteHeader(paletteHeader);
 
-		auto bitmapFile = BitmapFile::CreateIndexed(tilesetHeader.bitDepth, tilesetHeader.pixelWidth, tilesetHeader.pixelHeight * -1);
+		const auto bitDepth = static_cast<uint16_t>(tilesetHeader.bitDepth);
+		if (static_cast<uint32_t>(bitDepth) != tilesetHeader.bitDepth) {
+			throw std::runtime_error("Invalid bitDepth reading custom tileset: " + std::to_string(tilesetHeader.bitDepth));
+		}
+
+		auto bitmapFile = BitmapFile::CreateIndexed(bitDepth, tilesetHeader.pixelWidth, tilesetHeader.pixelHeight * -1);
 		reader.Read(bitmapFile.palette);
 
 		SectionHeader pixelHeader;

--- a/src/StringUtility.cpp
+++ b/src/StringUtility.cpp
@@ -7,7 +7,7 @@ namespace OP2Utility::StringUtility
 	void ConvertToUpperInPlace(std::string& str)
 	{
 		for (auto& c : str) {
-			c = toupper(c);
+			c = static_cast<char>(toupper(static_cast<unsigned char>(c)));
 		}
 	}
 

--- a/test/Archive/AdaptiveHuffmanTree.test.cpp
+++ b/test/Archive/AdaptiveHuffmanTree.test.cpp
@@ -33,7 +33,7 @@ protected:
 // Test the encoder and decoder against each other
 TEST_F(AdaptiveHuffmanTreeOutpost2, EncodeDecode) {
 	auto codeCount = tree.TerminalNodeCount();
-	for (unsigned int i = 0; i < codeCount; ++i) {
+	for (unsigned short i = 0; i < codeCount; ++i) {
 		unsigned int codeLength;
 		auto bitString = tree.GetEncodedBitString(i, codeLength);
 		auto node = tree.GetRootNodeIndex();


### PR DESCRIPTION
Fix Clang warning `-Wimplicit-int-conversion`.

Many of these were also reported by MSVC at warning level 4.

Related:
- Issue #175
- PR #424
