### PR TITLE
Fix Clang warnings `-Wshadow`

### DIFF
--- a/src/Archive/VolFile.cpp
+++ b/src/Archive/VolFile.cpp
@@ -129,17 +129,17 @@ namespace OP2Utility::Archive
 
 			// Load data into temporary memory buffer
 			std::size_t length = sectionHeader.length;
-			std::vector<uint8_t> buffer(length);
-			archiveFileReader.Read(buffer);
+			std::vector<uint8_t> compressedBuffer(length);
+			archiveFileReader.Read(compressedBuffer);
 
-			HuffLZ decompressor(BitStreamReader(buffer.data(), length));
+			HuffLZ decompressor(BitStreamReader(compressedBuffer.data(), length));
 
 			Stream::FileWriter fileStreamWriter(pathOut);
 
 			do
 			{
-				const void *buffer = decompressor.GetInternalBuffer(&length);
-				fileStreamWriter.Write(buffer, length);
+				const void *decompressedBuffer = decompressor.GetInternalBuffer(&length);
+				fileStreamWriter.Write(decompressedBuffer, length);
 			} while (length);
 		}
 		catch (const std::exception& e)

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -102,7 +102,6 @@ namespace OP2Utility
 
 		// Write
 		MapHeader CreateHeader() const;
-		uint32_t GetWidthInTilesLog2(uint32_t widthInTiles) const;
 		static void WriteTilesetSources(Stream::Writer& stream, const std::vector<TilesetSource>& tilesetSources);
 		static void WriteTileGroups(Stream::Writer& stream, const std::vector<TileGroup>& tileGroups);
 		static void WriteContainerSize(Stream::Writer& stream, std::size_t size);

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -68,7 +68,7 @@ namespace OP2Utility
 		void Write(const std::string& filename) const;
 		void Write(Stream::Writer& streamWriter) const;
 
-		void SetVersionTag(uint32_t newVersionTag) { this->versionTag = newVersionTag; }
+		void SetVersionTag(uint32_t newVersionTag) { versionTag = newVersionTag; }
 		uint32_t GetVersionTag() const { return versionTag; }
 		bool IsSavedGame() const { return isSavedGame; }
 		uint32_t WidthInTiles() const { return widthInTiles; }

--- a/src/Map/Map.h
+++ b/src/Map/Map.h
@@ -68,7 +68,7 @@ namespace OP2Utility
 		void Write(const std::string& filename) const;
 		void Write(Stream::Writer& streamWriter) const;
 
-		void SetVersionTag(uint32_t versionTag) { this->versionTag = versionTag; }
+		void SetVersionTag(uint32_t newVersionTag) { this->versionTag = newVersionTag; }
 		uint32_t GetVersionTag() const { return versionTag; }
 		bool IsSavedGame() const { return isSavedGame; }
 		uint32_t WidthInTiles() const { return widthInTiles; }

