### PR TITLE
Update GitHub actions Linux environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         compiler: [g++, clang++]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/outpostuniverse/op2utility:1.2
+      image: ghcr.io/outpostuniverse/op2utility:1.3
       env:
         CXX: ${{ matrix.compiler }}
 

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -7,8 +7,8 @@ jobs:
   dockerBuild:
     runs-on: ubuntu-latest
     env:
-      buildPath: .circleci/
-      imageName: ghcr.io/outpostuniverse/op2utility:1.2
+      buildPath: dockerBuildEnv/
+      imageName: ghcr.io/outpostuniverse/op2utility:1.3
 
     steps:
       - uses: actions/checkout@v6

--- a/dockerBuildEnv/Dockerfile
+++ b/dockerBuildEnv/Dockerfile
@@ -1,0 +1,18 @@
+# For building on GitHub Actions
+
+# To update:
+# 1. Bump the version number tag on `imageName` in: `.github/workflows/buildDockerBuildEnv.yml`
+# 2. Make and push changes to Dockerfile
+# 3. Run `buildDockerBuildEnv` workflow on branch with changes
+#      https://github.com/OutpostUniverse/OP2Utility/actions/workflows/buildDockerBuildEnv.yml
+# 4. Update `.github/workflows/build.yml` workflow to use new version number tag
+
+FROM ubuntu:resolute-20260421
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+    cmake \
+    libgtest-dev \
+    libgmock-dev \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Update build environment to be based on Ubuntu 26.04 (LTS), and slim down list of tools to install.

Based on the CircleCI build image.

Related:
- Issue #414
- PR #447
- PR #446
