### PR TITLE
Simplify vcxproj files - Remove explicit `DebugInformationFormat`

### DIFF
--- a/OP2Utility/OP2Utility.vcxproj
+++ b/OP2Utility/OP2Utility.vcxproj
@@ -75,7 +75,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <SDLCheck>false</SDLCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
@@ -83,7 +82,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <SDLCheck>false</SDLCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>

--- a/OP2UtilityTest/OP2UtilityTest.vcxproj
+++ b/OP2UtilityTest/OP2UtilityTest.vcxproj
@@ -57,7 +57,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>..\OP2Utility\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -72,7 +71,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>..\OP2Utility\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>

--- a/OP2UtilityTest/OP2UtilityTest.vcxproj
+++ b/OP2UtilityTest/OP2UtilityTest.vcxproj
@@ -85,7 +85,6 @@
     <ClCompile>
       <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\OP2Utility\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
@@ -101,7 +100,6 @@
     <ClCompile>
       <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\OP2Utility\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>


### PR DESCRIPTION
Remove explicit setting for `DebugInformationFormat`, which typically defaults to `ProgramDatabase`, though may be set to `EditAndContinue` for `Debug` configurations when other settings don't conflict with the Edit and Continue feature.

This effectively changes the value of the setting to `EditAndContinue` for `Debug` configurations.

Related:
- Issue #414
- PR #456
- PR https://github.com/OutpostUniverse/OPHD/pull/2215
- PR https://github.com/lairworks/nas2d-core/pull/1486
