### PR TITLE
Update Linux build environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         compiler: [g++, clang++]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/outpostuniverse/op2utility:1.3
+      image: ghcr.io/outpostuniverse/op2utility:1.4
       env:
         CXX: ${{ matrix.compiler }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - run: make
-      - run: make test
-      - run: make check
+      - run: make --keep-going
+      - run: make --keep-going test
+      - run: make --keep-going check

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       buildPath: dockerBuildEnv/
-      imageName: ghcr.io/outpostuniverse/op2utility:1.3
+      imageName: ghcr.io/outpostuniverse/op2utility:1.4
 
     steps:
       - uses: actions/checkout@v6

--- a/dockerBuildEnv/Dockerfile
+++ b/dockerBuildEnv/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     build-essential \
     clang \
     cmake \
+    git \
+    ca-certificates \
     libgtest-dev \
     libgmock-dev \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add `git` to help with checkout from within the container, so checkout doesn't need to fall back on the REST API. This is particularly relevant for projects that use OP2Utility as a submodule, and wish to use the build image either directly or as a base image. They may want to use the `submodules: recursive` option, which requires `git`.

Add `ca-certificates` so secure connections can be made.

----

Add `--keep-going` flag when running `make` on CI.

----

Related:
- Issue #414
- PR https://github.com/OutpostUniverse/op2-landlord/pull/114
  - Commit: https://github.com/OutpostUniverse/op2-landlord/pull/114/changes/4c95ca34c39d0f80b2885d3881afe1ad66aecd38
