### PR TITLE
Disable Vcpkg for main library

### DIFF
--- a/OP2Utility/OP2Utility.vcxproj
+++ b/OP2Utility/OP2Utility.vcxproj
@@ -69,6 +69,9 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>


### PR DESCRIPTION
Only the unit test project uses Vcpkg, and that's for the Google Test dependency. The main library project doesn't have any dependencies.

As OP2Utility may be used as a dependency in projects that do use Vcpkg for their own dependencies, it may be helpful here to disable Vcpkg for the OP2Utility project. Part of that is so it doesn't get confused by manifest files in the host project while not having manifests enabled in the this project. Explicitly disabling Vcpkg for this project makes it easier to integrate into project that do use Vcpkg. The other part is that when Vcpkg is enabled it will add to the include search paths and the library search paths, even though it has no dependencies to load. Plus, when built on it's own, it may default to Classic Mode rather than Manifest Mode, so the search path adjustments may be different between projects, which is kind of odd.

----

Related:
- Issue #414
- PR #444
