### PR TITLE
Add `Debug` builds to CI `matrix`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [x86, x64]
-        configuration: [Release]
+        configuration: [Debug, Release]
     runs-on: windows-2025
     env:
       Platform: ${{ matrix.platform }}


### PR DESCRIPTION
Some Vcpkg settings are sensitive to `Debug` configuration settings. We should enable `Debug` CI builds before changing to use Vcpkg.

Related:
- Issue #414
