### PR TITLE
Link with `gmock_main.lib` rather than `gtest_main.lib`

### DIFF
--- a/makefile
+++ b/makefile
@@ -67,7 +67,7 @@ TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTINTDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I$(GTESTINCDIR)
 TESTLDFLAGS := -L./ -L$(GTESTLOCALLIBDIR) -L$(GTESTLOCALLIBDIR)/gtest/
-TESTLIBS := -lOP2Utility -lgtest -lgtest_main -lpthread -lstdc++fs
+TESTLIBS := -lOP2Utility -lgmock_main -lgmock -lgtest -lpthread -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTINTDIR)/$*.Td


### PR DESCRIPTION
Re-order dependencies so libraries are linked before the libraries they use.

----

While updating other support sections of the `makefile` I noticed the incorrect use of `gtest_main.lib` rather than `gmock_main.lib`. The correct library to link had come up recently in the context of MSVC project files in the issue to modernize the build workflow.

----

Related:
- Issue #414
- Issue #406
- PR #439
- PR #438
