### PR TITLE
Update `.gitignore` for Vcpkg work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ libOP2Utility.a
 
 # Nuget
 **/packages
+
+# Vcpkg
+**/vcpkg_installed/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 **/x64
 **/Debug
 **/Release
-**/packages
 .build/
 *.user
 *.vs
@@ -12,3 +11,6 @@ CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
 libOP2Utility.a
+
+# Nuget
+**/packages


### PR DESCRIPTION
Some of the Vcpkg work has been ongoing for a bit, and there was still some issues with the `Debug` configurations. Adding the `vcpkg_installed/` folder to `.gitignore` here will make it easier to switch between the Vcpkg development branch and other branches.

Related:
- Issue #414