--- a/src/Map/MapWriter.cpp
+++ b/src/Map/MapWriter.cpp
@@ -56,7 +56,6 @@ namespace OP2Utility
 
 	uint32_t Map::GetWidthInTilesLog2(uint32_t widthInTiles) const
 	{
-		//if (!IsPowerOf2(widthInTiles)) {
 		if (widthInTiles && !IsPowerOf2(widthInTiles)) {
 			throw std::runtime_error("Map width in tiles must be a power of 2");
 		}

--- a/src/Map/MapWriter.cpp
+++ b/src/Map/MapWriter.cpp
@@ -6,8 +6,21 @@
 #include <cmath>
 #include <limits>
 
+
 namespace OP2Utility
 {
+	namespace
+	{
+		uint32_t GetWidthInTilesLog2(uint32_t widthInTiles)
+		{
+			if (widthInTiles && !IsPowerOf2(widthInTiles)) {
+				throw std::runtime_error("Map width in tiles must be a power of 2");
+			}
+			return Log2OfPowerOf2(widthInTiles);
+		}
+	}
+
+
 	void Map::Write(const std::string& filename) const
 	{
 		Stream::FileWriter mapStream(filename);
@@ -52,14 +65,6 @@ namespace OP2Utility
 		mapHeader.tilesetCount = static_cast<uint32_t>(tilesetSources.size());
 
 		return mapHeader;
-	}
-
-	uint32_t Map::GetWidthInTilesLog2(uint32_t widthInTiles) const
-	{
-		if (widthInTiles && !IsPowerOf2(widthInTiles)) {
-			throw std::runtime_error("Map width in tiles must be a power of 2");
-		}
-		return Log2OfPowerOf2(widthInTiles);
 	}
 
 	void Map::WriteTilesetSources(Stream::Writer& stream, const std::vector<TilesetSource>& tilesetSources)

--- a/src/Map/MapWriter.cpp
+++ b/src/Map/MapWriter.cpp
@@ -24,7 +24,7 @@ namespace OP2Utility
 	void Map::Write(const std::string& filename) const
 	{
 		Stream::FileWriter mapStream(filename);
-		this->Write(mapStream);
+		Write(mapStream);
 	}
 
 	void Map::Write(Stream::Writer& mapStream) const

--- a/src/Stream/MemoryReader.cpp
+++ b/src/Stream/MemoryReader.cpp
@@ -36,13 +36,13 @@ namespace OP2Utility::Stream
 		return position;
 	}
 
-	void MemoryReader::Seek(uint64_t position) {
-		if (position > streamSize) {
+	void MemoryReader::Seek(uint64_t newPosition) {
+		if (newPosition > streamSize) {
 			throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 		}
 
-		// position is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
-		this->position = static_cast<std::size_t>(position);
+		// newPosition is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
+		this->position = static_cast<std::size_t>(newPosition);
 	}
 
 	void MemoryReader::SeekForward(uint64_t offset)

--- a/src/Stream/MemoryReader.cpp
+++ b/src/Stream/MemoryReader.cpp
@@ -42,29 +42,29 @@ namespace OP2Utility::Stream
 		}
 
 		// newPosition is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
-		this->position = static_cast<std::size_t>(newPosition);
+		position = static_cast<std::size_t>(newPosition);
 	}
 
 	void MemoryReader::SeekForward(uint64_t offset)
 	{
-		uint64_t newPosition = this->position + offset;
+		uint64_t newPosition = position + offset;
 		
-		if (newPosition > streamSize || newPosition < this->position) // Check if offset wraps past max size.
+		if (newPosition > streamSize || newPosition < position) // Check if offset wraps past max size.
 		{
 			throw std::runtime_error("Change in offset puts read position outside bounds of buffer.");
 		}
 
 		// offset is checked against size of streamSize, which cannot exceed SIZE_MAX (max size of std::size_t)
-		this->position = static_cast<std::size_t>(newPosition);
+		position = static_cast<std::size_t>(newPosition);
 	}
 
 	void MemoryReader::SeekBackward(uint64_t offset)
 	{
-		if (offset > this->position) {
+		if (offset > position) {
 			throw std::runtime_error("Change in offset puts read position outside bounds of buffer.");
 		}
 
-		this->position -= static_cast<std::size_t>(offset);
+		position -= static_cast<std::size_t>(offset);
 	}
 
 	MemoryReader MemoryReader::Slice(uint64_t sliceLength)

--- a/src/Stream/MemoryWriter.cpp
+++ b/src/Stream/MemoryWriter.cpp
@@ -29,8 +29,6 @@ namespace OP2Utility::Stream
 
 	void MemoryWriter::Seek(uint64_t newOffset)
 	{
-		// Checking if newOffset goes below 0 is unnecessary. Arithmetic on a signed and unsigned number results
-		// in a signed number that will wraparound to a large positive and be caught.
 		if (newOffset > streamSize) {
 			throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 		}

--- a/src/Stream/MemoryWriter.cpp
+++ b/src/Stream/MemoryWriter.cpp
@@ -33,16 +33,16 @@ namespace OP2Utility::Stream
 			throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 		}
 
-		this->offset = static_cast<std::size_t>(newOffset);
+		offset = static_cast<std::size_t>(newOffset);
 	}
 
 	void MemoryWriter::SeekForward(uint64_t forwardOffset)
 	{
-		Seek(this->offset + forwardOffset);
+		Seek(offset + forwardOffset);
 	}
 
 	void MemoryWriter::SeekBackward(uint64_t backwardOffset)
 	{
-		Seek(this->offset - backwardOffset);
+		Seek(offset - backwardOffset);
 	}
 }

