### PR TITLE
Remove `__cpp_lib_filesystem` check for `<filesystem>`

### DIFF
--- a/OP2Utility/src/XFile.cpp
+++ b/OP2Utility/src/XFile.cpp
@@ -3,13 +3,8 @@
 #include <cstddef>
 #include <algorithm>
 
-#ifdef __cpp_lib_filesystem
 #include <filesystem>
 namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
 
 namespace OP2Utility::XFile
 {


### PR DESCRIPTION
This project has long since targetted `c++17`, which includes `<filesystem>` as part of the standard. It has then been updated to target `c++20`. Further the `__cpp_lib_filesystem` macro is defined in `<version>` which is part of the `c++20` standard. That means we'd need to use a `c++20` feature to detect support for a `c++17` feature. Seems kind of pointless.

Closes #450

Related:
- Issue #450
