### PR TITLE
Add GitHub Actions workflow to build Docker build env

### DIFF
--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -1,0 +1,23 @@
+name: Build Docker Build Env
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dockerBuild:
+    runs-on: ubuntu-latest
+    env:
+      buildPath: .circleci/
+      imageName: ghcr.io/outpostuniverse/op2utility:1.2
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Docker build
+        run: docker build "${{ env.buildPath }}" --tag "${{ env.imageName }}"
+
+      - name: Docker login
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.repository_owner }}" --password-stdin
+
+      - name: Docker push
+        run: docker push "${{ env.imageName }}"


### PR DESCRIPTION
It's much faster to build and upload an image from a GitHub Actions runner than to build locally and then upload from a remote connection.

To keep this simple, this workflow will only run on demand. It will need to be part of the default branch (`main`) before it can be run on demand.

The typically workflow might be to update the `Dockerfile` and the tag in the `buildDockerBuildEnv` workflow, and then run it, from the branch, to build the new image. Update the image tag used by the runners in a followup commit, and then open a PR.

Related:
- Issue #414
