### PR TITLE
Fix Clang warnings `-Wshift-sign-overflow`

### DIFF
--- a/src/Archive/VolFile.cpp
+++ b/src/Archive/VolFile.cpp
@@ -287,8 +287,8 @@ namespace OP2Utility::Archive
 		volInfo.indexTableLength = static_cast<uint32_t>(volInfo.fileCount()) * sizeof(IndexEntry);
 
 		// Calculate the zero padded length of the string table and index table
-		volInfo.paddedStringTableLength = (volInfo.stringTableLength + 7) & ~3;
-		volInfo.paddedIndexTableLength = (volInfo.indexTableLength + 3) & ~3;
+		volInfo.paddedStringTableLength = (volInfo.stringTableLength + 7) & ~3u;
+		volInfo.paddedIndexTableLength = (volInfo.indexTableLength + 3) & ~3u;
 
 		if (volInfo.indexEntries.size() == 0) {
 			return;
@@ -300,7 +300,7 @@ namespace OP2Utility::Archive
 		for (std::size_t i = 1; i < volInfo.fileCount(); ++i)
 		{
 			const IndexEntry& previousIndex = volInfo.indexEntries[i - 1];
-			volInfo.indexEntries[i].dataBlockOffset = (previousIndex.dataBlockOffset + previousIndex.fileSize + 11) & ~3;
+			volInfo.indexEntries[i].dataBlockOffset = (previousIndex.dataBlockOffset + previousIndex.fileSize + 11) & ~3u;
 		}
 	}
 

--- a/src/BitTwiddle.cpp
+++ b/src/BitTwiddle.cpp
@@ -10,7 +10,7 @@ namespace OP2Utility
 	// This method assumes the argument is a power of 2
 	uint32_t Log2OfPowerOf2(uint32_t value)
 	{
-		static const int MultiplyDeBruijnBitPosition2[32] =
+		static const uint32_t MultiplyDeBruijnBitPosition2[32] =
 		{
 			0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
 			31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9

--- a/src/Bitmap/ImageHeader.cpp
+++ b/src/Bitmap/ImageHeader.cpp
@@ -74,7 +74,7 @@ namespace OP2Utility
 	std::size_t ImageHeader::CalculatePitch(uint16_t bitCount, int32_t width)
 	{
 		const auto bytesOfPixelsPerRow = CalcPixelByteWidth(bitCount, width);
-		return (bytesOfPixelsPerRow + 3) & ~3;
+		return (bytesOfPixelsPerRow + 3) & ~3u;
 	}
 
 	std::size_t ImageHeader::CalcPixelByteWidth() const

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -93,7 +93,7 @@ namespace OP2Utility
 		void TrimTilesetSources();
 
 	private:
-		int32_t versionTag;
+		uint32_t versionTag;
 		bool isSavedGame;
 		uint32_t widthInTiles;
 		uint32_t heightInTiles;

--- a/src/Sprite/ArtFile.cpp
+++ b/src/Sprite/ArtFile.cpp
@@ -14,7 +14,7 @@ namespace OP2Utility
 	{
 		for (const auto& imageMeta : imageMetas) {
 			// Bitwise operation rounds up to the next 4 byte interval
-			if (imageMeta.scanLineByteWidth != ((imageMeta.width + 3) & ~3)) {
+			if (imageMeta.scanLineByteWidth != ((imageMeta.width + 3) & ~3u)) {
 				throw std::runtime_error("Image scan line byte width is not valid. It must be the width of the image rounded up to a 4 byte interval.");
 			}
 

--- a/test/BitTwiddle.test.cpp
+++ b/test/BitTwiddle.test.cpp
@@ -17,7 +17,7 @@ TEST(BitTwiddle, IsPowerOf2) {
 	EXPECT_TRUE(IsPowerOf2(256));
 	EXPECT_TRUE(IsPowerOf2(512));
 
-	EXPECT_TRUE(IsPowerOf2(1 << 31));
+	EXPECT_TRUE(IsPowerOf2(1u << 31));
 
 	EXPECT_FALSE(IsPowerOf2(0));
 	EXPECT_FALSE(IsPowerOf2(3));
@@ -38,5 +38,5 @@ TEST(BitTwiddle, Log2OfPowerOf2) {
 	EXPECT_EQ(8u, Log2OfPowerOf2(256));
 	EXPECT_EQ(9u, Log2OfPowerOf2(512));
 
-	EXPECT_EQ(31u, Log2OfPowerOf2(1 << 31));
+	EXPECT_EQ(31u, Log2OfPowerOf2(1u << 31));
 }


### PR DESCRIPTION
Fix Clang warning for `-Wshift-sign-overflow` and `-Wsign-conversion`.

This handles many of the easier looking cases for `-Wsign-conversion`. There are still more warnings for `-Wsign-conversion`.

Related:
- Issue #175
- PR #426
