### PR TITLE
Update Docker build environment - Minimize packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         compiler: [g++, clang++]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/outpostuniverse/op2utility:1.4
+      image: ghcr.io/outpostuniverse/op2utility:1.5
       env:
         CXX: ${{ matrix.compiler }}
 

--- a/.github/workflows/buildDockerBuildEnv.yml
+++ b/.github/workflows/buildDockerBuildEnv.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       buildPath: dockerBuildEnv/
-      imageName: ghcr.io/outpostuniverse/op2utility:1.4
+      imageName: ghcr.io/outpostuniverse/op2utility:1.5
 
     steps:
       - uses: actions/checkout@v6

--- a/dockerBuildEnv/Dockerfile
+++ b/dockerBuildEnv/Dockerfile
@@ -10,9 +10,9 @@
 FROM ubuntu:resolute-20260421
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    build-essential \
+    g++ \
+    make \
     clang \
-    cmake \
     git \
     ca-certificates \
     libgtest-dev \


### PR DESCRIPTION
Minimize installed `apt` packages to reduce Docker image size.

Related:
- Issue #414