--- a/src/Stream/MemoryWriter.cpp
+++ b/src/Stream/MemoryWriter.cpp
@@ -27,24 +27,24 @@ namespace OP2Utility::Stream
 		return offset;
 	}
 
-	void MemoryWriter::Seek(uint64_t offset)
+	void MemoryWriter::Seek(uint64_t newOffset)
 	{
-		// Checking if offset goes below 0 is unnecessary. Arithmetic on a signed and unsigned number results
+		// Checking if newOffset goes below 0 is unnecessary. Arithmetic on a signed and unsigned number results
 		// in a signed number that will wraparound to a large positive and be caught.
-		if (offset > streamSize) {
+		if (newOffset > streamSize) {
 			throw std::runtime_error("Change in offset places read position outside bounds of buffer.");
 		}
 
-		this->offset = static_cast<std::size_t>(offset);
+		this->offset = static_cast<std::size_t>(newOffset);
 	}
 
-	void MemoryWriter::SeekForward(uint64_t offset)
+	void MemoryWriter::SeekForward(uint64_t forwardOffset)
 	{
-		Seek(this->offset + offset);
+		Seek(this->offset + forwardOffset);
 	}
 
-	void MemoryWriter::SeekBackward(uint64_t offset)
+	void MemoryWriter::SeekBackward(uint64_t backwardOffset)
 	{
-		Seek(this->offset - offset);
+		Seek(this->offset - backwardOffset);
 	}
 }

--- a/src/Stream/SliceReader.h
+++ b/src/Stream/SliceReader.h
@@ -97,19 +97,19 @@ namespace OP2Utility::Stream
 		}
 
 
-		SliceReader<WrappedStreamType> Slice(uint64_t sliceLength) {
-			auto slice = Slice(Position(), sliceLength);
+		SliceReader<WrappedStreamType> Slice(uint64_t newSliceLength) {
+			auto slice = Slice(Position(), newSliceLength);
 
 			// Wait until slice is successfully created before seeking forward.
-			SeekForward(sliceLength);
+			SeekForward(newSliceLength);
 
 			return slice;
 		}
 
-		SliceReader<WrappedStreamType> Slice(uint64_t sliceStartPosition, uint64_t sliceLength) const {
+		SliceReader<WrappedStreamType> Slice(uint64_t sliceStartPosition, uint64_t newSliceLength) const {
 			if (
-				sliceStartPosition + sliceLength > this->sliceLength ||
-				sliceLength > std::numeric_limits<decltype(sliceStartPosition)>::max() - sliceStartPosition
+				sliceStartPosition + newSliceLength > this->sliceLength ||
+				newSliceLength > std::numeric_limits<decltype(sliceStartPosition)>::max() - sliceStartPosition
 			) {
 				throw std::runtime_error(
 					"Requested stream slice exceeds the bounds of current stream slice."
@@ -117,7 +117,7 @@ namespace OP2Utility::Stream
 				);
 			}
 
-			return SliceReader(wrappedStream, this->startingOffset + sliceStartPosition, sliceLength);
+			return SliceReader(wrappedStream, this->startingOffset + sliceStartPosition, newSliceLength);
 		}
 
 		const std::string& GetFilename() const {


### PR DESCRIPTION
Fix Clang warnings `-Wshadow`.

Fix MSVC warnings (Level 4) for the same issue.

Related:
- Issue #175
- PR #428
- PR #427
- PR #426
- PR #424
