### PR TITLE
Update target C++ standard to C++20

### DIFF
--- a/OP2Utility.vcxproj
+++ b/OP2Utility.vcxproj
@@ -75,7 +75,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -84,7 +84,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -95,7 +95,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -110,7 +110,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ clangWarnNotInterested := -Wno-c++98-compat-pedantic -Wno-pre-c++17-compat
 clangWarnShow := -Weverything $(clangWarnNotInterested)
 
 CXXFLAGS_WARN := -Wall -Wno-unknown-pragmas
-CXXFLAGS := -std=c++17 -g $(CXXFLAGS_EXTRA) $(CXXFLAGS_WARN)
+CXXFLAGS := -std=c++20 -g $(CXXFLAGS_EXTRA) $(CXXFLAGS_WARN)
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(INTDIR)/$*.Td
 
@@ -51,7 +51,7 @@ GTESTLIBDIR := /usr/lib/
 .PHONY: gtest gtest-install gtest-clean
 gtest:
 	mkdir -p "$(GTESTBUILDDIR)"
-	cd "$(GTESTBUILDDIR)" && cmake -DCMAKE_CXX_COMPILER="$(CXX)" -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_FLAGS="-std=c++17" "$(GTESTSRCDIR)"
+	cd "$(GTESTBUILDDIR)" && cmake -DCMAKE_CXX_COMPILER="$(CXX)" -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_FLAGS="-std=c++20" "$(GTESTSRCDIR)"
 	make -C "$(GTESTBUILDDIR)"
 gtest-install:
 	cp $(GTESTBUILDDIR)googlemock/gtest/lib*.a "$(GTESTLIBDIR)"


### PR DESCRIPTION
Update to latest well supported C++ standard.

----

As a side effect, this also eliminates the Clang warning `-Wc++20-compat` from the unit test project.

The file `Tag.test.cpp` used to emit a warning for:
```cpp
EXPECT_EQ(5u, RemoveLastElement(u8"UTF-8").size());
```
> error: type of UTF-8 string literal will change from array of const char to array of const char8_t in C++20 [-Werror,-Wc++20-compat]
> ...
> note: remove 'u8' prefix to avoid a change of behavior; Clang encodes unprefixed narrow string literals as UTF-8

The use of UTF-8 was very intentional there, and should use whatever native data types are involved. The call is to a template function, which will select an appropriate matching data type.

----

Related:
- Issue #414
- Issue #406
