### PR TITLE
Strip UTF-8 BOM from project and project filter files

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/OP2Utility.vcxproj.filters
+++ b/OP2Utility.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/test/OP2UtilityTest.vcxproj.filters
+++ b/test/OP2UtilityTest.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="Stream\MemoryStreamReader.test.cpp">


### PR DESCRIPTION
The Byte Order Mark (BOM) isn't needed, and tends to be included inconsistently by various project files. Notably some downstream projects, such as MissionScanner don't include a BOM.

Stripping the BOM, and using a consistent line ending format, makes it easier to compare project settings between various project files, by reducing the noise of trivial changes in the diff.

For reference, the NAS2D library was used as a point of comparison for its update to using `vcpkg` for dependencies.

Related:
- Issue #414
- PR https://github.com/lairworks/nas2d-core/pull/1213
