### PR TITLE
Remove `GenerateDebugInformation` from `Link` section

### DIFF
--- a/OP2UtilityTest/OP2UtilityTest.vcxproj
+++ b/OP2UtilityTest/OP2UtilityTest.vcxproj
@@ -61,7 +61,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -75,7 +74,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -88,7 +86,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
@@ -103,7 +100,6 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>gmock_main.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
According to the documentation the `/DEBUG` flag is equivalent to `/DEBUG:FULL`. According to MSBuild files, the default for `GenerateDebugInformation` is `DebugFull`. Hence there doesn't seem to be a reason to override the default value with an equivalent non-default value.

Documentation:
https://learn.microsoft.com/en-us/cpp/build/reference/debug-generate-debug-info?view=msvc-180

----

Related:
- Issue https://github.com/OutpostUniverse/OP2Utility/issues/414
- PR https://github.com/OutpostUniverse/OP2Utility/pull/456
- PR https://github.com/OutpostUniverse/OP2Utility/pull/457
- PR https://github.com/lairworks/nas2d-core/pull/1487
- PR https://github.com/OutpostUniverse/MissionScanner/pull/45
- Commit https://github.com/OutpostUniverse/MissionScanner/pull/45/changes/d0c8ad154a43451c9d3a523697a3494a8c06ce32