### PR TITLE
Add property `UseDebugLibraries` to OP2UtilityTest `Debug` configurations

### DIFF
--- a/test/OP2UtilityTest.vcxproj
+++ b/test/OP2UtilityTest.vcxproj
@@ -26,6 +26,12 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings" />
   <ImportGroup Label="Shared" />


### PR DESCRIPTION
A freshly generated project would expect to set `UseDebugLibraries` to `true` for `Debug` configurations. It is used to set several defaults within a MSVC project. Actual `Debug` related settings can be overridden despite the defaults, so this setting isn't guaranteed to correspond with individual settings.

Documentation:
https://learn.microsoft.com/en-us/cpp/build/reference/advanced-property-page?view=msvc-170#use-debug-libraries

There is a plan to switch to `vcpkg` for dependency management. The `UseDebugLibraries` property would be used by the `vcpkg` package manager to set the `VcpkgConfiguration` value. This is what allows `vcpkg` to link `Debug` libraries with `Debug` configuration builds.

Documentation:
https://learn.microsoft.com/en-us/vcpkg/users/buildsystems/msbuild-integration#vcpkgconfiguration-vcpkg-configuration

Source:
https://github.com/microsoft/vcpkg/blob/ba27a182ef0c24b70b55b723605451a491cd891a/scripts/buildsystems/msbuild/vcpkg.props#L8-L26

----

Related:
- Issue #414
