### PR TITLE
Cleanup unit test temp folders

### DIFF
--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -102,4 +102,5 @@ TEST(FileWriter, DirectoryDoesNotExistCreate) {
 
 	// Delete the path after testing creation
 	XFile::DeletePath(path);
+	XFile::DeletePath(folder);
 }

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -94,6 +94,7 @@ TEST(FileWriter, DirectoryDoesNotExistCreate) {
 	const std::string& path("NewDirectory/TestFile.temp");
 
 	EXPECT_NO_THROW(Stream::FileWriter writer(path));
+	EXPECT_TRUE(XFile::PathExists(path));
 
 	// Delete the path after testing creation
 	XFile::DeletePath(path);

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -82,12 +82,16 @@ TEST(FileWriter, InvalidFilename) {
 	EXPECT_THROW(Stream::FileWriter fileWriter("data"), std::runtime_error);
 }
 
-TEST(FileWriter, DirectoryDoesNotExist) {
+TEST(FileWriter, DirectoryDoesNotExistFail) {
 	const std::string& path("NewDirectory/TestFile.temp");
 
 	// New directory should not be created when writer cannot create new files
 	EXPECT_THROW(Stream::FileWriter writer(path, Stream::FileWriter::OpenMode::CanOpenExisting), std::runtime_error);
 	EXPECT_FALSE(XFile::PathExists(path));
+}
+
+TEST(FileWriter, DirectoryDoesNotExistCreate) {
+	const std::string& path("NewDirectory/TestFile.temp");
 
 	EXPECT_NO_THROW(Stream::FileWriter writer(path));
 

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -8,7 +8,6 @@
 
 using namespace OP2Utility;
 
-void WriteToNewDirectory(const std::string& path);
 
 TEST(FileWriterOpenMode, BadFlagCombinations) {
 	using OpenMode = Stream::FileWriter::OpenMode;
@@ -84,17 +83,14 @@ TEST(FileWriter, InvalidFilename) {
 }
 
 TEST(FileWriter, DirectoryDoesNotExist) {
-	WriteToNewDirectory("NewDirectory/TestFile.temp");
-}
+	const std::string& path("NewDirectory/TestFile.temp");
 
-// Will delete the path after testing creation
-void WriteToNewDirectory(const std::string& path)
-{
 	// New directory should not be created when writer cannot create new files
 	EXPECT_THROW(Stream::FileWriter writer(path, Stream::FileWriter::OpenMode::CanOpenExisting), std::runtime_error);
 	EXPECT_FALSE(XFile::PathExists(path));
 
 	EXPECT_NO_THROW(Stream::FileWriter writer(path));
 
+	// Delete the path after testing creation
 	XFile::DeletePath(path);
 }

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -57,12 +57,14 @@ TEST(FileWriterOpenMode, PermissionChecks) {
 	ASSERT_THROW(Stream::FileWriter writer(filename, OpenMode::CanOpenNew), std::runtime_error);
 
 	// Try to open new file in new directory with permission
-	const std::string directoryAndFilename("NewDirectory/OpenModePermissionChecks.temp");
+	const std::string folder{"NewDirectory/"};
+	const std::string directoryAndFilename(folder + "OpenModePermissionChecks.temp");
 	ASSERT_NO_THROW(Stream::FileWriter writer(directoryAndFilename, OpenMode::CanOpenNew));
 
 	// Cleanup temporary file
 	XFile::DeletePath(filename);
 	XFile::DeletePath(directoryAndFilename);
+	XFile::DeletePath(folder);
 }
 
 

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -83,7 +83,7 @@ TEST(FileWriter, InvalidFilename) {
 }
 
 TEST(FileWriter, DirectoryDoesNotExistFail) {
-	const std::string& path("NewDirectory/TestFile.temp");
+	const std::string& path("NewDirectoryNotCreated/TestFile.temp");
 
 	// New directory should not be created when writer cannot create new files
 	EXPECT_THROW(Stream::FileWriter writer(path, Stream::FileWriter::OpenMode::CanOpenExisting), std::runtime_error);

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -83,17 +83,21 @@ TEST(FileWriter, InvalidFilename) {
 }
 
 TEST(FileWriter, DirectoryDoesNotExistFail) {
-	const std::string& path("NewDirectoryNotCreated/TestFile.temp");
+	const std::string folder{"NewDirectoryNotCreated/"};
+	const std::string path{folder + "TestFile.temp"};
 
 	// New directory should not be created when writer cannot create new files
 	EXPECT_THROW(Stream::FileWriter writer(path, Stream::FileWriter::OpenMode::CanOpenExisting), std::runtime_error);
+	EXPECT_FALSE(XFile::PathExists(folder));
 	EXPECT_FALSE(XFile::PathExists(path));
 }
 
 TEST(FileWriter, DirectoryDoesNotExistCreate) {
-	const std::string& path("NewDirectory/TestFile.temp");
+	const std::string folder{"NewDirectory/"};
+	const std::string path{folder + "TestFile.temp"};
 
 	EXPECT_NO_THROW(Stream::FileWriter writer(path));
+	EXPECT_TRUE(XFile::PathExists(folder));
 	EXPECT_TRUE(XFile::PathExists(path));
 
 	// Delete the path after testing creation

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -84,8 +84,6 @@ TEST(FileWriter, InvalidFilename) {
 }
 
 TEST(FileWriter, DirectoryDoesNotExist) {
-	WriteToNewDirectory("../NewDirectory/TestFile.temp");
-	WriteToNewDirectory("./NewDirectory/TestFile.temp");
 	WriteToNewDirectory("NewDirectory/TestFile.temp");
 }
 

--- a/OP2UtilityTest/Stream/FileWriter.test.cpp
+++ b/OP2UtilityTest/Stream/FileWriter.test.cpp
@@ -57,7 +57,7 @@ TEST(FileWriterOpenMode, PermissionChecks) {
 	ASSERT_THROW(Stream::FileWriter writer(filename, OpenMode::CanOpenNew), std::runtime_error);
 
 	// Try to open new file in new directory with permission
-	const std::string folder{"NewDirectory/"};
+	const std::string folder{"NewDirectoryPermissionChecks/"};
 	const std::string directoryAndFilename(folder + "OpenModePermissionChecks.temp");
 	ASSERT_NO_THROW(Stream::FileWriter writer(directoryAndFilename, OpenMode::CanOpenNew));
 
@@ -95,7 +95,7 @@ TEST(FileWriter, DirectoryDoesNotExistFail) {
 }
 
 TEST(FileWriter, DirectoryDoesNotExistCreate) {
-	const std::string folder{"NewDirectory/"};
+	const std::string folder{"NewDirectoryCreated/"};
 	const std::string path{folder + "TestFile.temp"};
 
 	EXPECT_NO_THROW(Stream::FileWriter writer(path));


### PR DESCRIPTION
Cleanup temp folders as well as any generated temp files.

Rename temp folders so they are not shared by different test cases. This prevents unintended sharing of resources (the folder), and potential order dependent behaviors.

Related:
- Issue #453

Closes #453
