### PR TITLE
Update `makefile` helper targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -139,11 +139,11 @@ cppinclude-detailed:
 
 .PHONY: stale
 stale:
-	@$(MAKE) -n | grep -oE '[^ ]+\.cpp$$' || true
+	@$(MAKE) all -n | grep -oE '[^ ]+\.cpp$$' || true
 
 .PHONY: stale-objs
 stale-objs:
-	@$(MAKE) -n | grep -oE '[^ ]+\.o$$' || true
+	@$(MAKE) all -n | grep -oE '[^ ]+\.o$$' || true
 
 # This can create a lot of extra tab auto complete entries, so maybe disable by default
 AllObjectFiles := $(OBJS)) $(TESTOBJS)

--- a/makefile
+++ b/makefile
@@ -110,6 +110,8 @@ clean-all: clean
 .PHONY: show-warnings
 show-warnings:
 	@$(MAKE) clean > /dev/null
+	$(MAKE) --output-sync CXX=clang++ CXXFLAGS_WARN="$(clangWarnShow)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
+	@echo
 	$(MAKE) --output-sync all CXX=clang++ CXXFLAGS_WARN="$(clangWarnShow)" 2>&1 >/dev/null | grep -o "\[-W.*\]" | sort | uniq
 	@$(MAKE) clean > /dev/null
 


### PR DESCRIPTION
Update `makefile` helper targets `show-warnings`, `stale`, and `stale-objs`.

The `show-warnings` target will now separate the errors from the default target (`op2utility`), and the `all` target, which includes the `test` project.

The `stale` and `stale-objs` helpers will now list stale files for the `all` target, which includes both the main `op2utility` target and the `test` target.

Related:
- Issue #406
